### PR TITLE
Bumps Cortex-M dep to 0.6.

### DIFF
--- a/crates/tm4c123x/Cargo.toml
+++ b/crates/tm4c123x/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tm4c123x"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["whitequark <whitequark@whitequark.org>"]
 description = "Peripheral access API for TI TM4C123x microcontrollers"
 documentation = "https://docs.rs/tm4c123x"

--- a/crates/tm4c123x/Cargo.toml
+++ b/crates/tm4c123x/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tm4c123x"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["whitequark <whitequark@whitequark.org>"]
 description = "Peripheral access API for TI TM4C123x microcontrollers"
 documentation = "https://docs.rs/tm4c123x"
@@ -11,7 +11,7 @@ license = "0BSD"
 
 [dependencies]
 bare-metal = "0.2.0"
-cortex-m = "0.5.0"
+cortex-m = "0.6"
 vcell = "0.1.0"
 
 [dependencies.cortex-m-rt]

--- a/crates/tm4c129x/Cargo.toml
+++ b/crates/tm4c129x/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tm4c129x"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["whitequark <whitequark@whitequark.org>"]
 description = "Peripheral access API for TI TM4C129x microcontrollers"
 documentation = "https://docs.rs/tm4c129x"

--- a/crates/tm4c129x/Cargo.toml
+++ b/crates/tm4c129x/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tm4c129x"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["whitequark <whitequark@whitequark.org>"]
 description = "Peripheral access API for TI TM4C129x microcontrollers"
 documentation = "https://docs.rs/tm4c129x"
@@ -11,7 +11,7 @@ license = "0BSD"
 
 [dependencies]
 bare-metal = "0.2.0"
-cortex-m = "0.5.0"
+cortex-m = "0.6.0"
 vcell = "0.1.0"
 
 [dependencies.cortex-m-rt]

--- a/crates/tm4c129x/Cargo.toml
+++ b/crates/tm4c129x/Cargo.toml
@@ -11,7 +11,7 @@ license = "0BSD"
 
 [dependencies]
 bare-metal = "0.2.0"
-cortex-m = "0.6.0"
+cortex-m = "0.6"
 vcell = "0.1.0"
 
 [dependencies.cortex-m-rt]


### PR DESCRIPTION
Avoids users pulling in both 0.5 and 0.6 when they build applications.