### PR TITLE
Bump cortex-m-rt to 0.6.

### DIFF
--- a/crates/tm4c123x/Cargo.toml
+++ b/crates/tm4c123x/Cargo.toml
@@ -16,7 +16,7 @@ vcell = "0.1.0"
 
 [dependencies.cortex-m-rt]
 optional = true
-version = "0.5.0"
+version = "0.6"
 
 [features]
 rt = ["cortex-m-rt/device"]

--- a/crates/tm4c129x/Cargo.toml
+++ b/crates/tm4c129x/Cargo.toml
@@ -16,7 +16,7 @@ vcell = "0.1.0"
 
 [dependencies.cortex-m-rt]
 optional = true
-version = "0.5.0"
+version = "0.6.0"
 
 [features]
 rt = ["cortex-m-rt/device"]


### PR DESCRIPTION
Saves the user from building two versions of cortex-m-rt if they use 0.6 (which they should).