### PR TITLE
Add `NVIC_PRIO_BITS`

### DIFF
--- a/crates/tm4c123x/src/adc0.rs
+++ b/crates/tm4c123x/src/adc0.rs
@@ -127,7 +127,7 @@ pub struct RegisterBlock {
     #[doc = "0xfc8 - ADC Clock Configuration"]
     pub cc: CC,
 }
-#[doc = "ADC Active Sample Sequencer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [actss](actss) module"]
+#[doc = "ADC Active Sample Sequencer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [actss](actss) module"]
 pub type ACTSS = crate::Reg<u32, _ACTSS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -138,7 +138,7 @@ impl crate::Readable for ACTSS {}
 impl crate::Writable for ACTSS {}
 #[doc = "ADC Active Sample Sequencer"]
 pub mod actss;
-#[doc = "ADC Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "ADC Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -147,7 +147,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "ADC Raw Interrupt Status"]
 pub mod ris;
-#[doc = "ADC Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [im](im) module"]
+#[doc = "ADC Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [im](im) module"]
 pub type IM = crate::Reg<u32, _IM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -158,7 +158,7 @@ impl crate::Readable for IM {}
 impl crate::Writable for IM {}
 #[doc = "ADC Interrupt Mask"]
 pub mod im;
-#[doc = "ADC Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [isc](isc) module"]
+#[doc = "ADC Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [isc](isc) module"]
 pub type ISC = crate::Reg<u32, _ISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -169,7 +169,7 @@ impl crate::Readable for ISC {}
 impl crate::Writable for ISC {}
 #[doc = "ADC Interrupt Status and Clear"]
 pub mod isc;
-#[doc = "ADC Overflow Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ostat](ostat) module"]
+#[doc = "ADC Overflow Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ostat](ostat) module"]
 pub type OSTAT = crate::Reg<u32, _OSTAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -180,7 +180,7 @@ impl crate::Readable for OSTAT {}
 impl crate::Writable for OSTAT {}
 #[doc = "ADC Overflow Status"]
 pub mod ostat;
-#[doc = "ADC Event Multiplexer Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [emux](emux) module"]
+#[doc = "ADC Event Multiplexer Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [emux](emux) module"]
 pub type EMUX = crate::Reg<u32, _EMUX>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -191,7 +191,7 @@ impl crate::Readable for EMUX {}
 impl crate::Writable for EMUX {}
 #[doc = "ADC Event Multiplexer Select"]
 pub mod emux;
-#[doc = "ADC Underflow Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ustat](ustat) module"]
+#[doc = "ADC Underflow Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ustat](ustat) module"]
 pub type USTAT = crate::Reg<u32, _USTAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -202,7 +202,7 @@ impl crate::Readable for USTAT {}
 impl crate::Writable for USTAT {}
 #[doc = "ADC Underflow Status"]
 pub mod ustat;
-#[doc = "ADC Trigger Source Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tssel](tssel) module"]
+#[doc = "ADC Trigger Source Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tssel](tssel) module"]
 pub type TSSEL = crate::Reg<u32, _TSSEL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -213,7 +213,7 @@ impl crate::Readable for TSSEL {}
 impl crate::Writable for TSSEL {}
 #[doc = "ADC Trigger Source Select"]
 pub mod tssel;
-#[doc = "ADC Sample Sequencer Priority\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sspri](sspri) module"]
+#[doc = "ADC Sample Sequencer Priority\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sspri](sspri) module"]
 pub type SSPRI = crate::Reg<u32, _SSPRI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -224,7 +224,7 @@ impl crate::Readable for SSPRI {}
 impl crate::Writable for SSPRI {}
 #[doc = "ADC Sample Sequencer Priority"]
 pub mod sspri;
-#[doc = "ADC Sample Phase Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [spc](spc) module"]
+#[doc = "ADC Sample Phase Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [spc](spc) module"]
 pub type SPC = crate::Reg<u32, _SPC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -235,7 +235,7 @@ impl crate::Readable for SPC {}
 impl crate::Writable for SPC {}
 #[doc = "ADC Sample Phase Control"]
 pub mod spc;
-#[doc = "ADC Processor Sample Sequence Initiate\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pssi](pssi) module"]
+#[doc = "ADC Processor Sample Sequence Initiate\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pssi](pssi) module"]
 pub type PSSI = crate::Reg<u32, _PSSI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -246,7 +246,7 @@ impl crate::Readable for PSSI {}
 impl crate::Writable for PSSI {}
 #[doc = "ADC Processor Sample Sequence Initiate"]
 pub mod pssi;
-#[doc = "ADC Sample Averaging Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sac](sac) module"]
+#[doc = "ADC Sample Averaging Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sac](sac) module"]
 pub type SAC = crate::Reg<u32, _SAC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -257,7 +257,7 @@ impl crate::Readable for SAC {}
 impl crate::Writable for SAC {}
 #[doc = "ADC Sample Averaging Control"]
 pub mod sac;
-#[doc = "ADC Digital Comparator Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcisc](dcisc) module"]
+#[doc = "ADC Digital Comparator Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcisc](dcisc) module"]
 pub type DCISC = crate::Reg<u32, _DCISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -268,7 +268,7 @@ impl crate::Readable for DCISC {}
 impl crate::Writable for DCISC {}
 #[doc = "ADC Digital Comparator Interrupt Status and Clear"]
 pub mod dcisc;
-#[doc = "ADC Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctl](ctl) module"]
+#[doc = "ADC Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctl](ctl) module"]
 pub type CTL = crate::Reg<u32, _CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -279,7 +279,7 @@ impl crate::Readable for CTL {}
 impl crate::Writable for CTL {}
 #[doc = "ADC Control"]
 pub mod ctl;
-#[doc = "ADC Sample Sequence Input Multiplexer Select 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssmux0](ssmux0) module"]
+#[doc = "ADC Sample Sequence Input Multiplexer Select 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssmux0](ssmux0) module"]
 pub type SSMUX0 = crate::Reg<u32, _SSMUX0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -290,7 +290,7 @@ impl crate::Readable for SSMUX0 {}
 impl crate::Writable for SSMUX0 {}
 #[doc = "ADC Sample Sequence Input Multiplexer Select 0"]
 pub mod ssmux0;
-#[doc = "ADC Sample Sequence Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssctl0](ssctl0) module"]
+#[doc = "ADC Sample Sequence Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssctl0](ssctl0) module"]
 pub type SSCTL0 = crate::Reg<u32, _SSCTL0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -301,7 +301,7 @@ impl crate::Readable for SSCTL0 {}
 impl crate::Writable for SSCTL0 {}
 #[doc = "ADC Sample Sequence Control 0"]
 pub mod ssctl0;
-#[doc = "ADC Sample Sequence Result FIFO 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssfifo0](ssfifo0) module"]
+#[doc = "ADC Sample Sequence Result FIFO 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssfifo0](ssfifo0) module"]
 pub type SSFIFO0 = crate::Reg<u32, _SSFIFO0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -310,7 +310,7 @@ pub struct _SSFIFO0;
 impl crate::Readable for SSFIFO0 {}
 #[doc = "ADC Sample Sequence Result FIFO 0"]
 pub mod ssfifo0;
-#[doc = "ADC Sample Sequence FIFO 0 Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssfstat0](ssfstat0) module"]
+#[doc = "ADC Sample Sequence FIFO 0 Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssfstat0](ssfstat0) module"]
 pub type SSFSTAT0 = crate::Reg<u32, _SSFSTAT0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -319,7 +319,7 @@ pub struct _SSFSTAT0;
 impl crate::Readable for SSFSTAT0 {}
 #[doc = "ADC Sample Sequence FIFO 0 Status"]
 pub mod ssfstat0;
-#[doc = "ADC Sample Sequence 0 Operation\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssop0](ssop0) module"]
+#[doc = "ADC Sample Sequence 0 Operation\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssop0](ssop0) module"]
 pub type SSOP0 = crate::Reg<u32, _SSOP0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -330,7 +330,7 @@ impl crate::Readable for SSOP0 {}
 impl crate::Writable for SSOP0 {}
 #[doc = "ADC Sample Sequence 0 Operation"]
 pub mod ssop0;
-#[doc = "ADC Sample Sequence 0 Digital Comparator Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssdc0](ssdc0) module"]
+#[doc = "ADC Sample Sequence 0 Digital Comparator Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssdc0](ssdc0) module"]
 pub type SSDC0 = crate::Reg<u32, _SSDC0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -341,7 +341,7 @@ impl crate::Readable for SSDC0 {}
 impl crate::Writable for SSDC0 {}
 #[doc = "ADC Sample Sequence 0 Digital Comparator Select"]
 pub mod ssdc0;
-#[doc = "ADC Sample Sequence Input Multiplexer Select 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssmux1](ssmux1) module"]
+#[doc = "ADC Sample Sequence Input Multiplexer Select 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssmux1](ssmux1) module"]
 pub type SSMUX1 = crate::Reg<u32, _SSMUX1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -352,7 +352,7 @@ impl crate::Readable for SSMUX1 {}
 impl crate::Writable for SSMUX1 {}
 #[doc = "ADC Sample Sequence Input Multiplexer Select 1"]
 pub mod ssmux1;
-#[doc = "ADC Sample Sequence Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssctl1](ssctl1) module"]
+#[doc = "ADC Sample Sequence Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssctl1](ssctl1) module"]
 pub type SSCTL1 = crate::Reg<u32, _SSCTL1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -363,7 +363,7 @@ impl crate::Readable for SSCTL1 {}
 impl crate::Writable for SSCTL1 {}
 #[doc = "ADC Sample Sequence Control 1"]
 pub mod ssctl1;
-#[doc = "ADC Sample Sequence Result FIFO 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssfifo1](ssfifo1) module"]
+#[doc = "ADC Sample Sequence Result FIFO 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssfifo1](ssfifo1) module"]
 pub type SSFIFO1 = crate::Reg<u32, _SSFIFO1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -372,7 +372,7 @@ pub struct _SSFIFO1;
 impl crate::Readable for SSFIFO1 {}
 #[doc = "ADC Sample Sequence Result FIFO 1"]
 pub mod ssfifo1;
-#[doc = "ADC Sample Sequence FIFO 1 Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssfstat1](ssfstat1) module"]
+#[doc = "ADC Sample Sequence FIFO 1 Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssfstat1](ssfstat1) module"]
 pub type SSFSTAT1 = crate::Reg<u32, _SSFSTAT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -381,7 +381,7 @@ pub struct _SSFSTAT1;
 impl crate::Readable for SSFSTAT1 {}
 #[doc = "ADC Sample Sequence FIFO 1 Status"]
 pub mod ssfstat1;
-#[doc = "ADC Sample Sequence 1 Operation\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssop1](ssop1) module"]
+#[doc = "ADC Sample Sequence 1 Operation\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssop1](ssop1) module"]
 pub type SSOP1 = crate::Reg<u32, _SSOP1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -392,7 +392,7 @@ impl crate::Readable for SSOP1 {}
 impl crate::Writable for SSOP1 {}
 #[doc = "ADC Sample Sequence 1 Operation"]
 pub mod ssop1;
-#[doc = "ADC Sample Sequence 1 Digital Comparator Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssdc1](ssdc1) module"]
+#[doc = "ADC Sample Sequence 1 Digital Comparator Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssdc1](ssdc1) module"]
 pub type SSDC1 = crate::Reg<u32, _SSDC1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -403,7 +403,7 @@ impl crate::Readable for SSDC1 {}
 impl crate::Writable for SSDC1 {}
 #[doc = "ADC Sample Sequence 1 Digital Comparator Select"]
 pub mod ssdc1;
-#[doc = "ADC Sample Sequence Input Multiplexer Select 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssmux2](ssmux2) module"]
+#[doc = "ADC Sample Sequence Input Multiplexer Select 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssmux2](ssmux2) module"]
 pub type SSMUX2 = crate::Reg<u32, _SSMUX2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -414,7 +414,7 @@ impl crate::Readable for SSMUX2 {}
 impl crate::Writable for SSMUX2 {}
 #[doc = "ADC Sample Sequence Input Multiplexer Select 2"]
 pub mod ssmux2;
-#[doc = "ADC Sample Sequence Control 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssctl2](ssctl2) module"]
+#[doc = "ADC Sample Sequence Control 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssctl2](ssctl2) module"]
 pub type SSCTL2 = crate::Reg<u32, _SSCTL2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -425,7 +425,7 @@ impl crate::Readable for SSCTL2 {}
 impl crate::Writable for SSCTL2 {}
 #[doc = "ADC Sample Sequence Control 2"]
 pub mod ssctl2;
-#[doc = "ADC Sample Sequence Result FIFO 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssfifo2](ssfifo2) module"]
+#[doc = "ADC Sample Sequence Result FIFO 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssfifo2](ssfifo2) module"]
 pub type SSFIFO2 = crate::Reg<u32, _SSFIFO2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -434,7 +434,7 @@ pub struct _SSFIFO2;
 impl crate::Readable for SSFIFO2 {}
 #[doc = "ADC Sample Sequence Result FIFO 2"]
 pub mod ssfifo2;
-#[doc = "ADC Sample Sequence FIFO 2 Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssfstat2](ssfstat2) module"]
+#[doc = "ADC Sample Sequence FIFO 2 Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssfstat2](ssfstat2) module"]
 pub type SSFSTAT2 = crate::Reg<u32, _SSFSTAT2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -443,7 +443,7 @@ pub struct _SSFSTAT2;
 impl crate::Readable for SSFSTAT2 {}
 #[doc = "ADC Sample Sequence FIFO 2 Status"]
 pub mod ssfstat2;
-#[doc = "ADC Sample Sequence 2 Operation\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssop2](ssop2) module"]
+#[doc = "ADC Sample Sequence 2 Operation\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssop2](ssop2) module"]
 pub type SSOP2 = crate::Reg<u32, _SSOP2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -454,7 +454,7 @@ impl crate::Readable for SSOP2 {}
 impl crate::Writable for SSOP2 {}
 #[doc = "ADC Sample Sequence 2 Operation"]
 pub mod ssop2;
-#[doc = "ADC Sample Sequence 2 Digital Comparator Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssdc2](ssdc2) module"]
+#[doc = "ADC Sample Sequence 2 Digital Comparator Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssdc2](ssdc2) module"]
 pub type SSDC2 = crate::Reg<u32, _SSDC2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -465,7 +465,7 @@ impl crate::Readable for SSDC2 {}
 impl crate::Writable for SSDC2 {}
 #[doc = "ADC Sample Sequence 2 Digital Comparator Select"]
 pub mod ssdc2;
-#[doc = "ADC Sample Sequence Input Multiplexer Select 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssmux3](ssmux3) module"]
+#[doc = "ADC Sample Sequence Input Multiplexer Select 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssmux3](ssmux3) module"]
 pub type SSMUX3 = crate::Reg<u32, _SSMUX3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -476,7 +476,7 @@ impl crate::Readable for SSMUX3 {}
 impl crate::Writable for SSMUX3 {}
 #[doc = "ADC Sample Sequence Input Multiplexer Select 3"]
 pub mod ssmux3;
-#[doc = "ADC Sample Sequence Control 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssctl3](ssctl3) module"]
+#[doc = "ADC Sample Sequence Control 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssctl3](ssctl3) module"]
 pub type SSCTL3 = crate::Reg<u32, _SSCTL3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -487,7 +487,7 @@ impl crate::Readable for SSCTL3 {}
 impl crate::Writable for SSCTL3 {}
 #[doc = "ADC Sample Sequence Control 3"]
 pub mod ssctl3;
-#[doc = "ADC Sample Sequence Result FIFO 3\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssfifo3](ssfifo3) module"]
+#[doc = "ADC Sample Sequence Result FIFO 3\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssfifo3](ssfifo3) module"]
 pub type SSFIFO3 = crate::Reg<u32, _SSFIFO3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -496,7 +496,7 @@ pub struct _SSFIFO3;
 impl crate::Readable for SSFIFO3 {}
 #[doc = "ADC Sample Sequence Result FIFO 3"]
 pub mod ssfifo3;
-#[doc = "ADC Sample Sequence FIFO 3 Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssfstat3](ssfstat3) module"]
+#[doc = "ADC Sample Sequence FIFO 3 Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssfstat3](ssfstat3) module"]
 pub type SSFSTAT3 = crate::Reg<u32, _SSFSTAT3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -505,7 +505,7 @@ pub struct _SSFSTAT3;
 impl crate::Readable for SSFSTAT3 {}
 #[doc = "ADC Sample Sequence FIFO 3 Status"]
 pub mod ssfstat3;
-#[doc = "ADC Sample Sequence 3 Operation\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssop3](ssop3) module"]
+#[doc = "ADC Sample Sequence 3 Operation\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssop3](ssop3) module"]
 pub type SSOP3 = crate::Reg<u32, _SSOP3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -516,7 +516,7 @@ impl crate::Readable for SSOP3 {}
 impl crate::Writable for SSOP3 {}
 #[doc = "ADC Sample Sequence 3 Operation"]
 pub mod ssop3;
-#[doc = "ADC Sample Sequence 3 Digital Comparator Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssdc3](ssdc3) module"]
+#[doc = "ADC Sample Sequence 3 Digital Comparator Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssdc3](ssdc3) module"]
 pub type SSDC3 = crate::Reg<u32, _SSDC3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -527,7 +527,7 @@ impl crate::Readable for SSDC3 {}
 impl crate::Writable for SSDC3 {}
 #[doc = "ADC Sample Sequence 3 Digital Comparator Select"]
 pub mod ssdc3;
-#[doc = "ADC Digital Comparator Reset Initial Conditions\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcric](dcric) module"]
+#[doc = "ADC Digital Comparator Reset Initial Conditions\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcric](dcric) module"]
 pub type DCRIC = crate::Reg<u32, _DCRIC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -536,7 +536,7 @@ pub struct _DCRIC;
 impl crate::Writable for DCRIC {}
 #[doc = "ADC Digital Comparator Reset Initial Conditions"]
 pub mod dcric;
-#[doc = "ADC Digital Comparator Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcctl0](dcctl0) module"]
+#[doc = "ADC Digital Comparator Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcctl0](dcctl0) module"]
 pub type DCCTL0 = crate::Reg<u32, _DCCTL0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -547,7 +547,7 @@ impl crate::Readable for DCCTL0 {}
 impl crate::Writable for DCCTL0 {}
 #[doc = "ADC Digital Comparator Control 0"]
 pub mod dcctl0;
-#[doc = "ADC Digital Comparator Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcctl1](dcctl1) module"]
+#[doc = "ADC Digital Comparator Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcctl1](dcctl1) module"]
 pub type DCCTL1 = crate::Reg<u32, _DCCTL1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -558,7 +558,7 @@ impl crate::Readable for DCCTL1 {}
 impl crate::Writable for DCCTL1 {}
 #[doc = "ADC Digital Comparator Control 1"]
 pub mod dcctl1;
-#[doc = "ADC Digital Comparator Control 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcctl2](dcctl2) module"]
+#[doc = "ADC Digital Comparator Control 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcctl2](dcctl2) module"]
 pub type DCCTL2 = crate::Reg<u32, _DCCTL2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -569,7 +569,7 @@ impl crate::Readable for DCCTL2 {}
 impl crate::Writable for DCCTL2 {}
 #[doc = "ADC Digital Comparator Control 2"]
 pub mod dcctl2;
-#[doc = "ADC Digital Comparator Control 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcctl3](dcctl3) module"]
+#[doc = "ADC Digital Comparator Control 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcctl3](dcctl3) module"]
 pub type DCCTL3 = crate::Reg<u32, _DCCTL3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -580,7 +580,7 @@ impl crate::Readable for DCCTL3 {}
 impl crate::Writable for DCCTL3 {}
 #[doc = "ADC Digital Comparator Control 3"]
 pub mod dcctl3;
-#[doc = "ADC Digital Comparator Control 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcctl4](dcctl4) module"]
+#[doc = "ADC Digital Comparator Control 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcctl4](dcctl4) module"]
 pub type DCCTL4 = crate::Reg<u32, _DCCTL4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -591,7 +591,7 @@ impl crate::Readable for DCCTL4 {}
 impl crate::Writable for DCCTL4 {}
 #[doc = "ADC Digital Comparator Control 4"]
 pub mod dcctl4;
-#[doc = "ADC Digital Comparator Control 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcctl5](dcctl5) module"]
+#[doc = "ADC Digital Comparator Control 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcctl5](dcctl5) module"]
 pub type DCCTL5 = crate::Reg<u32, _DCCTL5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -602,7 +602,7 @@ impl crate::Readable for DCCTL5 {}
 impl crate::Writable for DCCTL5 {}
 #[doc = "ADC Digital Comparator Control 5"]
 pub mod dcctl5;
-#[doc = "ADC Digital Comparator Control 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcctl6](dcctl6) module"]
+#[doc = "ADC Digital Comparator Control 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcctl6](dcctl6) module"]
 pub type DCCTL6 = crate::Reg<u32, _DCCTL6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -613,7 +613,7 @@ impl crate::Readable for DCCTL6 {}
 impl crate::Writable for DCCTL6 {}
 #[doc = "ADC Digital Comparator Control 6"]
 pub mod dcctl6;
-#[doc = "ADC Digital Comparator Control 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcctl7](dcctl7) module"]
+#[doc = "ADC Digital Comparator Control 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcctl7](dcctl7) module"]
 pub type DCCTL7 = crate::Reg<u32, _DCCTL7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -624,7 +624,7 @@ impl crate::Readable for DCCTL7 {}
 impl crate::Writable for DCCTL7 {}
 #[doc = "ADC Digital Comparator Control 7"]
 pub mod dcctl7;
-#[doc = "ADC Digital Comparator Range 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dccmp0](dccmp0) module"]
+#[doc = "ADC Digital Comparator Range 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dccmp0](dccmp0) module"]
 pub type DCCMP0 = crate::Reg<u32, _DCCMP0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -635,7 +635,7 @@ impl crate::Readable for DCCMP0 {}
 impl crate::Writable for DCCMP0 {}
 #[doc = "ADC Digital Comparator Range 0"]
 pub mod dccmp0;
-#[doc = "ADC Digital Comparator Range 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dccmp1](dccmp1) module"]
+#[doc = "ADC Digital Comparator Range 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dccmp1](dccmp1) module"]
 pub type DCCMP1 = crate::Reg<u32, _DCCMP1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -646,7 +646,7 @@ impl crate::Readable for DCCMP1 {}
 impl crate::Writable for DCCMP1 {}
 #[doc = "ADC Digital Comparator Range 1"]
 pub mod dccmp1;
-#[doc = "ADC Digital Comparator Range 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dccmp2](dccmp2) module"]
+#[doc = "ADC Digital Comparator Range 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dccmp2](dccmp2) module"]
 pub type DCCMP2 = crate::Reg<u32, _DCCMP2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -657,7 +657,7 @@ impl crate::Readable for DCCMP2 {}
 impl crate::Writable for DCCMP2 {}
 #[doc = "ADC Digital Comparator Range 2"]
 pub mod dccmp2;
-#[doc = "ADC Digital Comparator Range 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dccmp3](dccmp3) module"]
+#[doc = "ADC Digital Comparator Range 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dccmp3](dccmp3) module"]
 pub type DCCMP3 = crate::Reg<u32, _DCCMP3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -668,7 +668,7 @@ impl crate::Readable for DCCMP3 {}
 impl crate::Writable for DCCMP3 {}
 #[doc = "ADC Digital Comparator Range 3"]
 pub mod dccmp3;
-#[doc = "ADC Digital Comparator Range 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dccmp4](dccmp4) module"]
+#[doc = "ADC Digital Comparator Range 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dccmp4](dccmp4) module"]
 pub type DCCMP4 = crate::Reg<u32, _DCCMP4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -679,7 +679,7 @@ impl crate::Readable for DCCMP4 {}
 impl crate::Writable for DCCMP4 {}
 #[doc = "ADC Digital Comparator Range 4"]
 pub mod dccmp4;
-#[doc = "ADC Digital Comparator Range 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dccmp5](dccmp5) module"]
+#[doc = "ADC Digital Comparator Range 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dccmp5](dccmp5) module"]
 pub type DCCMP5 = crate::Reg<u32, _DCCMP5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -690,7 +690,7 @@ impl crate::Readable for DCCMP5 {}
 impl crate::Writable for DCCMP5 {}
 #[doc = "ADC Digital Comparator Range 5"]
 pub mod dccmp5;
-#[doc = "ADC Digital Comparator Range 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dccmp6](dccmp6) module"]
+#[doc = "ADC Digital Comparator Range 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dccmp6](dccmp6) module"]
 pub type DCCMP6 = crate::Reg<u32, _DCCMP6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -701,7 +701,7 @@ impl crate::Readable for DCCMP6 {}
 impl crate::Writable for DCCMP6 {}
 #[doc = "ADC Digital Comparator Range 6"]
 pub mod dccmp6;
-#[doc = "ADC Digital Comparator Range 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dccmp7](dccmp7) module"]
+#[doc = "ADC Digital Comparator Range 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dccmp7](dccmp7) module"]
 pub type DCCMP7 = crate::Reg<u32, _DCCMP7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -712,7 +712,7 @@ impl crate::Readable for DCCMP7 {}
 impl crate::Writable for DCCMP7 {}
 #[doc = "ADC Digital Comparator Range 7"]
 pub mod dccmp7;
-#[doc = "ADC Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "ADC Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -721,7 +721,7 @@ pub struct _PP;
 impl crate::Readable for PP {}
 #[doc = "ADC Peripheral Properties"]
 pub mod pp;
-#[doc = "ADC Peripheral Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pc](pc) module"]
+#[doc = "ADC Peripheral Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pc](pc) module"]
 pub type PC = crate::Reg<u32, _PC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -732,7 +732,7 @@ impl crate::Readable for PC {}
 impl crate::Writable for PC {}
 #[doc = "ADC Peripheral Configuration"]
 pub mod pc;
-#[doc = "ADC Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc](cc) module"]
+#[doc = "ADC Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cc](cc) module"]
 pub type CC = crate::Reg<u32, _CC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/adc0/cc.rs
+++ b/crates/tm4c123x/src/adc0/cc.rs
@@ -12,19 +12,17 @@ impl crate::ResetValue for super::CC {
 }
 #[doc = "ADC Clock Source\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CS_A {
     #[doc = "0: PLL VCO divided by CLKDIV"]
-    SYSPLL,
+    SYSPLL = 0,
     #[doc = "1: PIOSC"]
-    PIOSC,
+    PIOSC = 1,
 }
 impl From<CS_A> for u8 {
     #[inline(always)]
     fn from(variant: CS_A) -> Self {
-        match variant {
-            CS_A::SYSPLL => 0,
-            CS_A::PIOSC => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CS`"]

--- a/crates/tm4c123x/src/adc0/ctl.rs
+++ b/crates/tm4c123x/src/adc0/ctl.rs
@@ -14,14 +14,12 @@ impl crate::ResetValue for super::CTL {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum VREF_A {
     #[doc = "0: VDDA and GNDA are the voltage references"]
-    INTERNAL,
+    INTERNAL = 0,
 }
 impl From<VREF_A> for bool {
     #[inline(always)]
     fn from(variant: VREF_A) -> Self {
-        match variant {
-            VREF_A::INTERNAL => false,
-        }
+        variant as u8 != 0
     }
 }
 #[doc = "Reader of field `VREF`"]

--- a/crates/tm4c123x/src/adc0/dcctl0.rs
+++ b/crates/tm4c123x/src/adc0/dcctl0.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::DCCTL0 {
 }
 #[doc = "Comparison Interrupt Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CIM_A> for u8 {
     #[inline(always)]
     fn from(variant: CIM_A) -> Self {
-        match variant {
-            CIM_A::ALWAYS => 0,
-            CIM_A::ONCE => 1,
-            CIM_A::HALWAYS => 2,
-            CIM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIM`"]
@@ -109,22 +105,19 @@ impl<'a> CIM_W<'a> {
 }
 #[doc = "Comparison Interrupt Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CIC_A> for u8 {
     #[inline(always)]
     fn from(variant: CIC_A) -> Self {
-        match variant {
-            CIC_A::LOW => 0,
-            CIC_A::MID => 1,
-            CIC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIC`"]
@@ -215,25 +208,21 @@ impl<'a> CIE_W<'a> {
 }
 #[doc = "Comparison Trigger Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CTM_A> for u8 {
     #[inline(always)]
     fn from(variant: CTM_A) -> Self {
-        match variant {
-            CTM_A::ALWAYS => 0,
-            CTM_A::ONCE => 1,
-            CTM_A::HALWAYS => 2,
-            CTM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTM`"]
@@ -312,22 +301,19 @@ impl<'a> CTM_W<'a> {
 }
 #[doc = "Comparison Trigger Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CTC_A> for u8 {
     #[inline(always)]
     fn from(variant: CTC_A) -> Self {
-        match variant {
-            CTC_A::LOW => 0,
-            CTC_A::MID => 1,
-            CTC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTC`"]

--- a/crates/tm4c123x/src/adc0/dcctl1.rs
+++ b/crates/tm4c123x/src/adc0/dcctl1.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::DCCTL1 {
 }
 #[doc = "Comparison Interrupt Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CIM_A> for u8 {
     #[inline(always)]
     fn from(variant: CIM_A) -> Self {
-        match variant {
-            CIM_A::ALWAYS => 0,
-            CIM_A::ONCE => 1,
-            CIM_A::HALWAYS => 2,
-            CIM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIM`"]
@@ -109,22 +105,19 @@ impl<'a> CIM_W<'a> {
 }
 #[doc = "Comparison Interrupt Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CIC_A> for u8 {
     #[inline(always)]
     fn from(variant: CIC_A) -> Self {
-        match variant {
-            CIC_A::LOW => 0,
-            CIC_A::MID => 1,
-            CIC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIC`"]
@@ -215,25 +208,21 @@ impl<'a> CIE_W<'a> {
 }
 #[doc = "Comparison Trigger Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CTM_A> for u8 {
     #[inline(always)]
     fn from(variant: CTM_A) -> Self {
-        match variant {
-            CTM_A::ALWAYS => 0,
-            CTM_A::ONCE => 1,
-            CTM_A::HALWAYS => 2,
-            CTM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTM`"]
@@ -312,22 +301,19 @@ impl<'a> CTM_W<'a> {
 }
 #[doc = "Comparison Trigger Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CTC_A> for u8 {
     #[inline(always)]
     fn from(variant: CTC_A) -> Self {
-        match variant {
-            CTC_A::LOW => 0,
-            CTC_A::MID => 1,
-            CTC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTC`"]

--- a/crates/tm4c123x/src/adc0/dcctl2.rs
+++ b/crates/tm4c123x/src/adc0/dcctl2.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::DCCTL2 {
 }
 #[doc = "Comparison Interrupt Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CIM_A> for u8 {
     #[inline(always)]
     fn from(variant: CIM_A) -> Self {
-        match variant {
-            CIM_A::ALWAYS => 0,
-            CIM_A::ONCE => 1,
-            CIM_A::HALWAYS => 2,
-            CIM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIM`"]
@@ -109,22 +105,19 @@ impl<'a> CIM_W<'a> {
 }
 #[doc = "Comparison Interrupt Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CIC_A> for u8 {
     #[inline(always)]
     fn from(variant: CIC_A) -> Self {
-        match variant {
-            CIC_A::LOW => 0,
-            CIC_A::MID => 1,
-            CIC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIC`"]
@@ -215,25 +208,21 @@ impl<'a> CIE_W<'a> {
 }
 #[doc = "Comparison Trigger Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CTM_A> for u8 {
     #[inline(always)]
     fn from(variant: CTM_A) -> Self {
-        match variant {
-            CTM_A::ALWAYS => 0,
-            CTM_A::ONCE => 1,
-            CTM_A::HALWAYS => 2,
-            CTM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTM`"]
@@ -312,22 +301,19 @@ impl<'a> CTM_W<'a> {
 }
 #[doc = "Comparison Trigger Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CTC_A> for u8 {
     #[inline(always)]
     fn from(variant: CTC_A) -> Self {
-        match variant {
-            CTC_A::LOW => 0,
-            CTC_A::MID => 1,
-            CTC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTC`"]

--- a/crates/tm4c123x/src/adc0/dcctl3.rs
+++ b/crates/tm4c123x/src/adc0/dcctl3.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::DCCTL3 {
 }
 #[doc = "Comparison Interrupt Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CIM_A> for u8 {
     #[inline(always)]
     fn from(variant: CIM_A) -> Self {
-        match variant {
-            CIM_A::ALWAYS => 0,
-            CIM_A::ONCE => 1,
-            CIM_A::HALWAYS => 2,
-            CIM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIM`"]
@@ -109,22 +105,19 @@ impl<'a> CIM_W<'a> {
 }
 #[doc = "Comparison Interrupt Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CIC_A> for u8 {
     #[inline(always)]
     fn from(variant: CIC_A) -> Self {
-        match variant {
-            CIC_A::LOW => 0,
-            CIC_A::MID => 1,
-            CIC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIC`"]
@@ -215,25 +208,21 @@ impl<'a> CIE_W<'a> {
 }
 #[doc = "Comparison Trigger Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CTM_A> for u8 {
     #[inline(always)]
     fn from(variant: CTM_A) -> Self {
-        match variant {
-            CTM_A::ALWAYS => 0,
-            CTM_A::ONCE => 1,
-            CTM_A::HALWAYS => 2,
-            CTM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTM`"]
@@ -312,22 +301,19 @@ impl<'a> CTM_W<'a> {
 }
 #[doc = "Comparison Trigger Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CTC_A> for u8 {
     #[inline(always)]
     fn from(variant: CTC_A) -> Self {
-        match variant {
-            CTC_A::LOW => 0,
-            CTC_A::MID => 1,
-            CTC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTC`"]

--- a/crates/tm4c123x/src/adc0/dcctl4.rs
+++ b/crates/tm4c123x/src/adc0/dcctl4.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::DCCTL4 {
 }
 #[doc = "Comparison Interrupt Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CIM_A> for u8 {
     #[inline(always)]
     fn from(variant: CIM_A) -> Self {
-        match variant {
-            CIM_A::ALWAYS => 0,
-            CIM_A::ONCE => 1,
-            CIM_A::HALWAYS => 2,
-            CIM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIM`"]
@@ -109,22 +105,19 @@ impl<'a> CIM_W<'a> {
 }
 #[doc = "Comparison Interrupt Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CIC_A> for u8 {
     #[inline(always)]
     fn from(variant: CIC_A) -> Self {
-        match variant {
-            CIC_A::LOW => 0,
-            CIC_A::MID => 1,
-            CIC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIC`"]
@@ -215,25 +208,21 @@ impl<'a> CIE_W<'a> {
 }
 #[doc = "Comparison Trigger Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CTM_A> for u8 {
     #[inline(always)]
     fn from(variant: CTM_A) -> Self {
-        match variant {
-            CTM_A::ALWAYS => 0,
-            CTM_A::ONCE => 1,
-            CTM_A::HALWAYS => 2,
-            CTM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTM`"]
@@ -312,22 +301,19 @@ impl<'a> CTM_W<'a> {
 }
 #[doc = "Comparison Trigger Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CTC_A> for u8 {
     #[inline(always)]
     fn from(variant: CTC_A) -> Self {
-        match variant {
-            CTC_A::LOW => 0,
-            CTC_A::MID => 1,
-            CTC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTC`"]

--- a/crates/tm4c123x/src/adc0/dcctl5.rs
+++ b/crates/tm4c123x/src/adc0/dcctl5.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::DCCTL5 {
 }
 #[doc = "Comparison Interrupt Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CIM_A> for u8 {
     #[inline(always)]
     fn from(variant: CIM_A) -> Self {
-        match variant {
-            CIM_A::ALWAYS => 0,
-            CIM_A::ONCE => 1,
-            CIM_A::HALWAYS => 2,
-            CIM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIM`"]
@@ -109,22 +105,19 @@ impl<'a> CIM_W<'a> {
 }
 #[doc = "Comparison Interrupt Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CIC_A> for u8 {
     #[inline(always)]
     fn from(variant: CIC_A) -> Self {
-        match variant {
-            CIC_A::LOW => 0,
-            CIC_A::MID => 1,
-            CIC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIC`"]
@@ -215,25 +208,21 @@ impl<'a> CIE_W<'a> {
 }
 #[doc = "Comparison Trigger Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CTM_A> for u8 {
     #[inline(always)]
     fn from(variant: CTM_A) -> Self {
-        match variant {
-            CTM_A::ALWAYS => 0,
-            CTM_A::ONCE => 1,
-            CTM_A::HALWAYS => 2,
-            CTM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTM`"]
@@ -312,22 +301,19 @@ impl<'a> CTM_W<'a> {
 }
 #[doc = "Comparison Trigger Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CTC_A> for u8 {
     #[inline(always)]
     fn from(variant: CTC_A) -> Self {
-        match variant {
-            CTC_A::LOW => 0,
-            CTC_A::MID => 1,
-            CTC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTC`"]

--- a/crates/tm4c123x/src/adc0/dcctl6.rs
+++ b/crates/tm4c123x/src/adc0/dcctl6.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::DCCTL6 {
 }
 #[doc = "Comparison Interrupt Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CIM_A> for u8 {
     #[inline(always)]
     fn from(variant: CIM_A) -> Self {
-        match variant {
-            CIM_A::ALWAYS => 0,
-            CIM_A::ONCE => 1,
-            CIM_A::HALWAYS => 2,
-            CIM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIM`"]
@@ -109,22 +105,19 @@ impl<'a> CIM_W<'a> {
 }
 #[doc = "Comparison Interrupt Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CIC_A> for u8 {
     #[inline(always)]
     fn from(variant: CIC_A) -> Self {
-        match variant {
-            CIC_A::LOW => 0,
-            CIC_A::MID => 1,
-            CIC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIC`"]
@@ -215,25 +208,21 @@ impl<'a> CIE_W<'a> {
 }
 #[doc = "Comparison Trigger Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CTM_A> for u8 {
     #[inline(always)]
     fn from(variant: CTM_A) -> Self {
-        match variant {
-            CTM_A::ALWAYS => 0,
-            CTM_A::ONCE => 1,
-            CTM_A::HALWAYS => 2,
-            CTM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTM`"]
@@ -312,22 +301,19 @@ impl<'a> CTM_W<'a> {
 }
 #[doc = "Comparison Trigger Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CTC_A> for u8 {
     #[inline(always)]
     fn from(variant: CTC_A) -> Self {
-        match variant {
-            CTC_A::LOW => 0,
-            CTC_A::MID => 1,
-            CTC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTC`"]

--- a/crates/tm4c123x/src/adc0/dcctl7.rs
+++ b/crates/tm4c123x/src/adc0/dcctl7.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::DCCTL7 {
 }
 #[doc = "Comparison Interrupt Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CIM_A> for u8 {
     #[inline(always)]
     fn from(variant: CIM_A) -> Self {
-        match variant {
-            CIM_A::ALWAYS => 0,
-            CIM_A::ONCE => 1,
-            CIM_A::HALWAYS => 2,
-            CIM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIM`"]
@@ -109,22 +105,19 @@ impl<'a> CIM_W<'a> {
 }
 #[doc = "Comparison Interrupt Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CIC_A> for u8 {
     #[inline(always)]
     fn from(variant: CIC_A) -> Self {
-        match variant {
-            CIC_A::LOW => 0,
-            CIC_A::MID => 1,
-            CIC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIC`"]
@@ -215,25 +208,21 @@ impl<'a> CIE_W<'a> {
 }
 #[doc = "Comparison Trigger Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CTM_A> for u8 {
     #[inline(always)]
     fn from(variant: CTM_A) -> Self {
-        match variant {
-            CTM_A::ALWAYS => 0,
-            CTM_A::ONCE => 1,
-            CTM_A::HALWAYS => 2,
-            CTM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTM`"]
@@ -312,22 +301,19 @@ impl<'a> CTM_W<'a> {
 }
 #[doc = "Comparison Trigger Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CTC_A> for u8 {
     #[inline(always)]
     fn from(variant: CTC_A) -> Self {
-        match variant {
-            CTC_A::LOW => 0,
-            CTC_A::MID => 1,
-            CTC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTC`"]

--- a/crates/tm4c123x/src/adc0/emux.rs
+++ b/crates/tm4c123x/src/adc0/emux.rs
@@ -12,43 +12,33 @@ impl crate::ResetValue for super::EMUX {
 }
 #[doc = "SS0 Trigger Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum EM0_A {
     #[doc = "0: Processor (default)"]
-    PROCESSOR,
+    PROCESSOR = 0,
     #[doc = "1: Analog Comparator 0"]
-    COMP0,
+    COMP0 = 1,
     #[doc = "2: Analog Comparator 1"]
-    COMP1,
+    COMP1 = 2,
     #[doc = "4: External (GPIO Pins)"]
-    EXTERNAL,
+    EXTERNAL = 4,
     #[doc = "5: Timer"]
-    TIMER,
+    TIMER = 5,
     #[doc = "6: PWM generator 0"]
-    PWM0,
+    PWM0 = 6,
     #[doc = "7: PWM generator 1"]
-    PWM1,
+    PWM1 = 7,
     #[doc = "8: PWM generator 2"]
-    PWM2,
+    PWM2 = 8,
     #[doc = "9: PWM generator 3"]
-    PWM3,
+    PWM3 = 9,
     #[doc = "15: Always (continuously sample)"]
-    ALWAYS,
+    ALWAYS = 15,
 }
 impl From<EM0_A> for u8 {
     #[inline(always)]
     fn from(variant: EM0_A) -> Self {
-        match variant {
-            EM0_A::PROCESSOR => 0,
-            EM0_A::COMP0 => 1,
-            EM0_A::COMP1 => 2,
-            EM0_A::EXTERNAL => 4,
-            EM0_A::TIMER => 5,
-            EM0_A::PWM0 => 6,
-            EM0_A::PWM1 => 7,
-            EM0_A::PWM2 => 8,
-            EM0_A::PWM3 => 9,
-            EM0_A::ALWAYS => 15,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `EM0`"]
@@ -192,43 +182,33 @@ impl<'a> EM0_W<'a> {
 }
 #[doc = "SS1 Trigger Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum EM1_A {
     #[doc = "0: Processor (default)"]
-    PROCESSOR,
+    PROCESSOR = 0,
     #[doc = "1: Analog Comparator 0"]
-    COMP0,
+    COMP0 = 1,
     #[doc = "2: Analog Comparator 1"]
-    COMP1,
+    COMP1 = 2,
     #[doc = "4: External (GPIO Pins)"]
-    EXTERNAL,
+    EXTERNAL = 4,
     #[doc = "5: Timer"]
-    TIMER,
+    TIMER = 5,
     #[doc = "6: PWM generator 0"]
-    PWM0,
+    PWM0 = 6,
     #[doc = "7: PWM generator 1"]
-    PWM1,
+    PWM1 = 7,
     #[doc = "8: PWM generator 2"]
-    PWM2,
+    PWM2 = 8,
     #[doc = "9: PWM generator 3"]
-    PWM3,
+    PWM3 = 9,
     #[doc = "15: Always (continuously sample)"]
-    ALWAYS,
+    ALWAYS = 15,
 }
 impl From<EM1_A> for u8 {
     #[inline(always)]
     fn from(variant: EM1_A) -> Self {
-        match variant {
-            EM1_A::PROCESSOR => 0,
-            EM1_A::COMP0 => 1,
-            EM1_A::COMP1 => 2,
-            EM1_A::EXTERNAL => 4,
-            EM1_A::TIMER => 5,
-            EM1_A::PWM0 => 6,
-            EM1_A::PWM1 => 7,
-            EM1_A::PWM2 => 8,
-            EM1_A::PWM3 => 9,
-            EM1_A::ALWAYS => 15,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `EM1`"]
@@ -372,43 +352,33 @@ impl<'a> EM1_W<'a> {
 }
 #[doc = "SS2 Trigger Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum EM2_A {
     #[doc = "0: Processor (default)"]
-    PROCESSOR,
+    PROCESSOR = 0,
     #[doc = "1: Analog Comparator 0"]
-    COMP0,
+    COMP0 = 1,
     #[doc = "2: Analog Comparator 1"]
-    COMP1,
+    COMP1 = 2,
     #[doc = "4: External (GPIO Pins)"]
-    EXTERNAL,
+    EXTERNAL = 4,
     #[doc = "5: Timer"]
-    TIMER,
+    TIMER = 5,
     #[doc = "6: PWM generator 0"]
-    PWM0,
+    PWM0 = 6,
     #[doc = "7: PWM generator 1"]
-    PWM1,
+    PWM1 = 7,
     #[doc = "8: PWM generator 2"]
-    PWM2,
+    PWM2 = 8,
     #[doc = "9: PWM generator 3"]
-    PWM3,
+    PWM3 = 9,
     #[doc = "15: Always (continuously sample)"]
-    ALWAYS,
+    ALWAYS = 15,
 }
 impl From<EM2_A> for u8 {
     #[inline(always)]
     fn from(variant: EM2_A) -> Self {
-        match variant {
-            EM2_A::PROCESSOR => 0,
-            EM2_A::COMP0 => 1,
-            EM2_A::COMP1 => 2,
-            EM2_A::EXTERNAL => 4,
-            EM2_A::TIMER => 5,
-            EM2_A::PWM0 => 6,
-            EM2_A::PWM1 => 7,
-            EM2_A::PWM2 => 8,
-            EM2_A::PWM3 => 9,
-            EM2_A::ALWAYS => 15,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `EM2`"]
@@ -552,43 +522,33 @@ impl<'a> EM2_W<'a> {
 }
 #[doc = "SS3 Trigger Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum EM3_A {
     #[doc = "0: Processor (default)"]
-    PROCESSOR,
+    PROCESSOR = 0,
     #[doc = "1: Analog Comparator 0"]
-    COMP0,
+    COMP0 = 1,
     #[doc = "2: Analog Comparator 1"]
-    COMP1,
+    COMP1 = 2,
     #[doc = "4: External (GPIO Pins)"]
-    EXTERNAL,
+    EXTERNAL = 4,
     #[doc = "5: Timer"]
-    TIMER,
+    TIMER = 5,
     #[doc = "6: PWM generator 0"]
-    PWM0,
+    PWM0 = 6,
     #[doc = "7: PWM generator 1"]
-    PWM1,
+    PWM1 = 7,
     #[doc = "8: PWM generator 2"]
-    PWM2,
+    PWM2 = 8,
     #[doc = "9: PWM generator 3"]
-    PWM3,
+    PWM3 = 9,
     #[doc = "15: Always (continuously sample)"]
-    ALWAYS,
+    ALWAYS = 15,
 }
 impl From<EM3_A> for u8 {
     #[inline(always)]
     fn from(variant: EM3_A) -> Self {
-        match variant {
-            EM3_A::PROCESSOR => 0,
-            EM3_A::COMP0 => 1,
-            EM3_A::COMP1 => 2,
-            EM3_A::EXTERNAL => 4,
-            EM3_A::TIMER => 5,
-            EM3_A::PWM0 => 6,
-            EM3_A::PWM1 => 7,
-            EM3_A::PWM2 => 8,
-            EM3_A::PWM3 => 9,
-            EM3_A::ALWAYS => 15,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `EM3`"]

--- a/crates/tm4c123x/src/adc0/pc.rs
+++ b/crates/tm4c123x/src/adc0/pc.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::PC {
 }
 #[doc = "ADC Sample Rate\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SR_A {
     #[doc = "1: 125 ksps"]
-    _125K,
+    _125K = 1,
     #[doc = "3: 250 ksps"]
-    _250K,
+    _250K = 3,
     #[doc = "5: 500 ksps"]
-    _500K,
+    _500K = 5,
     #[doc = "7: 1 Msps"]
-    _1M,
+    _1M = 7,
 }
 impl From<SR_A> for u8 {
     #[inline(always)]
     fn from(variant: SR_A) -> Self {
-        match variant {
-            SR_A::_125K => 1,
-            SR_A::_250K => 3,
-            SR_A::_500K => 5,
-            SR_A::_1M => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SR`"]

--- a/crates/tm4c123x/src/adc0/pp.rs
+++ b/crates/tm4c123x/src/adc0/pp.rs
@@ -2,25 +2,21 @@
 pub type R = crate::R<u32, super::PP>;
 #[doc = "Maximum ADC Sample Rate\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MSR_A {
     #[doc = "1: 125 ksps"]
-    _125K,
+    _125K = 1,
     #[doc = "3: 250 ksps"]
-    _250K,
+    _250K = 3,
     #[doc = "5: 500 ksps"]
-    _500K,
+    _500K = 5,
     #[doc = "7: 1 Msps"]
-    _1M,
+    _1M = 7,
 }
 impl From<MSR_A> for u8 {
     #[inline(always)]
     fn from(variant: MSR_A) -> Self {
-        match variant {
-            MSR_A::_125K => 1,
-            MSR_A::_250K => 3,
-            MSR_A::_500K => 5,
-            MSR_A::_1M => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MSR`"]
@@ -65,16 +61,15 @@ pub type CH_R = crate::R<u8, u8>;
 pub type DC_R = crate::R<u8, u8>;
 #[doc = "ADC Architecture\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TYPE_A {
     #[doc = "0: SAR"]
-    SAR,
+    SAR = 0,
 }
 impl From<TYPE_A> for u8 {
     #[inline(always)]
     fn from(variant: TYPE_A) -> Self {
-        match variant {
-            TYPE_A::SAR => 0,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TYPE`"]

--- a/crates/tm4c123x/src/adc0/sac.rs
+++ b/crates/tm4c123x/src/adc0/sac.rs
@@ -12,34 +12,27 @@ impl crate::ResetValue for super::SAC {
 }
 #[doc = "Hardware Averaging Control\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum AVG_A {
     #[doc = "0: No hardware oversampling"]
-    OFF,
+    OFF = 0,
     #[doc = "1: 2x hardware oversampling"]
-    _2X,
+    _2X = 1,
     #[doc = "2: 4x hardware oversampling"]
-    _4X,
+    _4X = 2,
     #[doc = "3: 8x hardware oversampling"]
-    _8X,
+    _8X = 3,
     #[doc = "4: 16x hardware oversampling"]
-    _16X,
+    _16X = 4,
     #[doc = "5: 32x hardware oversampling"]
-    _32X,
+    _32X = 5,
     #[doc = "6: 64x hardware oversampling"]
-    _64X,
+    _64X = 6,
 }
 impl From<AVG_A> for u8 {
     #[inline(always)]
     fn from(variant: AVG_A) -> Self {
-        match variant {
-            AVG_A::OFF => 0,
-            AVG_A::_2X => 1,
-            AVG_A::_4X => 2,
-            AVG_A::_8X => 3,
-            AVG_A::_16X => 4,
-            AVG_A::_32X => 5,
-            AVG_A::_64X => 6,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `AVG`"]

--- a/crates/tm4c123x/src/adc0/spc.rs
+++ b/crates/tm4c123x/src/adc0/spc.rs
@@ -12,61 +12,45 @@ impl crate::ResetValue for super::SPC {
 }
 #[doc = "Phase Difference\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PHASE_A {
     #[doc = "0: ADC sample lags by 0.0"]
-    _0,
+    _0 = 0,
     #[doc = "1: ADC sample lags by 22.5"]
-    _22_5,
+    _22_5 = 1,
     #[doc = "2: ADC sample lags by 45.0"]
-    _45,
+    _45 = 2,
     #[doc = "3: ADC sample lags by 67.5"]
-    _67_5,
+    _67_5 = 3,
     #[doc = "4: ADC sample lags by 90.0"]
-    _90,
+    _90 = 4,
     #[doc = "5: ADC sample lags by 112.5"]
-    _112_5,
+    _112_5 = 5,
     #[doc = "6: ADC sample lags by 135.0"]
-    _135,
+    _135 = 6,
     #[doc = "7: ADC sample lags by 157.5"]
-    _157_5,
+    _157_5 = 7,
     #[doc = "8: ADC sample lags by 180.0"]
-    _180,
+    _180 = 8,
     #[doc = "9: ADC sample lags by 202.5"]
-    _202_5,
+    _202_5 = 9,
     #[doc = "10: ADC sample lags by 225.0"]
-    _225,
+    _225 = 10,
     #[doc = "11: ADC sample lags by 247.5"]
-    _247_5,
+    _247_5 = 11,
     #[doc = "12: ADC sample lags by 270.0"]
-    _270,
+    _270 = 12,
     #[doc = "13: ADC sample lags by 292.5"]
-    _292_5,
+    _292_5 = 13,
     #[doc = "14: ADC sample lags by 315.0"]
-    _315,
+    _315 = 14,
     #[doc = "15: ADC sample lags by 337.5"]
-    _337_5,
+    _337_5 = 15,
 }
 impl From<PHASE_A> for u8 {
     #[inline(always)]
     fn from(variant: PHASE_A) -> Self {
-        match variant {
-            PHASE_A::_0 => 0,
-            PHASE_A::_22_5 => 1,
-            PHASE_A::_45 => 2,
-            PHASE_A::_67_5 => 3,
-            PHASE_A::_90 => 4,
-            PHASE_A::_112_5 => 5,
-            PHASE_A::_135 => 6,
-            PHASE_A::_157_5 => 7,
-            PHASE_A::_180 => 8,
-            PHASE_A::_202_5 => 9,
-            PHASE_A::_225 => 10,
-            PHASE_A::_247_5 => 11,
-            PHASE_A::_270 => 12,
-            PHASE_A::_292_5 => 13,
-            PHASE_A::_315 => 14,
-            PHASE_A::_337_5 => 15,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PHASE`"]

--- a/crates/tm4c123x/src/adc0/tssel.rs
+++ b/crates/tm4c123x/src/adc0/tssel.rs
@@ -12,19 +12,17 @@ impl crate::ResetValue for super::TSSEL {
 }
 #[doc = "Generator 0 PWM Module Trigger Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PS0_A {
     #[doc = "0: Use Generator 0 (and its trigger) in PWM module 0"]
-    _0,
+    _0 = 0,
     #[doc = "1: Use Generator 0 (and its trigger) in PWM module 1"]
-    _1,
+    _1 = 1,
 }
 impl From<PS0_A> for u8 {
     #[inline(always)]
     fn from(variant: PS0_A) -> Self {
-        match variant {
-            PS0_A::_0 => 0,
-            PS0_A::_1 => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PS0`"]
@@ -80,19 +78,17 @@ impl<'a> PS0_W<'a> {
 }
 #[doc = "Generator 1 PWM Module Trigger Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PS1_A {
     #[doc = "0: Use Generator 1 (and its trigger) in PWM module 0"]
-    _0,
+    _0 = 0,
     #[doc = "1: Use Generator 1 (and its trigger) in PWM module 1"]
-    _1,
+    _1 = 1,
 }
 impl From<PS1_A> for u8 {
     #[inline(always)]
     fn from(variant: PS1_A) -> Self {
-        match variant {
-            PS1_A::_0 => 0,
-            PS1_A::_1 => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PS1`"]
@@ -148,19 +144,17 @@ impl<'a> PS1_W<'a> {
 }
 #[doc = "Generator 2 PWM Module Trigger Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PS2_A {
     #[doc = "0: Use Generator 2 (and its trigger) in PWM module 0"]
-    _0,
+    _0 = 0,
     #[doc = "1: Use Generator 2 (and its trigger) in PWM module 1"]
-    _1,
+    _1 = 1,
 }
 impl From<PS2_A> for u8 {
     #[inline(always)]
     fn from(variant: PS2_A) -> Self {
-        match variant {
-            PS2_A::_0 => 0,
-            PS2_A::_1 => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PS2`"]
@@ -216,19 +210,17 @@ impl<'a> PS2_W<'a> {
 }
 #[doc = "Generator 3 PWM Module Trigger Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PS3_A {
     #[doc = "0: Use Generator 3 (and its trigger) in PWM module 0"]
-    _0,
+    _0 = 0,
     #[doc = "1: Use Generator 3 (and its trigger) in PWM module 1"]
-    _1,
+    _1 = 1,
 }
 impl From<PS3_A> for u8 {
     #[inline(always)]
     fn from(variant: PS3_A) -> Self {
-        match variant {
-            PS3_A::_0 => 0,
-            PS3_A::_1 => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PS3`"]

--- a/crates/tm4c123x/src/can0.rs
+++ b/crates/tm4c123x/src/can0.rs
@@ -82,7 +82,7 @@ pub struct RegisterBlock {
     #[doc = "0x164 - CAN Message 2 Valid"]
     pub msg2val: MSG2VAL,
 }
-#[doc = "CAN Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctl](ctl) module"]
+#[doc = "CAN Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctl](ctl) module"]
 pub type CTL = crate::Reg<u32, _CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -93,7 +93,7 @@ impl crate::Readable for CTL {}
 impl crate::Writable for CTL {}
 #[doc = "CAN Control"]
 pub mod ctl;
-#[doc = "CAN Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sts](sts) module"]
+#[doc = "CAN Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sts](sts) module"]
 pub type STS = crate::Reg<u32, _STS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -104,7 +104,7 @@ impl crate::Readable for STS {}
 impl crate::Writable for STS {}
 #[doc = "CAN Status"]
 pub mod sts;
-#[doc = "CAN Error Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [err](err) module"]
+#[doc = "CAN Error Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [err](err) module"]
 pub type ERR = crate::Reg<u32, _ERR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -113,7 +113,7 @@ pub struct _ERR;
 impl crate::Readable for ERR {}
 #[doc = "CAN Error Counter"]
 pub mod err;
-#[doc = "CAN Bit Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [bit_](bit_) module"]
+#[doc = "CAN Bit Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [bit_](bit_) module"]
 pub type BIT = crate::Reg<u32, _BIT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -124,7 +124,7 @@ impl crate::Readable for BIT {}
 impl crate::Writable for BIT {}
 #[doc = "CAN Bit Timing"]
 pub mod bit_;
-#[doc = "CAN Interrupt\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [int](int) module"]
+#[doc = "CAN Interrupt\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [int](int) module"]
 pub type INT = crate::Reg<u32, _INT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -133,7 +133,7 @@ pub struct _INT;
 impl crate::Readable for INT {}
 #[doc = "CAN Interrupt"]
 pub mod int;
-#[doc = "CAN Test\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tst](tst) module"]
+#[doc = "CAN Test\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tst](tst) module"]
 pub type TST = crate::Reg<u32, _TST>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -144,7 +144,7 @@ impl crate::Readable for TST {}
 impl crate::Writable for TST {}
 #[doc = "CAN Test"]
 pub mod tst;
-#[doc = "CAN Baud Rate Prescaler Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [brpe](brpe) module"]
+#[doc = "CAN Baud Rate Prescaler Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [brpe](brpe) module"]
 pub type BRPE = crate::Reg<u32, _BRPE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -155,7 +155,7 @@ impl crate::Readable for BRPE {}
 impl crate::Writable for BRPE {}
 #[doc = "CAN Baud Rate Prescaler Extension"]
 pub mod brpe;
-#[doc = "CAN IF1 Command Request\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1crq](if1crq) module"]
+#[doc = "CAN IF1 Command Request\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1crq](if1crq) module"]
 pub type IF1CRQ = crate::Reg<u32, _IF1CRQ>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -166,7 +166,7 @@ impl crate::Readable for IF1CRQ {}
 impl crate::Writable for IF1CRQ {}
 #[doc = "CAN IF1 Command Request"]
 pub mod if1crq;
-#[doc = "CAN IF1 Command Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1cmsk](if1cmsk) module"]
+#[doc = "CAN IF1 Command Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1cmsk](if1cmsk) module"]
 pub type IF1CMSK = crate::Reg<u32, _IF1CMSK>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -177,7 +177,7 @@ impl crate::Readable for IF1CMSK {}
 impl crate::Writable for IF1CMSK {}
 #[doc = "CAN IF1 Command Mask"]
 pub mod if1cmsk;
-#[doc = "CAN IF1 Mask 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1msk1](if1msk1) module"]
+#[doc = "CAN IF1 Mask 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1msk1](if1msk1) module"]
 pub type IF1MSK1 = crate::Reg<u32, _IF1MSK1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -188,7 +188,7 @@ impl crate::Readable for IF1MSK1 {}
 impl crate::Writable for IF1MSK1 {}
 #[doc = "CAN IF1 Mask 1"]
 pub mod if1msk1;
-#[doc = "CAN IF1 Mask 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1msk2](if1msk2) module"]
+#[doc = "CAN IF1 Mask 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1msk2](if1msk2) module"]
 pub type IF1MSK2 = crate::Reg<u32, _IF1MSK2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -199,7 +199,7 @@ impl crate::Readable for IF1MSK2 {}
 impl crate::Writable for IF1MSK2 {}
 #[doc = "CAN IF1 Mask 2"]
 pub mod if1msk2;
-#[doc = "CAN IF1 Arbitration 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1arb1](if1arb1) module"]
+#[doc = "CAN IF1 Arbitration 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1arb1](if1arb1) module"]
 pub type IF1ARB1 = crate::Reg<u32, _IF1ARB1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -210,7 +210,7 @@ impl crate::Readable for IF1ARB1 {}
 impl crate::Writable for IF1ARB1 {}
 #[doc = "CAN IF1 Arbitration 1"]
 pub mod if1arb1;
-#[doc = "CAN IF1 Arbitration 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1arb2](if1arb2) module"]
+#[doc = "CAN IF1 Arbitration 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1arb2](if1arb2) module"]
 pub type IF1ARB2 = crate::Reg<u32, _IF1ARB2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -221,7 +221,7 @@ impl crate::Readable for IF1ARB2 {}
 impl crate::Writable for IF1ARB2 {}
 #[doc = "CAN IF1 Arbitration 2"]
 pub mod if1arb2;
-#[doc = "CAN IF1 Message Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1mctl](if1mctl) module"]
+#[doc = "CAN IF1 Message Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1mctl](if1mctl) module"]
 pub type IF1MCTL = crate::Reg<u32, _IF1MCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -232,7 +232,7 @@ impl crate::Readable for IF1MCTL {}
 impl crate::Writable for IF1MCTL {}
 #[doc = "CAN IF1 Message Control"]
 pub mod if1mctl;
-#[doc = "CAN IF1 Data A1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1da1](if1da1) module"]
+#[doc = "CAN IF1 Data A1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1da1](if1da1) module"]
 pub type IF1DA1 = crate::Reg<u32, _IF1DA1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -243,7 +243,7 @@ impl crate::Readable for IF1DA1 {}
 impl crate::Writable for IF1DA1 {}
 #[doc = "CAN IF1 Data A1"]
 pub mod if1da1;
-#[doc = "CAN IF1 Data A2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1da2](if1da2) module"]
+#[doc = "CAN IF1 Data A2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1da2](if1da2) module"]
 pub type IF1DA2 = crate::Reg<u32, _IF1DA2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -254,7 +254,7 @@ impl crate::Readable for IF1DA2 {}
 impl crate::Writable for IF1DA2 {}
 #[doc = "CAN IF1 Data A2"]
 pub mod if1da2;
-#[doc = "CAN IF1 Data B1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1db1](if1db1) module"]
+#[doc = "CAN IF1 Data B1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1db1](if1db1) module"]
 pub type IF1DB1 = crate::Reg<u32, _IF1DB1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -265,7 +265,7 @@ impl crate::Readable for IF1DB1 {}
 impl crate::Writable for IF1DB1 {}
 #[doc = "CAN IF1 Data B1"]
 pub mod if1db1;
-#[doc = "CAN IF1 Data B2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1db2](if1db2) module"]
+#[doc = "CAN IF1 Data B2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1db2](if1db2) module"]
 pub type IF1DB2 = crate::Reg<u32, _IF1DB2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -276,7 +276,7 @@ impl crate::Readable for IF1DB2 {}
 impl crate::Writable for IF1DB2 {}
 #[doc = "CAN IF1 Data B2"]
 pub mod if1db2;
-#[doc = "CAN IF2 Command Request\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2crq](if2crq) module"]
+#[doc = "CAN IF2 Command Request\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2crq](if2crq) module"]
 pub type IF2CRQ = crate::Reg<u32, _IF2CRQ>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -287,7 +287,7 @@ impl crate::Readable for IF2CRQ {}
 impl crate::Writable for IF2CRQ {}
 #[doc = "CAN IF2 Command Request"]
 pub mod if2crq;
-#[doc = "CAN IF2 Command Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2cmsk](if2cmsk) module"]
+#[doc = "CAN IF2 Command Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2cmsk](if2cmsk) module"]
 pub type IF2CMSK = crate::Reg<u32, _IF2CMSK>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -298,7 +298,7 @@ impl crate::Readable for IF2CMSK {}
 impl crate::Writable for IF2CMSK {}
 #[doc = "CAN IF2 Command Mask"]
 pub mod if2cmsk;
-#[doc = "CAN IF2 Mask 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2msk1](if2msk1) module"]
+#[doc = "CAN IF2 Mask 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2msk1](if2msk1) module"]
 pub type IF2MSK1 = crate::Reg<u32, _IF2MSK1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -309,7 +309,7 @@ impl crate::Readable for IF2MSK1 {}
 impl crate::Writable for IF2MSK1 {}
 #[doc = "CAN IF2 Mask 1"]
 pub mod if2msk1;
-#[doc = "CAN IF2 Mask 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2msk2](if2msk2) module"]
+#[doc = "CAN IF2 Mask 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2msk2](if2msk2) module"]
 pub type IF2MSK2 = crate::Reg<u32, _IF2MSK2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -320,7 +320,7 @@ impl crate::Readable for IF2MSK2 {}
 impl crate::Writable for IF2MSK2 {}
 #[doc = "CAN IF2 Mask 2"]
 pub mod if2msk2;
-#[doc = "CAN IF2 Arbitration 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2arb1](if2arb1) module"]
+#[doc = "CAN IF2 Arbitration 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2arb1](if2arb1) module"]
 pub type IF2ARB1 = crate::Reg<u32, _IF2ARB1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -331,7 +331,7 @@ impl crate::Readable for IF2ARB1 {}
 impl crate::Writable for IF2ARB1 {}
 #[doc = "CAN IF2 Arbitration 1"]
 pub mod if2arb1;
-#[doc = "CAN IF2 Arbitration 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2arb2](if2arb2) module"]
+#[doc = "CAN IF2 Arbitration 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2arb2](if2arb2) module"]
 pub type IF2ARB2 = crate::Reg<u32, _IF2ARB2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -342,7 +342,7 @@ impl crate::Readable for IF2ARB2 {}
 impl crate::Writable for IF2ARB2 {}
 #[doc = "CAN IF2 Arbitration 2"]
 pub mod if2arb2;
-#[doc = "CAN IF2 Message Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2mctl](if2mctl) module"]
+#[doc = "CAN IF2 Message Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2mctl](if2mctl) module"]
 pub type IF2MCTL = crate::Reg<u32, _IF2MCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -353,7 +353,7 @@ impl crate::Readable for IF2MCTL {}
 impl crate::Writable for IF2MCTL {}
 #[doc = "CAN IF2 Message Control"]
 pub mod if2mctl;
-#[doc = "CAN IF2 Data A1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2da1](if2da1) module"]
+#[doc = "CAN IF2 Data A1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2da1](if2da1) module"]
 pub type IF2DA1 = crate::Reg<u32, _IF2DA1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -364,7 +364,7 @@ impl crate::Readable for IF2DA1 {}
 impl crate::Writable for IF2DA1 {}
 #[doc = "CAN IF2 Data A1"]
 pub mod if2da1;
-#[doc = "CAN IF2 Data A2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2da2](if2da2) module"]
+#[doc = "CAN IF2 Data A2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2da2](if2da2) module"]
 pub type IF2DA2 = crate::Reg<u32, _IF2DA2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -375,7 +375,7 @@ impl crate::Readable for IF2DA2 {}
 impl crate::Writable for IF2DA2 {}
 #[doc = "CAN IF2 Data A2"]
 pub mod if2da2;
-#[doc = "CAN IF2 Data B1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2db1](if2db1) module"]
+#[doc = "CAN IF2 Data B1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2db1](if2db1) module"]
 pub type IF2DB1 = crate::Reg<u32, _IF2DB1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -386,7 +386,7 @@ impl crate::Readable for IF2DB1 {}
 impl crate::Writable for IF2DB1 {}
 #[doc = "CAN IF2 Data B1"]
 pub mod if2db1;
-#[doc = "CAN IF2 Data B2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2db2](if2db2) module"]
+#[doc = "CAN IF2 Data B2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2db2](if2db2) module"]
 pub type IF2DB2 = crate::Reg<u32, _IF2DB2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -397,7 +397,7 @@ impl crate::Readable for IF2DB2 {}
 impl crate::Writable for IF2DB2 {}
 #[doc = "CAN IF2 Data B2"]
 pub mod if2db2;
-#[doc = "CAN Transmission Request 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txrq1](txrq1) module"]
+#[doc = "CAN Transmission Request 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txrq1](txrq1) module"]
 pub type TXRQ1 = crate::Reg<u32, _TXRQ1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -406,7 +406,7 @@ pub struct _TXRQ1;
 impl crate::Readable for TXRQ1 {}
 #[doc = "CAN Transmission Request 1"]
 pub mod txrq1;
-#[doc = "CAN Transmission Request 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txrq2](txrq2) module"]
+#[doc = "CAN Transmission Request 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txrq2](txrq2) module"]
 pub type TXRQ2 = crate::Reg<u32, _TXRQ2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -415,7 +415,7 @@ pub struct _TXRQ2;
 impl crate::Readable for TXRQ2 {}
 #[doc = "CAN Transmission Request 2"]
 pub mod txrq2;
-#[doc = "CAN New Data 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [nwda1](nwda1) module"]
+#[doc = "CAN New Data 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [nwda1](nwda1) module"]
 pub type NWDA1 = crate::Reg<u32, _NWDA1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -424,7 +424,7 @@ pub struct _NWDA1;
 impl crate::Readable for NWDA1 {}
 #[doc = "CAN New Data 1"]
 pub mod nwda1;
-#[doc = "CAN New Data 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [nwda2](nwda2) module"]
+#[doc = "CAN New Data 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [nwda2](nwda2) module"]
 pub type NWDA2 = crate::Reg<u32, _NWDA2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -433,7 +433,7 @@ pub struct _NWDA2;
 impl crate::Readable for NWDA2 {}
 #[doc = "CAN New Data 2"]
 pub mod nwda2;
-#[doc = "CAN Message 1 Interrupt Pending\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [msg1int](msg1int) module"]
+#[doc = "CAN Message 1 Interrupt Pending\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [msg1int](msg1int) module"]
 pub type MSG1INT = crate::Reg<u32, _MSG1INT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -442,7 +442,7 @@ pub struct _MSG1INT;
 impl crate::Readable for MSG1INT {}
 #[doc = "CAN Message 1 Interrupt Pending"]
 pub mod msg1int;
-#[doc = "CAN Message 2 Interrupt Pending\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [msg2int](msg2int) module"]
+#[doc = "CAN Message 2 Interrupt Pending\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [msg2int](msg2int) module"]
 pub type MSG2INT = crate::Reg<u32, _MSG2INT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -451,7 +451,7 @@ pub struct _MSG2INT;
 impl crate::Readable for MSG2INT {}
 #[doc = "CAN Message 2 Interrupt Pending"]
 pub mod msg2int;
-#[doc = "CAN Message 1 Valid\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [msg1val](msg1val) module"]
+#[doc = "CAN Message 1 Valid\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [msg1val](msg1val) module"]
 pub type MSG1VAL = crate::Reg<u32, _MSG1VAL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -460,7 +460,7 @@ pub struct _MSG1VAL;
 impl crate::Readable for MSG1VAL {}
 #[doc = "CAN Message 1 Valid"]
 pub mod msg1val;
-#[doc = "CAN Message 2 Valid\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [msg2val](msg2val) module"]
+#[doc = "CAN Message 2 Valid\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [msg2val](msg2val) module"]
 pub type MSG2VAL = crate::Reg<u32, _MSG2VAL>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/can0/int.rs
+++ b/crates/tm4c123x/src/can0/int.rs
@@ -2,19 +2,17 @@
 pub type R = crate::R<u32, super::INT>;
 #[doc = "Interrupt Identifier\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u16)]
 pub enum INTID_A {
     #[doc = "0: No interrupt pending"]
-    NONE,
+    NONE = 0,
     #[doc = "32768: Status Interrupt"]
-    STATUS,
+    STATUS = 32768,
 }
 impl From<INTID_A> for u16 {
     #[inline(always)]
     fn from(variant: INTID_A) -> Self {
-        match variant {
-            INTID_A::NONE => 0,
-            INTID_A::STATUS => 32768,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `INTID`"]

--- a/crates/tm4c123x/src/can0/sts.rs
+++ b/crates/tm4c123x/src/can0/sts.rs
@@ -12,37 +12,29 @@ impl crate::ResetValue for super::STS {
 }
 #[doc = "Last Error Code\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum LEC_A {
     #[doc = "0: No Error"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Stuff Error"]
-    STUFF,
+    STUFF = 1,
     #[doc = "2: Format Error"]
-    FORM,
+    FORM = 2,
     #[doc = "3: ACK Error"]
-    ACK,
+    ACK = 3,
     #[doc = "4: Bit 1 Error"]
-    BIT1,
+    BIT1 = 4,
     #[doc = "5: Bit 0 Error"]
-    BIT0,
+    BIT0 = 5,
     #[doc = "6: CRC Error"]
-    CRC,
+    CRC = 6,
     #[doc = "7: No Event"]
-    NOEVENT,
+    NOEVENT = 7,
 }
 impl From<LEC_A> for u8 {
     #[inline(always)]
     fn from(variant: LEC_A) -> Self {
-        match variant {
-            LEC_A::NONE => 0,
-            LEC_A::STUFF => 1,
-            LEC_A::FORM => 2,
-            LEC_A::ACK => 3,
-            LEC_A::BIT1 => 4,
-            LEC_A::BIT0 => 5,
-            LEC_A::CRC => 6,
-            LEC_A::NOEVENT => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `LEC`"]

--- a/crates/tm4c123x/src/can0/tst.rs
+++ b/crates/tm4c123x/src/can0/tst.rs
@@ -84,25 +84,21 @@ impl<'a> LBACK_W<'a> {
 }
 #[doc = "Transmit Control\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TX_A {
     #[doc = "0: CAN Module Control"]
-    CANCTL,
+    CANCTL = 0,
     #[doc = "1: Sample Point"]
-    SAMPLE,
+    SAMPLE = 1,
     #[doc = "2: Driven Low"]
-    DOMINANT,
+    DOMINANT = 2,
     #[doc = "3: Driven High"]
-    RECESSIVE,
+    RECESSIVE = 3,
 }
 impl From<TX_A> for u8 {
     #[inline(always)]
     fn from(variant: TX_A) -> Self {
-        match variant {
-            TX_A::CANCTL => 0,
-            TX_A::SAMPLE => 1,
-            TX_A::DOMINANT => 2,
-            TX_A::RECESSIVE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TX`"]

--- a/crates/tm4c123x/src/comp.rs
+++ b/crates/tm4c123x/src/comp.rs
@@ -24,7 +24,7 @@ pub struct RegisterBlock {
     #[doc = "0xfc0 - Analog Comparator Peripheral Properties"]
     pub pp: PP,
 }
-#[doc = "Analog Comparator Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acmis](acmis) module"]
+#[doc = "Analog Comparator Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acmis](acmis) module"]
 pub type ACMIS = crate::Reg<u32, _ACMIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -35,7 +35,7 @@ impl crate::Readable for ACMIS {}
 impl crate::Writable for ACMIS {}
 #[doc = "Analog Comparator Masked Interrupt Status"]
 pub mod acmis;
-#[doc = "Analog Comparator Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acris](acris) module"]
+#[doc = "Analog Comparator Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acris](acris) module"]
 pub type ACRIS = crate::Reg<u32, _ACRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -44,7 +44,7 @@ pub struct _ACRIS;
 impl crate::Readable for ACRIS {}
 #[doc = "Analog Comparator Raw Interrupt Status"]
 pub mod acris;
-#[doc = "Analog Comparator Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acinten](acinten) module"]
+#[doc = "Analog Comparator Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acinten](acinten) module"]
 pub type ACINTEN = crate::Reg<u32, _ACINTEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -55,7 +55,7 @@ impl crate::Readable for ACINTEN {}
 impl crate::Writable for ACINTEN {}
 #[doc = "Analog Comparator Interrupt Enable"]
 pub mod acinten;
-#[doc = "Analog Comparator Reference Voltage Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acrefctl](acrefctl) module"]
+#[doc = "Analog Comparator Reference Voltage Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acrefctl](acrefctl) module"]
 pub type ACREFCTL = crate::Reg<u32, _ACREFCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -66,7 +66,7 @@ impl crate::Readable for ACREFCTL {}
 impl crate::Writable for ACREFCTL {}
 #[doc = "Analog Comparator Reference Voltage Control"]
 pub mod acrefctl;
-#[doc = "Analog Comparator Status 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acstat0](acstat0) module"]
+#[doc = "Analog Comparator Status 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acstat0](acstat0) module"]
 pub type ACSTAT0 = crate::Reg<u32, _ACSTAT0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -75,7 +75,7 @@ pub struct _ACSTAT0;
 impl crate::Readable for ACSTAT0 {}
 #[doc = "Analog Comparator Status 0"]
 pub mod acstat0;
-#[doc = "Analog Comparator Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acctl0](acctl0) module"]
+#[doc = "Analog Comparator Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acctl0](acctl0) module"]
 pub type ACCTL0 = crate::Reg<u32, _ACCTL0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -86,7 +86,7 @@ impl crate::Readable for ACCTL0 {}
 impl crate::Writable for ACCTL0 {}
 #[doc = "Analog Comparator Control 0"]
 pub mod acctl0;
-#[doc = "Analog Comparator Status 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acstat1](acstat1) module"]
+#[doc = "Analog Comparator Status 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acstat1](acstat1) module"]
 pub type ACSTAT1 = crate::Reg<u32, _ACSTAT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -95,7 +95,7 @@ pub struct _ACSTAT1;
 impl crate::Readable for ACSTAT1 {}
 #[doc = "Analog Comparator Status 1"]
 pub mod acstat1;
-#[doc = "Analog Comparator Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acctl1](acctl1) module"]
+#[doc = "Analog Comparator Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acctl1](acctl1) module"]
 pub type ACCTL1 = crate::Reg<u32, _ACCTL1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -106,7 +106,7 @@ impl crate::Readable for ACCTL1 {}
 impl crate::Writable for ACCTL1 {}
 #[doc = "Analog Comparator Control 1"]
 pub mod acctl1;
-#[doc = "Analog Comparator Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "Analog Comparator Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/comp/acctl0.rs
+++ b/crates/tm4c123x/src/comp/acctl0.rs
@@ -36,25 +36,21 @@ impl<'a> CINV_W<'a> {
 }
 #[doc = "Interrupt Sense\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ISEN_A {
     #[doc = "0: Level sense, see ISLVAL"]
-    LEVEL,
+    LEVEL = 0,
     #[doc = "1: Falling edge"]
-    FALL,
+    FALL = 1,
     #[doc = "2: Rising edge"]
-    RISE,
+    RISE = 2,
     #[doc = "3: Either edge"]
-    BOTH,
+    BOTH = 3,
 }
 impl From<ISEN_A> for u8 {
     #[inline(always)]
     fn from(variant: ISEN_A) -> Self {
-        match variant {
-            ISEN_A::LEVEL => 0,
-            ISEN_A::FALL => 1,
-            ISEN_A::RISE => 2,
-            ISEN_A::BOTH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ISEN`"]
@@ -157,25 +153,21 @@ impl<'a> ISLVAL_W<'a> {
 }
 #[doc = "Trigger Sense\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TSEN_A {
     #[doc = "0: Level sense, see TSLVAL"]
-    LEVEL,
+    LEVEL = 0,
     #[doc = "1: Falling edge"]
-    FALL,
+    FALL = 1,
     #[doc = "2: Rising edge"]
-    RISE,
+    RISE = 2,
     #[doc = "3: Either edge"]
-    BOTH,
+    BOTH = 3,
 }
 impl From<TSEN_A> for u8 {
     #[inline(always)]
     fn from(variant: TSEN_A) -> Self {
-        match variant {
-            TSEN_A::LEVEL => 0,
-            TSEN_A::FALL => 1,
-            TSEN_A::RISE => 2,
-            TSEN_A::BOTH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TSEN`"]
@@ -278,22 +270,19 @@ impl<'a> TSLVAL_W<'a> {
 }
 #[doc = "Analog Source Positive\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ASRCP_A {
     #[doc = "0: Pin value of Cn+"]
-    PIN,
+    PIN = 0,
     #[doc = "1: Pin value of C0+"]
-    PIN0,
+    PIN0 = 1,
     #[doc = "2: Internal voltage reference"]
-    REF,
+    REF = 2,
 }
 impl From<ASRCP_A> for u8 {
     #[inline(always)]
     fn from(variant: ASRCP_A) -> Self {
-        match variant {
-            ASRCP_A::PIN => 0,
-            ASRCP_A::PIN0 => 1,
-            ASRCP_A::REF => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ASRCP`"]

--- a/crates/tm4c123x/src/comp/acctl1.rs
+++ b/crates/tm4c123x/src/comp/acctl1.rs
@@ -36,25 +36,21 @@ impl<'a> CINV_W<'a> {
 }
 #[doc = "Interrupt Sense\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ISEN_A {
     #[doc = "0: Level sense, see ISLVAL"]
-    LEVEL,
+    LEVEL = 0,
     #[doc = "1: Falling edge"]
-    FALL,
+    FALL = 1,
     #[doc = "2: Rising edge"]
-    RISE,
+    RISE = 2,
     #[doc = "3: Either edge"]
-    BOTH,
+    BOTH = 3,
 }
 impl From<ISEN_A> for u8 {
     #[inline(always)]
     fn from(variant: ISEN_A) -> Self {
-        match variant {
-            ISEN_A::LEVEL => 0,
-            ISEN_A::FALL => 1,
-            ISEN_A::RISE => 2,
-            ISEN_A::BOTH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ISEN`"]
@@ -157,25 +153,21 @@ impl<'a> ISLVAL_W<'a> {
 }
 #[doc = "Trigger Sense\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TSEN_A {
     #[doc = "0: Level sense, see TSLVAL"]
-    LEVEL,
+    LEVEL = 0,
     #[doc = "1: Falling edge"]
-    FALL,
+    FALL = 1,
     #[doc = "2: Rising edge"]
-    RISE,
+    RISE = 2,
     #[doc = "3: Either edge"]
-    BOTH,
+    BOTH = 3,
 }
 impl From<TSEN_A> for u8 {
     #[inline(always)]
     fn from(variant: TSEN_A) -> Self {
-        match variant {
-            TSEN_A::LEVEL => 0,
-            TSEN_A::FALL => 1,
-            TSEN_A::RISE => 2,
-            TSEN_A::BOTH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TSEN`"]
@@ -278,22 +270,19 @@ impl<'a> TSLVAL_W<'a> {
 }
 #[doc = "Analog Source Positive\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ASRCP_A {
     #[doc = "0: Pin value of Cn+"]
-    PIN,
+    PIN = 0,
     #[doc = "1: Pin value of C0+"]
-    PIN0,
+    PIN0 = 1,
     #[doc = "2: Internal voltage reference"]
-    REF,
+    REF = 2,
 }
 impl From<ASRCP_A> for u8 {
     #[inline(always)]
     fn from(variant: ASRCP_A) -> Self {
-        match variant {
-            ASRCP_A::PIN => 0,
-            ASRCP_A::PIN0 => 1,
-            ASRCP_A::REF => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ASRCP`"]

--- a/crates/tm4c123x/src/eeprom.rs
+++ b/crates/tm4c123x/src/eeprom.rs
@@ -39,7 +39,7 @@ pub struct RegisterBlock {
     #[doc = "0xfc0 - EEPROM Peripheral Properties"]
     pub pp: PP,
 }
-#[doc = "EEPROM Size Information\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eesize](eesize) module"]
+#[doc = "EEPROM Size Information\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eesize](eesize) module"]
 pub type EESIZE = crate::Reg<u32, _EESIZE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -48,7 +48,7 @@ pub struct _EESIZE;
 impl crate::Readable for EESIZE {}
 #[doc = "EEPROM Size Information"]
 pub mod eesize;
-#[doc = "EEPROM Current Block\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eeblock](eeblock) module"]
+#[doc = "EEPROM Current Block\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eeblock](eeblock) module"]
 pub type EEBLOCK = crate::Reg<u32, _EEBLOCK>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -59,7 +59,7 @@ impl crate::Readable for EEBLOCK {}
 impl crate::Writable for EEBLOCK {}
 #[doc = "EEPROM Current Block"]
 pub mod eeblock;
-#[doc = "EEPROM Current Offset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eeoffset](eeoffset) module"]
+#[doc = "EEPROM Current Offset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eeoffset](eeoffset) module"]
 pub type EEOFFSET = crate::Reg<u32, _EEOFFSET>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -70,7 +70,7 @@ impl crate::Readable for EEOFFSET {}
 impl crate::Writable for EEOFFSET {}
 #[doc = "EEPROM Current Offset"]
 pub mod eeoffset;
-#[doc = "EEPROM Read-Write\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eerdwr](eerdwr) module"]
+#[doc = "EEPROM Read-Write\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eerdwr](eerdwr) module"]
 pub type EERDWR = crate::Reg<u32, _EERDWR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -81,7 +81,7 @@ impl crate::Readable for EERDWR {}
 impl crate::Writable for EERDWR {}
 #[doc = "EEPROM Read-Write"]
 pub mod eerdwr;
-#[doc = "EEPROM Read-Write with Increment\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eerdwrinc](eerdwrinc) module"]
+#[doc = "EEPROM Read-Write with Increment\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eerdwrinc](eerdwrinc) module"]
 pub type EERDWRINC = crate::Reg<u32, _EERDWRINC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -92,7 +92,7 @@ impl crate::Readable for EERDWRINC {}
 impl crate::Writable for EERDWRINC {}
 #[doc = "EEPROM Read-Write with Increment"]
 pub mod eerdwrinc;
-#[doc = "EEPROM Done Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eedone](eedone) module"]
+#[doc = "EEPROM Done Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eedone](eedone) module"]
 pub type EEDONE = crate::Reg<u32, _EEDONE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -101,7 +101,7 @@ pub struct _EEDONE;
 impl crate::Readable for EEDONE {}
 #[doc = "EEPROM Done Status"]
 pub mod eedone;
-#[doc = "EEPROM Support Control and Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eesupp](eesupp) module"]
+#[doc = "EEPROM Support Control and Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eesupp](eesupp) module"]
 pub type EESUPP = crate::Reg<u32, _EESUPP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -112,7 +112,7 @@ impl crate::Readable for EESUPP {}
 impl crate::Writable for EESUPP {}
 #[doc = "EEPROM Support Control and Status"]
 pub mod eesupp;
-#[doc = "EEPROM Unlock\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eeunlock](eeunlock) module"]
+#[doc = "EEPROM Unlock\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eeunlock](eeunlock) module"]
 pub type EEUNLOCK = crate::Reg<u32, _EEUNLOCK>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -123,7 +123,7 @@ impl crate::Readable for EEUNLOCK {}
 impl crate::Writable for EEUNLOCK {}
 #[doc = "EEPROM Unlock"]
 pub mod eeunlock;
-#[doc = "EEPROM Protection\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eeprot](eeprot) module"]
+#[doc = "EEPROM Protection\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eeprot](eeprot) module"]
 pub type EEPROT = crate::Reg<u32, _EEPROT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -134,7 +134,7 @@ impl crate::Readable for EEPROT {}
 impl crate::Writable for EEPROT {}
 #[doc = "EEPROM Protection"]
 pub mod eeprot;
-#[doc = "EEPROM Password\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eepass0](eepass0) module"]
+#[doc = "EEPROM Password\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eepass0](eepass0) module"]
 pub type EEPASS0 = crate::Reg<u32, _EEPASS0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -145,7 +145,7 @@ impl crate::Readable for EEPASS0 {}
 impl crate::Writable for EEPASS0 {}
 #[doc = "EEPROM Password"]
 pub mod eepass0;
-#[doc = "EEPROM Password\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eepass1](eepass1) module"]
+#[doc = "EEPROM Password\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eepass1](eepass1) module"]
 pub type EEPASS1 = crate::Reg<u32, _EEPASS1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -156,7 +156,7 @@ impl crate::Readable for EEPASS1 {}
 impl crate::Writable for EEPASS1 {}
 #[doc = "EEPROM Password"]
 pub mod eepass1;
-#[doc = "EEPROM Password\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eepass2](eepass2) module"]
+#[doc = "EEPROM Password\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eepass2](eepass2) module"]
 pub type EEPASS2 = crate::Reg<u32, _EEPASS2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -167,7 +167,7 @@ impl crate::Readable for EEPASS2 {}
 impl crate::Writable for EEPASS2 {}
 #[doc = "EEPROM Password"]
 pub mod eepass2;
-#[doc = "EEPROM Interrupt\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eeint](eeint) module"]
+#[doc = "EEPROM Interrupt\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eeint](eeint) module"]
 pub type EEINT = crate::Reg<u32, _EEINT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -178,7 +178,7 @@ impl crate::Readable for EEINT {}
 impl crate::Writable for EEINT {}
 #[doc = "EEPROM Interrupt"]
 pub mod eeint;
-#[doc = "EEPROM Block Hide\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eehide](eehide) module"]
+#[doc = "EEPROM Block Hide\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eehide](eehide) module"]
 pub type EEHIDE = crate::Reg<u32, _EEHIDE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -189,7 +189,7 @@ impl crate::Readable for EEHIDE {}
 impl crate::Writable for EEHIDE {}
 #[doc = "EEPROM Block Hide"]
 pub mod eehide;
-#[doc = "EEPROM Debug Mass Erase\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eedbgme](eedbgme) module"]
+#[doc = "EEPROM Debug Mass Erase\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eedbgme](eedbgme) module"]
 pub type EEDBGME = crate::Reg<u32, _EEDBGME>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -200,7 +200,7 @@ impl crate::Readable for EEDBGME {}
 impl crate::Writable for EEDBGME {}
 #[doc = "EEPROM Debug Mass Erase"]
 pub mod eedbgme;
-#[doc = "EEPROM Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "EEPROM Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/eeprom/eeprot.rs
+++ b/crates/tm4c123x/src/eeprom/eeprot.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::EEPROT {
 }
 #[doc = "Protection Control\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROT_A {
     #[doc = "0: This setting is the default. If there is no password, the block is not protected and is readable and writable"]
-    RWNPW,
+    RWNPW = 0,
     #[doc = "1: If there is a password, the block is readable or writable only when unlocked"]
-    RWPW,
+    RWPW = 1,
     #[doc = "2: If there is no password, the block is readable, not writable"]
-    RONPW,
+    RONPW = 2,
 }
 impl From<PROT_A> for u8 {
     #[inline(always)]
     fn from(variant: PROT_A) -> Self {
-        match variant {
-            PROT_A::RWNPW => 0,
-            PROT_A::RWPW => 1,
-            PROT_A::RONPW => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROT`"]

--- a/crates/tm4c123x/src/flash_ctrl.rs
+++ b/crates/tm4c123x/src/flash_ctrl.rs
@@ -64,7 +64,7 @@ pub struct RegisterBlock {
     #[doc = "0x140c - Flash Memory Protection Program Enable 3"]
     pub fmppe3: FMPPE3,
 }
-#[doc = "Flash Memory Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fma](fma) module"]
+#[doc = "Flash Memory Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fma](fma) module"]
 pub type FMA = crate::Reg<u32, _FMA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -75,7 +75,7 @@ impl crate::Readable for FMA {}
 impl crate::Writable for FMA {}
 #[doc = "Flash Memory Address"]
 pub mod fma;
-#[doc = "Flash Memory Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmd](fmd) module"]
+#[doc = "Flash Memory Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmd](fmd) module"]
 pub type FMD = crate::Reg<u32, _FMD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -86,7 +86,7 @@ impl crate::Readable for FMD {}
 impl crate::Writable for FMD {}
 #[doc = "Flash Memory Data"]
 pub mod fmd;
-#[doc = "Flash Memory Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmc](fmc) module"]
+#[doc = "Flash Memory Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmc](fmc) module"]
 pub type FMC = crate::Reg<u32, _FMC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -97,7 +97,7 @@ impl crate::Readable for FMC {}
 impl crate::Writable for FMC {}
 #[doc = "Flash Memory Control"]
 pub mod fmc;
-#[doc = "Flash Controller Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fcris](fcris) module"]
+#[doc = "Flash Controller Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fcris](fcris) module"]
 pub type FCRIS = crate::Reg<u32, _FCRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -106,7 +106,7 @@ pub struct _FCRIS;
 impl crate::Readable for FCRIS {}
 #[doc = "Flash Controller Raw Interrupt Status"]
 pub mod fcris;
-#[doc = "Flash Controller Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fcim](fcim) module"]
+#[doc = "Flash Controller Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fcim](fcim) module"]
 pub type FCIM = crate::Reg<u32, _FCIM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -117,7 +117,7 @@ impl crate::Readable for FCIM {}
 impl crate::Writable for FCIM {}
 #[doc = "Flash Controller Interrupt Mask"]
 pub mod fcim;
-#[doc = "Flash Controller Masked Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fcmisc](fcmisc) module"]
+#[doc = "Flash Controller Masked Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fcmisc](fcmisc) module"]
 pub type FCMISC = crate::Reg<u32, _FCMISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -128,7 +128,7 @@ impl crate::Readable for FCMISC {}
 impl crate::Writable for FCMISC {}
 #[doc = "Flash Controller Masked Interrupt Status and Clear"]
 pub mod fcmisc;
-#[doc = "Flash Memory Control 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmc2](fmc2) module"]
+#[doc = "Flash Memory Control 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmc2](fmc2) module"]
 pub type FMC2 = crate::Reg<u32, _FMC2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -139,7 +139,7 @@ impl crate::Readable for FMC2 {}
 impl crate::Writable for FMC2 {}
 #[doc = "Flash Memory Control 2"]
 pub mod fmc2;
-#[doc = "Flash Write Buffer Valid\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fwbval](fwbval) module"]
+#[doc = "Flash Write Buffer Valid\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fwbval](fwbval) module"]
 pub type FWBVAL = crate::Reg<u32, _FWBVAL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -150,7 +150,7 @@ impl crate::Readable for FWBVAL {}
 impl crate::Writable for FWBVAL {}
 #[doc = "Flash Write Buffer Valid"]
 pub mod fwbval;
-#[doc = "Flash Write Buffer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fwbn](fwbn) module"]
+#[doc = "Flash Write Buffer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fwbn](fwbn) module"]
 pub type FWBN = crate::Reg<u32, _FWBN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -161,7 +161,7 @@ impl crate::Readable for FWBN {}
 impl crate::Writable for FWBN {}
 #[doc = "Flash Write Buffer"]
 pub mod fwbn;
-#[doc = "Flash Size\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fsize](fsize) module"]
+#[doc = "Flash Size\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fsize](fsize) module"]
 pub type FSIZE = crate::Reg<u32, _FSIZE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -170,7 +170,7 @@ pub struct _FSIZE;
 impl crate::Readable for FSIZE {}
 #[doc = "Flash Size"]
 pub mod fsize;
-#[doc = "SRAM Size\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssize](ssize) module"]
+#[doc = "SRAM Size\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssize](ssize) module"]
 pub type SSIZE = crate::Reg<u32, _SSIZE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -179,7 +179,7 @@ pub struct _SSIZE;
 impl crate::Readable for SSIZE {}
 #[doc = "SRAM Size"]
 pub mod ssize;
-#[doc = "ROM Software Map\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [romswmap](romswmap) module"]
+#[doc = "ROM Software Map\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [romswmap](romswmap) module"]
 pub type ROMSWMAP = crate::Reg<u32, _ROMSWMAP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -188,7 +188,7 @@ pub struct _ROMSWMAP;
 impl crate::Readable for ROMSWMAP {}
 #[doc = "ROM Software Map"]
 pub mod romswmap;
-#[doc = "ROM Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rmctl](rmctl) module"]
+#[doc = "ROM Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rmctl](rmctl) module"]
 pub type RMCTL = crate::Reg<u32, _RMCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -199,7 +199,7 @@ impl crate::Readable for RMCTL {}
 impl crate::Writable for RMCTL {}
 #[doc = "ROM Control"]
 pub mod rmctl;
-#[doc = "Boot Configuration\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [bootcfg](bootcfg) module"]
+#[doc = "Boot Configuration\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [bootcfg](bootcfg) module"]
 pub type BOOTCFG = crate::Reg<u32, _BOOTCFG>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -208,7 +208,7 @@ pub struct _BOOTCFG;
 impl crate::Readable for BOOTCFG {}
 #[doc = "Boot Configuration"]
 pub mod bootcfg;
-#[doc = "User Register 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [userreg0](userreg0) module"]
+#[doc = "User Register 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [userreg0](userreg0) module"]
 pub type USERREG0 = crate::Reg<u32, _USERREG0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -219,7 +219,7 @@ impl crate::Readable for USERREG0 {}
 impl crate::Writable for USERREG0 {}
 #[doc = "User Register 0"]
 pub mod userreg0;
-#[doc = "User Register 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [userreg1](userreg1) module"]
+#[doc = "User Register 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [userreg1](userreg1) module"]
 pub type USERREG1 = crate::Reg<u32, _USERREG1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -230,7 +230,7 @@ impl crate::Readable for USERREG1 {}
 impl crate::Writable for USERREG1 {}
 #[doc = "User Register 1"]
 pub mod userreg1;
-#[doc = "User Register 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [userreg2](userreg2) module"]
+#[doc = "User Register 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [userreg2](userreg2) module"]
 pub type USERREG2 = crate::Reg<u32, _USERREG2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -241,7 +241,7 @@ impl crate::Readable for USERREG2 {}
 impl crate::Writable for USERREG2 {}
 #[doc = "User Register 2"]
 pub mod userreg2;
-#[doc = "User Register 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [userreg3](userreg3) module"]
+#[doc = "User Register 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [userreg3](userreg3) module"]
 pub type USERREG3 = crate::Reg<u32, _USERREG3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -252,7 +252,7 @@ impl crate::Readable for USERREG3 {}
 impl crate::Writable for USERREG3 {}
 #[doc = "User Register 3"]
 pub mod userreg3;
-#[doc = "Flash Memory Protection Read Enable 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre0](fmpre0) module"]
+#[doc = "Flash Memory Protection Read Enable 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre0](fmpre0) module"]
 pub type FMPRE0 = crate::Reg<u32, _FMPRE0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -263,7 +263,7 @@ impl crate::Readable for FMPRE0 {}
 impl crate::Writable for FMPRE0 {}
 #[doc = "Flash Memory Protection Read Enable 0"]
 pub mod fmpre0;
-#[doc = "Flash Memory Protection Read Enable 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre1](fmpre1) module"]
+#[doc = "Flash Memory Protection Read Enable 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre1](fmpre1) module"]
 pub type FMPRE1 = crate::Reg<u32, _FMPRE1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -274,7 +274,7 @@ impl crate::Readable for FMPRE1 {}
 impl crate::Writable for FMPRE1 {}
 #[doc = "Flash Memory Protection Read Enable 1"]
 pub mod fmpre1;
-#[doc = "Flash Memory Protection Read Enable 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre2](fmpre2) module"]
+#[doc = "Flash Memory Protection Read Enable 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre2](fmpre2) module"]
 pub type FMPRE2 = crate::Reg<u32, _FMPRE2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -285,7 +285,7 @@ impl crate::Readable for FMPRE2 {}
 impl crate::Writable for FMPRE2 {}
 #[doc = "Flash Memory Protection Read Enable 2"]
 pub mod fmpre2;
-#[doc = "Flash Memory Protection Read Enable 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre3](fmpre3) module"]
+#[doc = "Flash Memory Protection Read Enable 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre3](fmpre3) module"]
 pub type FMPRE3 = crate::Reg<u32, _FMPRE3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -296,7 +296,7 @@ impl crate::Readable for FMPRE3 {}
 impl crate::Writable for FMPRE3 {}
 #[doc = "Flash Memory Protection Read Enable 3"]
 pub mod fmpre3;
-#[doc = "Flash Memory Protection Program Enable 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe0](fmppe0) module"]
+#[doc = "Flash Memory Protection Program Enable 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe0](fmppe0) module"]
 pub type FMPPE0 = crate::Reg<u32, _FMPPE0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -307,7 +307,7 @@ impl crate::Readable for FMPPE0 {}
 impl crate::Writable for FMPPE0 {}
 #[doc = "Flash Memory Protection Program Enable 0"]
 pub mod fmppe0;
-#[doc = "Flash Memory Protection Program Enable 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe1](fmppe1) module"]
+#[doc = "Flash Memory Protection Program Enable 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe1](fmppe1) module"]
 pub type FMPPE1 = crate::Reg<u32, _FMPPE1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -318,7 +318,7 @@ impl crate::Readable for FMPPE1 {}
 impl crate::Writable for FMPPE1 {}
 #[doc = "Flash Memory Protection Program Enable 1"]
 pub mod fmppe1;
-#[doc = "Flash Memory Protection Program Enable 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe2](fmppe2) module"]
+#[doc = "Flash Memory Protection Program Enable 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe2](fmppe2) module"]
 pub type FMPPE2 = crate::Reg<u32, _FMPPE2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -329,7 +329,7 @@ impl crate::Readable for FMPPE2 {}
 impl crate::Writable for FMPPE2 {}
 #[doc = "Flash Memory Protection Program Enable 2"]
 pub mod fmppe2;
-#[doc = "Flash Memory Protection Program Enable 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe3](fmppe3) module"]
+#[doc = "Flash Memory Protection Program Enable 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe3](fmppe3) module"]
 pub type FMPPE3 = crate::Reg<u32, _FMPPE3>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/flash_ctrl/bootcfg.rs
+++ b/crates/tm4c123x/src/flash_ctrl/bootcfg.rs
@@ -12,37 +12,29 @@ pub type EN_R = crate::R<bool, bool>;
 pub type POL_R = crate::R<bool, bool>;
 #[doc = "Boot GPIO Pin\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PIN_A {
     #[doc = "0: Pin 0"]
-    _0,
+    _0 = 0,
     #[doc = "1: Pin 1"]
-    _1,
+    _1 = 1,
     #[doc = "2: Pin 2"]
-    _2,
+    _2 = 2,
     #[doc = "3: Pin 3"]
-    _3,
+    _3 = 3,
     #[doc = "4: Pin 4"]
-    _4,
+    _4 = 4,
     #[doc = "5: Pin 5"]
-    _5,
+    _5 = 5,
     #[doc = "6: Pin 6"]
-    _6,
+    _6 = 6,
     #[doc = "7: Pin 7"]
-    _7,
+    _7 = 7,
 }
 impl From<PIN_A> for u8 {
     #[inline(always)]
     fn from(variant: PIN_A) -> Self {
-        match variant {
-            PIN_A::_0 => 0,
-            PIN_A::_1 => 1,
-            PIN_A::_2 => 2,
-            PIN_A::_3 => 3,
-            PIN_A::_4 => 4,
-            PIN_A::_5 => 5,
-            PIN_A::_6 => 6,
-            PIN_A::_7 => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PIN`"]
@@ -106,37 +98,29 @@ impl PIN_R {
 }
 #[doc = "Boot GPIO Port\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PORT_A {
     #[doc = "0: Port A"]
-    A,
+    A = 0,
     #[doc = "1: Port B"]
-    B,
+    B = 1,
     #[doc = "2: Port C"]
-    C,
+    C = 2,
     #[doc = "3: Port D"]
-    D,
+    D = 3,
     #[doc = "4: Port E"]
-    E,
+    E = 4,
     #[doc = "5: Port F"]
-    F,
+    F = 5,
     #[doc = "6: Port G"]
-    G,
+    G = 6,
     #[doc = "7: Port H"]
-    H,
+    H = 7,
 }
 impl From<PORT_A> for u8 {
     #[inline(always)]
     fn from(variant: PORT_A) -> Self {
-        match variant {
-            PORT_A::A => 0,
-            PORT_A::B => 1,
-            PORT_A::C => 2,
-            PORT_A::D => 3,
-            PORT_A::E => 4,
-            PORT_A::F => 5,
-            PORT_A::G => 6,
-            PORT_A::H => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PORT`"]

--- a/crates/tm4c123x/src/flash_ctrl/fsize.rs
+++ b/crates/tm4c123x/src/flash_ctrl/fsize.rs
@@ -2,16 +2,15 @@
 pub type R = crate::R<u32, super::FSIZE>;
 #[doc = "Flash Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u16)]
 pub enum SIZE_A {
     #[doc = "127: 256 KB of Flash"]
-    _256KB,
+    _256KB = 127,
 }
 impl From<SIZE_A> for u16 {
     #[inline(always)]
     fn from(variant: SIZE_A) -> Self {
-        match variant {
-            SIZE_A::_256KB => 127,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SIZE`"]

--- a/crates/tm4c123x/src/flash_ctrl/ssize.rs
+++ b/crates/tm4c123x/src/flash_ctrl/ssize.rs
@@ -2,16 +2,15 @@
 pub type R = crate::R<u32, super::SSIZE>;
 #[doc = "SRAM Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u16)]
 pub enum SIZE_A {
     #[doc = "127: 32 KB of SRAM"]
-    _32KB,
+    _32KB = 127,
 }
 impl From<SIZE_A> for u16 {
     #[inline(always)]
     fn from(variant: SIZE_A) -> Self {
-        match variant {
-            SIZE_A::_32KB => 127,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SIZE`"]

--- a/crates/tm4c123x/src/gpio_porta.rs
+++ b/crates/tm4c123x/src/gpio_porta.rs
@@ -52,7 +52,7 @@ pub struct RegisterBlock {
     #[doc = "0x534 - GPIO DMA Control"]
     pub dmactl: DMACTL,
 }
-#[doc = "GPIO Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [data](data) module"]
+#[doc = "GPIO Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [data](data) module"]
 pub type DATA = crate::Reg<u32, _DATA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -63,7 +63,7 @@ impl crate::Readable for DATA {}
 impl crate::Writable for DATA {}
 #[doc = "GPIO Data"]
 pub mod data;
-#[doc = "GPIO Direction\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dir](dir) module"]
+#[doc = "GPIO Direction\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dir](dir) module"]
 pub type DIR = crate::Reg<u32, _DIR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -74,7 +74,7 @@ impl crate::Readable for DIR {}
 impl crate::Writable for DIR {}
 #[doc = "GPIO Direction"]
 pub mod dir;
-#[doc = "GPIO Interrupt Sense\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [is](is) module"]
+#[doc = "GPIO Interrupt Sense\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [is](is) module"]
 pub type IS = crate::Reg<u32, _IS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -85,7 +85,7 @@ impl crate::Readable for IS {}
 impl crate::Writable for IS {}
 #[doc = "GPIO Interrupt Sense"]
 pub mod is;
-#[doc = "GPIO Interrupt Both Edges\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ibe](ibe) module"]
+#[doc = "GPIO Interrupt Both Edges\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ibe](ibe) module"]
 pub type IBE = crate::Reg<u32, _IBE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -96,7 +96,7 @@ impl crate::Readable for IBE {}
 impl crate::Writable for IBE {}
 #[doc = "GPIO Interrupt Both Edges"]
 pub mod ibe;
-#[doc = "GPIO Interrupt Event\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [iev](iev) module"]
+#[doc = "GPIO Interrupt Event\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [iev](iev) module"]
 pub type IEV = crate::Reg<u32, _IEV>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -107,7 +107,7 @@ impl crate::Readable for IEV {}
 impl crate::Writable for IEV {}
 #[doc = "GPIO Interrupt Event"]
 pub mod iev;
-#[doc = "GPIO Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [im](im) module"]
+#[doc = "GPIO Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [im](im) module"]
 pub type IM = crate::Reg<u32, _IM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -118,7 +118,7 @@ impl crate::Readable for IM {}
 impl crate::Writable for IM {}
 #[doc = "GPIO Interrupt Mask"]
 pub mod im;
-#[doc = "GPIO Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "GPIO Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -127,7 +127,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "GPIO Raw Interrupt Status"]
 pub mod ris;
-#[doc = "GPIO Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mis](mis) module"]
+#[doc = "GPIO Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mis](mis) module"]
 pub type MIS = crate::Reg<u32, _MIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -136,7 +136,7 @@ pub struct _MIS;
 impl crate::Readable for MIS {}
 #[doc = "GPIO Masked Interrupt Status"]
 pub mod mis;
-#[doc = "GPIO Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [icr](icr) module"]
+#[doc = "GPIO Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [icr](icr) module"]
 pub type ICR = crate::Reg<u32, _ICR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -145,7 +145,7 @@ pub struct _ICR;
 impl crate::Writable for ICR {}
 #[doc = "GPIO Interrupt Clear"]
 pub mod icr;
-#[doc = "GPIO Alternate Function Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [afsel](afsel) module"]
+#[doc = "GPIO Alternate Function Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [afsel](afsel) module"]
 pub type AFSEL = crate::Reg<u32, _AFSEL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -156,7 +156,7 @@ impl crate::Readable for AFSEL {}
 impl crate::Writable for AFSEL {}
 #[doc = "GPIO Alternate Function Select"]
 pub mod afsel;
-#[doc = "GPIO 2-mA Drive Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dr2r](dr2r) module"]
+#[doc = "GPIO 2-mA Drive Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dr2r](dr2r) module"]
 pub type DR2R = crate::Reg<u32, _DR2R>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -167,7 +167,7 @@ impl crate::Readable for DR2R {}
 impl crate::Writable for DR2R {}
 #[doc = "GPIO 2-mA Drive Select"]
 pub mod dr2r;
-#[doc = "GPIO 4-mA Drive Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dr4r](dr4r) module"]
+#[doc = "GPIO 4-mA Drive Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dr4r](dr4r) module"]
 pub type DR4R = crate::Reg<u32, _DR4R>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -178,7 +178,7 @@ impl crate::Readable for DR4R {}
 impl crate::Writable for DR4R {}
 #[doc = "GPIO 4-mA Drive Select"]
 pub mod dr4r;
-#[doc = "GPIO 8-mA Drive Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dr8r](dr8r) module"]
+#[doc = "GPIO 8-mA Drive Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dr8r](dr8r) module"]
 pub type DR8R = crate::Reg<u32, _DR8R>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -189,7 +189,7 @@ impl crate::Readable for DR8R {}
 impl crate::Writable for DR8R {}
 #[doc = "GPIO 8-mA Drive Select"]
 pub mod dr8r;
-#[doc = "GPIO Open Drain Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [odr](odr) module"]
+#[doc = "GPIO Open Drain Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [odr](odr) module"]
 pub type ODR = crate::Reg<u32, _ODR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -200,7 +200,7 @@ impl crate::Readable for ODR {}
 impl crate::Writable for ODR {}
 #[doc = "GPIO Open Drain Select"]
 pub mod odr;
-#[doc = "GPIO Pull-Up Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pur](pur) module"]
+#[doc = "GPIO Pull-Up Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pur](pur) module"]
 pub type PUR = crate::Reg<u32, _PUR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -211,7 +211,7 @@ impl crate::Readable for PUR {}
 impl crate::Writable for PUR {}
 #[doc = "GPIO Pull-Up Select"]
 pub mod pur;
-#[doc = "GPIO Pull-Down Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pdr](pdr) module"]
+#[doc = "GPIO Pull-Down Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pdr](pdr) module"]
 pub type PDR = crate::Reg<u32, _PDR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -222,7 +222,7 @@ impl crate::Readable for PDR {}
 impl crate::Writable for PDR {}
 #[doc = "GPIO Pull-Down Select"]
 pub mod pdr;
-#[doc = "GPIO Slew Rate Control Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [slr](slr) module"]
+#[doc = "GPIO Slew Rate Control Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [slr](slr) module"]
 pub type SLR = crate::Reg<u32, _SLR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -233,7 +233,7 @@ impl crate::Readable for SLR {}
 impl crate::Writable for SLR {}
 #[doc = "GPIO Slew Rate Control Select"]
 pub mod slr;
-#[doc = "GPIO Digital Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [den](den) module"]
+#[doc = "GPIO Digital Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [den](den) module"]
 pub type DEN = crate::Reg<u32, _DEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -244,7 +244,7 @@ impl crate::Readable for DEN {}
 impl crate::Writable for DEN {}
 #[doc = "GPIO Digital Enable"]
 pub mod den;
-#[doc = "GPIO Lock\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [lock](lock) module"]
+#[doc = "GPIO Lock\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [lock](lock) module"]
 pub type LOCK = crate::Reg<u32, _LOCK>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -255,7 +255,7 @@ impl crate::Readable for LOCK {}
 impl crate::Writable for LOCK {}
 #[doc = "GPIO Lock"]
 pub mod lock;
-#[doc = "GPIO Commit\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cr](cr) module"]
+#[doc = "GPIO Commit\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cr](cr) module"]
 pub type CR = crate::Reg<u32, _CR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -266,7 +266,7 @@ impl crate::Readable for CR {}
 impl crate::Writable for CR {}
 #[doc = "GPIO Commit"]
 pub mod cr;
-#[doc = "GPIO Analog Mode Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [amsel](amsel) module"]
+#[doc = "GPIO Analog Mode Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [amsel](amsel) module"]
 pub type AMSEL = crate::Reg<u32, _AMSEL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -277,7 +277,7 @@ impl crate::Readable for AMSEL {}
 impl crate::Writable for AMSEL {}
 #[doc = "GPIO Analog Mode Select"]
 pub mod amsel;
-#[doc = "GPIO Port Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pctl](pctl) module"]
+#[doc = "GPIO Port Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pctl](pctl) module"]
 pub type PCTL = crate::Reg<u32, _PCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -288,7 +288,7 @@ impl crate::Readable for PCTL {}
 impl crate::Writable for PCTL {}
 #[doc = "GPIO Port Control"]
 pub mod pctl;
-#[doc = "GPIO ADC Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [adcctl](adcctl) module"]
+#[doc = "GPIO ADC Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [adcctl](adcctl) module"]
 pub type ADCCTL = crate::Reg<u32, _ADCCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -299,7 +299,7 @@ impl crate::Readable for ADCCTL {}
 impl crate::Writable for ADCCTL {}
 #[doc = "GPIO ADC Control"]
 pub mod adcctl;
-#[doc = "GPIO DMA Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmactl](dmactl) module"]
+#[doc = "GPIO DMA Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmactl](dmactl) module"]
 pub type DMACTL = crate::Reg<u32, _DMACTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/gpio_porta/lock.rs
+++ b/crates/tm4c123x/src/gpio_porta/lock.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::LOCK {
 }
 #[doc = "GPIO Lock\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u32)]
 pub enum LOCK_A {
     #[doc = "0: The GPIOCR register is unlocked and may be modified"]
-    UNLOCKED,
+    UNLOCKED = 0,
     #[doc = "1: The GPIOCR register is locked and may not be modified"]
-    LOCKED,
+    LOCKED = 1,
     #[doc = "1280262987: Unlocks the GPIO_CR register"]
-    KEY,
+    KEY = 1280262987,
 }
 impl From<LOCK_A> for u32 {
     #[inline(always)]
     fn from(variant: LOCK_A) -> Self {
-        match variant {
-            LOCK_A::UNLOCKED => 0,
-            LOCK_A::LOCKED => 1,
-            LOCK_A::KEY => 1280262987,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `LOCK`"]

--- a/crates/tm4c123x/src/hib.rs
+++ b/crates/tm4c123x/src/hib.rs
@@ -26,7 +26,7 @@ pub struct RegisterBlock {
     #[doc = "0x30 - Hibernation Data"]
     pub data: DATA,
 }
-#[doc = "Hibernation RTC Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rtcc](rtcc) module"]
+#[doc = "Hibernation RTC Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rtcc](rtcc) module"]
 pub type RTCC = crate::Reg<u32, _RTCC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -35,7 +35,7 @@ pub struct _RTCC;
 impl crate::Readable for RTCC {}
 #[doc = "Hibernation RTC Counter"]
 pub mod rtcc;
-#[doc = "Hibernation RTC Match 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rtcm0](rtcm0) module"]
+#[doc = "Hibernation RTC Match 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rtcm0](rtcm0) module"]
 pub type RTCM0 = crate::Reg<u32, _RTCM0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -46,7 +46,7 @@ impl crate::Readable for RTCM0 {}
 impl crate::Writable for RTCM0 {}
 #[doc = "Hibernation RTC Match 0"]
 pub mod rtcm0;
-#[doc = "Hibernation RTC Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rtcld](rtcld) module"]
+#[doc = "Hibernation RTC Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rtcld](rtcld) module"]
 pub type RTCLD = crate::Reg<u32, _RTCLD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -57,7 +57,7 @@ impl crate::Readable for RTCLD {}
 impl crate::Writable for RTCLD {}
 #[doc = "Hibernation RTC Load"]
 pub mod rtcld;
-#[doc = "Hibernation Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctl](ctl) module"]
+#[doc = "Hibernation Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctl](ctl) module"]
 pub type CTL = crate::Reg<u32, _CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -68,7 +68,7 @@ impl crate::Readable for CTL {}
 impl crate::Writable for CTL {}
 #[doc = "Hibernation Control"]
 pub mod ctl;
-#[doc = "Hibernation Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [im](im) module"]
+#[doc = "Hibernation Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [im](im) module"]
 pub type IM = crate::Reg<u32, _IM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -79,7 +79,7 @@ impl crate::Readable for IM {}
 impl crate::Writable for IM {}
 #[doc = "Hibernation Interrupt Mask"]
 pub mod im;
-#[doc = "Hibernation Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "Hibernation Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -88,7 +88,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "Hibernation Raw Interrupt Status"]
 pub mod ris;
-#[doc = "Hibernation Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mis](mis) module"]
+#[doc = "Hibernation Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mis](mis) module"]
 pub type MIS = crate::Reg<u32, _MIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -97,7 +97,7 @@ pub struct _MIS;
 impl crate::Readable for MIS {}
 #[doc = "Hibernation Masked Interrupt Status"]
 pub mod mis;
-#[doc = "Hibernation Interrupt Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ic](ic) module"]
+#[doc = "Hibernation Interrupt Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ic](ic) module"]
 pub type IC = crate::Reg<u32, _IC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -108,7 +108,7 @@ impl crate::Readable for IC {}
 impl crate::Writable for IC {}
 #[doc = "Hibernation Interrupt Clear"]
 pub mod ic;
-#[doc = "Hibernation RTC Trim\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rtct](rtct) module"]
+#[doc = "Hibernation RTC Trim\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rtct](rtct) module"]
 pub type RTCT = crate::Reg<u32, _RTCT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -119,7 +119,7 @@ impl crate::Readable for RTCT {}
 impl crate::Writable for RTCT {}
 #[doc = "Hibernation RTC Trim"]
 pub mod rtct;
-#[doc = "Hibernation RTC Sub Seconds\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rtcss](rtcss) module"]
+#[doc = "Hibernation RTC Sub Seconds\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rtcss](rtcss) module"]
 pub type RTCSS = crate::Reg<u32, _RTCSS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -130,7 +130,7 @@ impl crate::Readable for RTCSS {}
 impl crate::Writable for RTCSS {}
 #[doc = "Hibernation RTC Sub Seconds"]
 pub mod rtcss;
-#[doc = "Hibernation Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [data](data) module"]
+#[doc = "Hibernation Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [data](data) module"]
 pub type DATA = crate::Reg<u32, _DATA>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/hib/ctl.rs
+++ b/crates/tm4c123x/src/hib/ctl.rs
@@ -228,25 +228,21 @@ impl<'a> BATCHK_W<'a> {
 }
 #[doc = "Select for Low-Battery Comparator\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum VBATSEL_A {
     #[doc = "0: 1.9 Volts"]
-    _1_9V,
+    _1_9V = 0,
     #[doc = "1: 2.1 Volts (default)"]
-    _2_1V,
+    _2_1V = 1,
     #[doc = "2: 2.3 Volts"]
-    _2_3V,
+    _2_3V = 2,
     #[doc = "3: 2.5 Volts"]
-    _2_5V,
+    _2_5V = 3,
 }
 impl From<VBATSEL_A> for u8 {
     #[inline(always)]
     fn from(variant: VBATSEL_A) -> Self {
-        match variant {
-            VBATSEL_A::_1_9V => 0,
-            VBATSEL_A::_2_1V => 1,
-            VBATSEL_A::_2_3V => 2,
-            VBATSEL_A::_2_5V => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `VBATSEL`"]

--- a/crates/tm4c123x/src/i2c0.rs
+++ b/crates/tm4c123x/src/i2c0.rs
@@ -52,7 +52,7 @@ pub struct RegisterBlock {
     #[doc = "0xfc4 - I2C Peripheral Configuration"]
     pub pc: PC,
 }
-#[doc = "I2C Master Slave Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [msa](msa) module"]
+#[doc = "I2C Master Slave Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [msa](msa) module"]
 pub type MSA = crate::Reg<u32, _MSA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -63,7 +63,7 @@ impl crate::Readable for MSA {}
 impl crate::Writable for MSA {}
 #[doc = "I2C Master Slave Address"]
 pub mod msa;
-#[doc = "I2C Master Control/Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mcs](mcs) module"]
+#[doc = "I2C Master Control/Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mcs](mcs) module"]
 pub type MCS = crate::Reg<u32, _MCS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -74,7 +74,7 @@ impl crate::Readable for MCS {}
 impl crate::Writable for MCS {}
 #[doc = "I2C Master Control/Status"]
 pub mod mcs;
-#[doc = "I2C Master Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mdr](mdr) module"]
+#[doc = "I2C Master Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mdr](mdr) module"]
 pub type MDR = crate::Reg<u32, _MDR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -85,7 +85,7 @@ impl crate::Readable for MDR {}
 impl crate::Writable for MDR {}
 #[doc = "I2C Master Data"]
 pub mod mdr;
-#[doc = "I2C Master Timer Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mtpr](mtpr) module"]
+#[doc = "I2C Master Timer Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mtpr](mtpr) module"]
 pub type MTPR = crate::Reg<u32, _MTPR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -96,7 +96,7 @@ impl crate::Readable for MTPR {}
 impl crate::Writable for MTPR {}
 #[doc = "I2C Master Timer Period"]
 pub mod mtpr;
-#[doc = "I2C Master Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mimr](mimr) module"]
+#[doc = "I2C Master Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mimr](mimr) module"]
 pub type MIMR = crate::Reg<u32, _MIMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -107,7 +107,7 @@ impl crate::Readable for MIMR {}
 impl crate::Writable for MIMR {}
 #[doc = "I2C Master Interrupt Mask"]
 pub mod mimr;
-#[doc = "I2C Master Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mris](mris) module"]
+#[doc = "I2C Master Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mris](mris) module"]
 pub type MRIS = crate::Reg<u32, _MRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -116,7 +116,7 @@ pub struct _MRIS;
 impl crate::Readable for MRIS {}
 #[doc = "I2C Master Raw Interrupt Status"]
 pub mod mris;
-#[doc = "I2C Master Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mmis](mmis) module"]
+#[doc = "I2C Master Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mmis](mmis) module"]
 pub type MMIS = crate::Reg<u32, _MMIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -125,7 +125,7 @@ pub struct _MMIS;
 impl crate::Readable for MMIS {}
 #[doc = "I2C Master Masked Interrupt Status"]
 pub mod mmis;
-#[doc = "I2C Master Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [micr](micr) module"]
+#[doc = "I2C Master Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [micr](micr) module"]
 pub type MICR = crate::Reg<u32, _MICR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -134,7 +134,7 @@ pub struct _MICR;
 impl crate::Writable for MICR {}
 #[doc = "I2C Master Interrupt Clear"]
 pub mod micr;
-#[doc = "I2C Master Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mcr](mcr) module"]
+#[doc = "I2C Master Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mcr](mcr) module"]
 pub type MCR = crate::Reg<u32, _MCR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -145,7 +145,7 @@ impl crate::Readable for MCR {}
 impl crate::Writable for MCR {}
 #[doc = "I2C Master Configuration"]
 pub mod mcr;
-#[doc = "I2C Master Clock Low Timeout Count\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mclkocnt](mclkocnt) module"]
+#[doc = "I2C Master Clock Low Timeout Count\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mclkocnt](mclkocnt) module"]
 pub type MCLKOCNT = crate::Reg<u32, _MCLKOCNT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -156,7 +156,7 @@ impl crate::Readable for MCLKOCNT {}
 impl crate::Writable for MCLKOCNT {}
 #[doc = "I2C Master Clock Low Timeout Count"]
 pub mod mclkocnt;
-#[doc = "I2C Master Bus Monitor\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mbmon](mbmon) module"]
+#[doc = "I2C Master Bus Monitor\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mbmon](mbmon) module"]
 pub type MBMON = crate::Reg<u32, _MBMON>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -165,7 +165,7 @@ pub struct _MBMON;
 impl crate::Readable for MBMON {}
 #[doc = "I2C Master Bus Monitor"]
 pub mod mbmon;
-#[doc = "I2C Master Configuration 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mcr2](mcr2) module"]
+#[doc = "I2C Master Configuration 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mcr2](mcr2) module"]
 pub type MCR2 = crate::Reg<u32, _MCR2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -176,7 +176,7 @@ impl crate::Readable for MCR2 {}
 impl crate::Writable for MCR2 {}
 #[doc = "I2C Master Configuration 2"]
 pub mod mcr2;
-#[doc = "I2C Slave Own Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [soar](soar) module"]
+#[doc = "I2C Slave Own Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [soar](soar) module"]
 pub type SOAR = crate::Reg<u32, _SOAR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -187,7 +187,7 @@ impl crate::Readable for SOAR {}
 impl crate::Writable for SOAR {}
 #[doc = "I2C Slave Own Address"]
 pub mod soar;
-#[doc = "I2C Slave Control/Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scsr](scsr) module"]
+#[doc = "I2C Slave Control/Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scsr](scsr) module"]
 pub type SCSR = crate::Reg<u32, _SCSR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -196,7 +196,7 @@ pub struct _SCSR;
 impl crate::Readable for SCSR {}
 #[doc = "I2C Slave Control/Status"]
 pub mod scsr;
-#[doc = "I2C Slave Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sdr](sdr) module"]
+#[doc = "I2C Slave Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sdr](sdr) module"]
 pub type SDR = crate::Reg<u32, _SDR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -207,7 +207,7 @@ impl crate::Readable for SDR {}
 impl crate::Writable for SDR {}
 #[doc = "I2C Slave Data"]
 pub mod sdr;
-#[doc = "I2C Slave Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [simr](simr) module"]
+#[doc = "I2C Slave Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [simr](simr) module"]
 pub type SIMR = crate::Reg<u32, _SIMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -218,7 +218,7 @@ impl crate::Readable for SIMR {}
 impl crate::Writable for SIMR {}
 #[doc = "I2C Slave Interrupt Mask"]
 pub mod simr;
-#[doc = "I2C Slave Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sris](sris) module"]
+#[doc = "I2C Slave Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sris](sris) module"]
 pub type SRIS = crate::Reg<u32, _SRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -227,7 +227,7 @@ pub struct _SRIS;
 impl crate::Readable for SRIS {}
 #[doc = "I2C Slave Raw Interrupt Status"]
 pub mod sris;
-#[doc = "I2C Slave Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [smis](smis) module"]
+#[doc = "I2C Slave Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [smis](smis) module"]
 pub type SMIS = crate::Reg<u32, _SMIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -236,7 +236,7 @@ pub struct _SMIS;
 impl crate::Readable for SMIS {}
 #[doc = "I2C Slave Masked Interrupt Status"]
 pub mod smis;
-#[doc = "I2C Slave Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sicr](sicr) module"]
+#[doc = "I2C Slave Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sicr](sicr) module"]
 pub type SICR = crate::Reg<u32, _SICR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -245,7 +245,7 @@ pub struct _SICR;
 impl crate::Writable for SICR {}
 #[doc = "I2C Slave Interrupt Clear"]
 pub mod sicr;
-#[doc = "I2C Slave Own Address 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [soar2](soar2) module"]
+#[doc = "I2C Slave Own Address 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [soar2](soar2) module"]
 pub type SOAR2 = crate::Reg<u32, _SOAR2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -256,7 +256,7 @@ impl crate::Readable for SOAR2 {}
 impl crate::Writable for SOAR2 {}
 #[doc = "I2C Slave Own Address 2"]
 pub mod soar2;
-#[doc = "I2C Slave ACK Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sackctl](sackctl) module"]
+#[doc = "I2C Slave ACK Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sackctl](sackctl) module"]
 pub type SACKCTL = crate::Reg<u32, _SACKCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -267,7 +267,7 @@ impl crate::Readable for SACKCTL {}
 impl crate::Writable for SACKCTL {}
 #[doc = "I2C Slave ACK Control"]
 pub mod sackctl;
-#[doc = "I2C Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "I2C Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -276,7 +276,7 @@ pub struct _PP;
 impl crate::Readable for PP {}
 #[doc = "I2C Peripheral Properties"]
 pub mod pp;
-#[doc = "I2C Peripheral Configuration\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pc](pc) module"]
+#[doc = "I2C Peripheral Configuration\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pc](pc) module"]
 pub type PC = crate::Reg<u32, _PC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/i2c0/mcr2.rs
+++ b/crates/tm4c123x/src/i2c0/mcr2.rs
@@ -12,37 +12,29 @@ impl crate::ResetValue for super::MCR2 {
 }
 #[doc = "I2C Glitch Filter Pulse Width\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum GFPW_A {
     #[doc = "0: Bypass"]
-    BYPASS,
+    BYPASS = 0,
     #[doc = "1: 1 clock"]
-    _1,
+    _1 = 1,
     #[doc = "2: 2 clocks"]
-    _2,
+    _2 = 2,
     #[doc = "3: 3 clocks"]
-    _3,
+    _3 = 3,
     #[doc = "4: 4 clocks"]
-    _4,
+    _4 = 4,
     #[doc = "5: 8 clocks"]
-    _8,
+    _8 = 5,
     #[doc = "6: 16 clocks"]
-    _16,
+    _16 = 6,
     #[doc = "7: 31 clocks"]
-    _31,
+    _31 = 7,
 }
 impl From<GFPW_A> for u8 {
     #[inline(always)]
     fn from(variant: GFPW_A) -> Self {
-        match variant {
-            GFPW_A::BYPASS => 0,
-            GFPW_A::_1 => 1,
-            GFPW_A::_2 => 2,
-            GFPW_A::_3 => 3,
-            GFPW_A::_4 => 4,
-            GFPW_A::_8 => 5,
-            GFPW_A::_16 => 6,
-            GFPW_A::_31 => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `GFPW`"]

--- a/crates/tm4c123x/src/lib.rs
+++ b/crates/tm4c123x/src/lib.rs
@@ -1,7 +1,25 @@
-#![doc = "Peripheral access API for TM4C123X microcontrollers (generated using svd2rust v0.16.1)\n\nYou can find an overview of the API [here].\n\n[here]: https://docs.rs/svd2rust/0.16.1/svd2rust/#peripheral-api"]
+#![doc = "Peripheral access API for TM4C123X microcontrollers (generated using svd2rust v0.17.0)\n\nYou can find an overview of the API [here].\n\n[here]: https://docs.rs/svd2rust/0.17.0/svd2rust/#peripheral-api"]
+#![deny(const_err)]
+#![deny(dead_code)]
+#![deny(improper_ctypes)]
+#![deny(legacy_directory_ownership)]
 #![deny(missing_docs)]
-#![deny(warnings)]
+#![deny(no_mangle_generic_items)]
+#![deny(non_shorthand_field_patterns)]
+#![deny(overflowing_literals)]
+#![deny(path_statements)]
+#![deny(patterns_in_fns_without_body)]
+#![deny(plugin_as_library)]
+#![deny(private_in_public)]
+#![deny(safe_extern_statics)]
+#![deny(unconditional_recursion)]
+#![deny(unions_with_drop_fields)]
+#![deny(unused_allocation)]
+#![deny(unused_comparisons)]
+#![deny(unused_parens)]
+#![deny(while_true)]
 #![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
 #![no_std]
 extern crate bare_metal;
 extern crate cortex_m;
@@ -10,6 +28,8 @@ extern crate cortex_m_rt;
 extern crate vcell;
 use core::marker::PhantomData;
 use core::ops::Deref;
+#[doc = r"Number available in the NVIC for configuring priority"]
+pub const NVIC_PRIO_BITS: u8 = 3;
 #[cfg(feature = "rt")]
 extern "C" {
     fn GPIOA();
@@ -243,247 +263,169 @@ pub static __INTERRUPTS: [Vector; 139] = [
 ];
 #[doc = r"Enumeration of all the interrupts"]
 #[derive(Copy, Clone, Debug)]
+#[repr(u8)]
 pub enum Interrupt {
     #[doc = "0 - GPIO Port A"]
-    GPIOA,
+    GPIOA = 0,
     #[doc = "1 - GPIO Port B"]
-    GPIOB,
+    GPIOB = 1,
     #[doc = "2 - GPIO Port C"]
-    GPIOC,
+    GPIOC = 2,
     #[doc = "3 - GPIO Port D"]
-    GPIOD,
+    GPIOD = 3,
     #[doc = "4 - GPIO Port E"]
-    GPIOE,
+    GPIOE = 4,
     #[doc = "5 - UART0"]
-    UART0,
+    UART0 = 5,
     #[doc = "6 - UART1"]
-    UART1,
+    UART1 = 6,
     #[doc = "7 - SSI0"]
-    SSI0,
+    SSI0 = 7,
     #[doc = "8 - I2C0"]
-    I2C0,
+    I2C0 = 8,
     #[doc = "9 - PWM0 Fault"]
-    PWM0_FAULT,
+    PWM0_FAULT = 9,
     #[doc = "10 - PWM0 Generator 0"]
-    PWM0_0,
+    PWM0_0 = 10,
     #[doc = "11 - PWM0 Generator 1"]
-    PWM0_1,
+    PWM0_1 = 11,
     #[doc = "12 - PWM0 Generator 2"]
-    PWM0_2,
+    PWM0_2 = 12,
     #[doc = "13 - QEI0"]
-    QEI0,
+    QEI0 = 13,
     #[doc = "14 - ADC0 Sequence 0"]
-    ADC0SS0,
+    ADC0SS0 = 14,
     #[doc = "15 - ADC0 Sequence 1"]
-    ADC0SS1,
+    ADC0SS1 = 15,
     #[doc = "16 - ADC0 Sequence 2"]
-    ADC0SS2,
+    ADC0SS2 = 16,
     #[doc = "17 - ADC0 Sequence 3"]
-    ADC0SS3,
+    ADC0SS3 = 17,
     #[doc = "18 - Watchdog Timers 0 and 1"]
-    WATCHDOG,
+    WATCHDOG = 18,
     #[doc = "19 - 16/32-Bit Timer 0A"]
-    TIMER0A,
+    TIMER0A = 19,
     #[doc = "20 - 16/32-Bit Timer 0B"]
-    TIMER0B,
+    TIMER0B = 20,
     #[doc = "21 - 16/32-Bit Timer 1A"]
-    TIMER1A,
+    TIMER1A = 21,
     #[doc = "22 - 16/32-Bit Timer 1B"]
-    TIMER1B,
+    TIMER1B = 22,
     #[doc = "23 - 16/32-Bit Timer 2A"]
-    TIMER2A,
+    TIMER2A = 23,
     #[doc = "24 - 16/32-Bit Timer 2B"]
-    TIMER2B,
+    TIMER2B = 24,
     #[doc = "25 - Analog Comparator 0"]
-    COMP0,
+    COMP0 = 25,
     #[doc = "26 - Analog Comparator 1"]
-    COMP1,
+    COMP1 = 26,
     #[doc = "28 - System Control"]
-    SYSCTL,
+    SYSCTL = 28,
     #[doc = "29 - Flash Memory Control and EEPROM Control"]
-    FLASH,
+    FLASH = 29,
     #[doc = "30 - GPIO Port F"]
-    GPIOF,
+    GPIOF = 30,
     #[doc = "33 - UART2"]
-    UART2,
+    UART2 = 33,
     #[doc = "34 - SSI1"]
-    SSI1,
+    SSI1 = 34,
     #[doc = "35 - Timer 3A"]
-    TIMER3A,
+    TIMER3A = 35,
     #[doc = "36 - Timer 3B"]
-    TIMER3B,
+    TIMER3B = 36,
     #[doc = "37 - I2C1"]
-    I2C1,
+    I2C1 = 37,
     #[doc = "38 - QEI1"]
-    QEI1,
+    QEI1 = 38,
     #[doc = "39 - CAN0"]
-    CAN0,
+    CAN0 = 39,
     #[doc = "40 - CAN1"]
-    CAN1,
+    CAN1 = 40,
     #[doc = "43 - Hibernation Module"]
-    HIBERNATE,
+    HIBERNATE = 43,
     #[doc = "44 - USB"]
-    USB0,
+    USB0 = 44,
     #[doc = "45 - PWM Generator 3"]
-    PWM0_3,
+    PWM0_3 = 45,
     #[doc = "46 - uDMA Software"]
-    UDMA,
+    UDMA = 46,
     #[doc = "47 - uDMA Error"]
-    UDMAERR,
+    UDMAERR = 47,
     #[doc = "48 - ADC1 Sequence 0"]
-    ADC1SS0,
+    ADC1SS0 = 48,
     #[doc = "49 - ADC1 Sequence 1"]
-    ADC1SS1,
+    ADC1SS1 = 49,
     #[doc = "50 - ADC1 Sequence 2"]
-    ADC1SS2,
+    ADC1SS2 = 50,
     #[doc = "51 - ADC1 Sequence 3"]
-    ADC1SS3,
+    ADC1SS3 = 51,
     #[doc = "57 - SSI2"]
-    SSI2,
+    SSI2 = 57,
     #[doc = "58 - SSI3"]
-    SSI3,
+    SSI3 = 58,
     #[doc = "59 - UART3"]
-    UART3,
+    UART3 = 59,
     #[doc = "60 - UART4"]
-    UART4,
+    UART4 = 60,
     #[doc = "61 - UART5"]
-    UART5,
+    UART5 = 61,
     #[doc = "62 - UART6"]
-    UART6,
+    UART6 = 62,
     #[doc = "63 - UART7"]
-    UART7,
+    UART7 = 63,
     #[doc = "68 - I2C2"]
-    I2C2,
+    I2C2 = 68,
     #[doc = "69 - I2C3"]
-    I2C3,
+    I2C3 = 69,
     #[doc = "70 - 16/32-Bit Timer 4A"]
-    TIMER4A,
+    TIMER4A = 70,
     #[doc = "71 - 16/32-Bit Timer 4B"]
-    TIMER4B,
+    TIMER4B = 71,
     #[doc = "92 - 16/32-Bit Timer 5A"]
-    TIMER5A,
+    TIMER5A = 92,
     #[doc = "93 - 16/32-Bit Timer 5B"]
-    TIMER5B,
+    TIMER5B = 93,
     #[doc = "94 - 32/64-Bit Timer 0A"]
-    WTIMER0A,
+    WTIMER0A = 94,
     #[doc = "95 - 32/64-Bit Timer 0B"]
-    WTIMER0B,
+    WTIMER0B = 95,
     #[doc = "96 - 32/64-Bit Timer 1A"]
-    WTIMER1A,
+    WTIMER1A = 96,
     #[doc = "97 - 32/64-Bit Timer 1B"]
-    WTIMER1B,
+    WTIMER1B = 97,
     #[doc = "98 - 32/64-Bit Timer 2A"]
-    WTIMER2A,
+    WTIMER2A = 98,
     #[doc = "99 - 32/64-Bit Timer 2B"]
-    WTIMER2B,
+    WTIMER2B = 99,
     #[doc = "100 - 32/64-Bit Timer 3A"]
-    WTIMER3A,
+    WTIMER3A = 100,
     #[doc = "101 - 32/64-Bit Timer 3B"]
-    WTIMER3B,
+    WTIMER3B = 101,
     #[doc = "102 - 32/64-Bit Timer 4A"]
-    WTIMER4A,
+    WTIMER4A = 102,
     #[doc = "103 - 32/64-Bit Timer 4B"]
-    WTIMER4B,
+    WTIMER4B = 103,
     #[doc = "104 - 32/64-Bit Timer 5A"]
-    WTIMER5A,
+    WTIMER5A = 104,
     #[doc = "105 - 32/64-Bit Timer 5B"]
-    WTIMER5B,
+    WTIMER5B = 105,
     #[doc = "106 - System Exception (imprecise)"]
-    SYSEXC,
+    SYSEXC = 106,
     #[doc = "134 - PWM1 Generator 0"]
-    PWM1_0,
+    PWM1_0 = 134,
     #[doc = "135 - PWM1 Generator 1"]
-    PWM1_1,
+    PWM1_1 = 135,
     #[doc = "136 - PWM1 Generator 2"]
-    PWM1_2,
+    PWM1_2 = 136,
     #[doc = "137 - PWM1 Generator 3"]
-    PWM1_3,
+    PWM1_3 = 137,
     #[doc = "138 - PWM1 Fault"]
-    PWM1_FAULT,
+    PWM1_FAULT = 138,
 }
 unsafe impl bare_metal::Nr for Interrupt {
-    #[inline]
+    #[inline(always)]
     fn nr(&self) -> u8 {
-        match *self {
-            Interrupt::GPIOA => 0,
-            Interrupt::GPIOB => 1,
-            Interrupt::GPIOC => 2,
-            Interrupt::GPIOD => 3,
-            Interrupt::GPIOE => 4,
-            Interrupt::UART0 => 5,
-            Interrupt::UART1 => 6,
-            Interrupt::SSI0 => 7,
-            Interrupt::I2C0 => 8,
-            Interrupt::PWM0_FAULT => 9,
-            Interrupt::PWM0_0 => 10,
-            Interrupt::PWM0_1 => 11,
-            Interrupt::PWM0_2 => 12,
-            Interrupt::QEI0 => 13,
-            Interrupt::ADC0SS0 => 14,
-            Interrupt::ADC0SS1 => 15,
-            Interrupt::ADC0SS2 => 16,
-            Interrupt::ADC0SS3 => 17,
-            Interrupt::WATCHDOG => 18,
-            Interrupt::TIMER0A => 19,
-            Interrupt::TIMER0B => 20,
-            Interrupt::TIMER1A => 21,
-            Interrupt::TIMER1B => 22,
-            Interrupt::TIMER2A => 23,
-            Interrupt::TIMER2B => 24,
-            Interrupt::COMP0 => 25,
-            Interrupt::COMP1 => 26,
-            Interrupt::SYSCTL => 28,
-            Interrupt::FLASH => 29,
-            Interrupt::GPIOF => 30,
-            Interrupt::UART2 => 33,
-            Interrupt::SSI1 => 34,
-            Interrupt::TIMER3A => 35,
-            Interrupt::TIMER3B => 36,
-            Interrupt::I2C1 => 37,
-            Interrupt::QEI1 => 38,
-            Interrupt::CAN0 => 39,
-            Interrupt::CAN1 => 40,
-            Interrupt::HIBERNATE => 43,
-            Interrupt::USB0 => 44,
-            Interrupt::PWM0_3 => 45,
-            Interrupt::UDMA => 46,
-            Interrupt::UDMAERR => 47,
-            Interrupt::ADC1SS0 => 48,
-            Interrupt::ADC1SS1 => 49,
-            Interrupt::ADC1SS2 => 50,
-            Interrupt::ADC1SS3 => 51,
-            Interrupt::SSI2 => 57,
-            Interrupt::SSI3 => 58,
-            Interrupt::UART3 => 59,
-            Interrupt::UART4 => 60,
-            Interrupt::UART5 => 61,
-            Interrupt::UART6 => 62,
-            Interrupt::UART7 => 63,
-            Interrupt::I2C2 => 68,
-            Interrupt::I2C3 => 69,
-            Interrupt::TIMER4A => 70,
-            Interrupt::TIMER4B => 71,
-            Interrupt::TIMER5A => 92,
-            Interrupt::TIMER5B => 93,
-            Interrupt::WTIMER0A => 94,
-            Interrupt::WTIMER0B => 95,
-            Interrupt::WTIMER1A => 96,
-            Interrupt::WTIMER1B => 97,
-            Interrupt::WTIMER2A => 98,
-            Interrupt::WTIMER2B => 99,
-            Interrupt::WTIMER3A => 100,
-            Interrupt::WTIMER3B => 101,
-            Interrupt::WTIMER4A => 102,
-            Interrupt::WTIMER4B => 103,
-            Interrupt::WTIMER5A => 104,
-            Interrupt::WTIMER5B => 105,
-            Interrupt::SYSEXC => 106,
-            Interrupt::PWM1_0 => 134,
-            Interrupt::PWM1_1 => 135,
-            Interrupt::PWM1_2 => 136,
-            Interrupt::PWM1_3 => 137,
-            Interrupt::PWM1_FAULT => 138,
-        }
+        *self as u8
     }
 }
 #[cfg(feature = "rt")]
@@ -510,6 +452,7 @@ impl WATCHDOG0 {
 }
 impl Deref for WATCHDOG0 {
     type Target = watchdog0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*WATCHDOG0::ptr() }
     }
@@ -530,6 +473,7 @@ impl WATCHDOG1 {
 }
 impl Deref for WATCHDOG1 {
     type Target = watchdog0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*WATCHDOG1::ptr() }
     }
@@ -548,6 +492,7 @@ impl GPIO_PORTA {
 }
 impl Deref for GPIO_PORTA {
     type Target = gpio_porta::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTA::ptr() }
     }
@@ -568,6 +513,7 @@ impl GPIO_PORTB {
 }
 impl Deref for GPIO_PORTB {
     type Target = gpio_porta::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTB::ptr() }
     }
@@ -586,6 +532,7 @@ impl GPIO_PORTC {
 }
 impl Deref for GPIO_PORTC {
     type Target = gpio_porta::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTC::ptr() }
     }
@@ -604,6 +551,7 @@ impl GPIO_PORTD {
 }
 impl Deref for GPIO_PORTD {
     type Target = gpio_porta::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTD::ptr() }
     }
@@ -622,6 +570,7 @@ impl SSI0 {
 }
 impl Deref for SSI0 {
     type Target = ssi0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*SSI0::ptr() }
     }
@@ -642,6 +591,7 @@ impl SSI1 {
 }
 impl Deref for SSI1 {
     type Target = ssi0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*SSI1::ptr() }
     }
@@ -660,6 +610,7 @@ impl SSI2 {
 }
 impl Deref for SSI2 {
     type Target = ssi0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*SSI2::ptr() }
     }
@@ -678,6 +629,7 @@ impl SSI3 {
 }
 impl Deref for SSI3 {
     type Target = ssi0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*SSI3::ptr() }
     }
@@ -696,6 +648,7 @@ impl UART0 {
 }
 impl Deref for UART0 {
     type Target = uart0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UART0::ptr() }
     }
@@ -716,6 +669,7 @@ impl UART1 {
 }
 impl Deref for UART1 {
     type Target = uart0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UART1::ptr() }
     }
@@ -734,6 +688,7 @@ impl UART2 {
 }
 impl Deref for UART2 {
     type Target = uart0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UART2::ptr() }
     }
@@ -752,6 +707,7 @@ impl UART3 {
 }
 impl Deref for UART3 {
     type Target = uart0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UART3::ptr() }
     }
@@ -770,6 +726,7 @@ impl UART4 {
 }
 impl Deref for UART4 {
     type Target = uart0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UART4::ptr() }
     }
@@ -788,6 +745,7 @@ impl UART5 {
 }
 impl Deref for UART5 {
     type Target = uart0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UART5::ptr() }
     }
@@ -806,6 +764,7 @@ impl UART6 {
 }
 impl Deref for UART6 {
     type Target = uart0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UART6::ptr() }
     }
@@ -824,6 +783,7 @@ impl UART7 {
 }
 impl Deref for UART7 {
     type Target = uart0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UART7::ptr() }
     }
@@ -842,6 +802,7 @@ impl I2C0 {
 }
 impl Deref for I2C0 {
     type Target = i2c0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*I2C0::ptr() }
     }
@@ -862,6 +823,7 @@ impl I2C1 {
 }
 impl Deref for I2C1 {
     type Target = i2c0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*I2C1::ptr() }
     }
@@ -880,6 +842,7 @@ impl I2C2 {
 }
 impl Deref for I2C2 {
     type Target = i2c0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*I2C2::ptr() }
     }
@@ -898,6 +861,7 @@ impl I2C3 {
 }
 impl Deref for I2C3 {
     type Target = i2c0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*I2C3::ptr() }
     }
@@ -916,6 +880,7 @@ impl GPIO_PORTE {
 }
 impl Deref for GPIO_PORTE {
     type Target = gpio_porta::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTE::ptr() }
     }
@@ -934,6 +899,7 @@ impl GPIO_PORTF {
 }
 impl Deref for GPIO_PORTF {
     type Target = gpio_porta::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTF::ptr() }
     }
@@ -952,6 +918,7 @@ impl PWM0 {
 }
 impl Deref for PWM0 {
     type Target = pwm0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*PWM0::ptr() }
     }
@@ -972,6 +939,7 @@ impl PWM1 {
 }
 impl Deref for PWM1 {
     type Target = pwm0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*PWM1::ptr() }
     }
@@ -990,6 +958,7 @@ impl QEI0 {
 }
 impl Deref for QEI0 {
     type Target = qei0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*QEI0::ptr() }
     }
@@ -1010,6 +979,7 @@ impl QEI1 {
 }
 impl Deref for QEI1 {
     type Target = qei0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*QEI1::ptr() }
     }
@@ -1028,6 +998,7 @@ impl TIMER0 {
 }
 impl Deref for TIMER0 {
     type Target = timer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*TIMER0::ptr() }
     }
@@ -1048,6 +1019,7 @@ impl TIMER1 {
 }
 impl Deref for TIMER1 {
     type Target = timer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*TIMER1::ptr() }
     }
@@ -1066,6 +1038,7 @@ impl TIMER2 {
 }
 impl Deref for TIMER2 {
     type Target = timer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*TIMER2::ptr() }
     }
@@ -1084,6 +1057,7 @@ impl TIMER3 {
 }
 impl Deref for TIMER3 {
     type Target = timer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*TIMER3::ptr() }
     }
@@ -1102,6 +1076,7 @@ impl TIMER4 {
 }
 impl Deref for TIMER4 {
     type Target = timer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*TIMER4::ptr() }
     }
@@ -1120,6 +1095,7 @@ impl TIMER5 {
 }
 impl Deref for TIMER5 {
     type Target = timer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*TIMER5::ptr() }
     }
@@ -1138,6 +1114,7 @@ impl WTIMER0 {
 }
 impl Deref for WTIMER0 {
     type Target = wtimer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*WTIMER0::ptr() }
     }
@@ -1158,6 +1135,7 @@ impl WTIMER1 {
 }
 impl Deref for WTIMER1 {
     type Target = wtimer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*WTIMER1::ptr() }
     }
@@ -1176,6 +1154,7 @@ impl ADC0 {
 }
 impl Deref for ADC0 {
     type Target = adc0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*ADC0::ptr() }
     }
@@ -1196,6 +1175,7 @@ impl ADC1 {
 }
 impl Deref for ADC1 {
     type Target = adc0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*ADC1::ptr() }
     }
@@ -1214,6 +1194,7 @@ impl COMP {
 }
 impl Deref for COMP {
     type Target = comp::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*COMP::ptr() }
     }
@@ -1234,6 +1215,7 @@ impl CAN0 {
 }
 impl Deref for CAN0 {
     type Target = can0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*CAN0::ptr() }
     }
@@ -1254,6 +1236,7 @@ impl CAN1 {
 }
 impl Deref for CAN1 {
     type Target = can0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*CAN1::ptr() }
     }
@@ -1272,6 +1255,7 @@ impl WTIMER2 {
 }
 impl Deref for WTIMER2 {
     type Target = wtimer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*WTIMER2::ptr() }
     }
@@ -1290,6 +1274,7 @@ impl WTIMER3 {
 }
 impl Deref for WTIMER3 {
     type Target = wtimer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*WTIMER3::ptr() }
     }
@@ -1308,6 +1293,7 @@ impl WTIMER4 {
 }
 impl Deref for WTIMER4 {
     type Target = wtimer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*WTIMER4::ptr() }
     }
@@ -1326,6 +1312,7 @@ impl WTIMER5 {
 }
 impl Deref for WTIMER5 {
     type Target = wtimer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*WTIMER5::ptr() }
     }
@@ -1344,6 +1331,7 @@ impl USB0 {
 }
 impl Deref for USB0 {
     type Target = usb0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*USB0::ptr() }
     }
@@ -1364,6 +1352,7 @@ impl GPIO_PORTA_AHB {
 }
 impl Deref for GPIO_PORTA_AHB {
     type Target = gpio_porta::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTA_AHB::ptr() }
     }
@@ -1382,6 +1371,7 @@ impl GPIO_PORTB_AHB {
 }
 impl Deref for GPIO_PORTB_AHB {
     type Target = gpio_porta::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTB_AHB::ptr() }
     }
@@ -1400,6 +1390,7 @@ impl GPIO_PORTC_AHB {
 }
 impl Deref for GPIO_PORTC_AHB {
     type Target = gpio_porta::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTC_AHB::ptr() }
     }
@@ -1418,6 +1409,7 @@ impl GPIO_PORTD_AHB {
 }
 impl Deref for GPIO_PORTD_AHB {
     type Target = gpio_porta::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTD_AHB::ptr() }
     }
@@ -1436,6 +1428,7 @@ impl GPIO_PORTE_AHB {
 }
 impl Deref for GPIO_PORTE_AHB {
     type Target = gpio_porta::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTE_AHB::ptr() }
     }
@@ -1454,6 +1447,7 @@ impl GPIO_PORTF_AHB {
 }
 impl Deref for GPIO_PORTF_AHB {
     type Target = gpio_porta::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTF_AHB::ptr() }
     }
@@ -1472,6 +1466,7 @@ impl EEPROM {
 }
 impl Deref for EEPROM {
     type Target = eeprom::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*EEPROM::ptr() }
     }
@@ -1492,6 +1487,7 @@ impl SYSEXC {
 }
 impl Deref for SYSEXC {
     type Target = sysexc::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*SYSEXC::ptr() }
     }
@@ -1512,6 +1508,7 @@ impl HIB {
 }
 impl Deref for HIB {
     type Target = hib::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*HIB::ptr() }
     }
@@ -1532,6 +1529,7 @@ impl FLASH_CTRL {
 }
 impl Deref for FLASH_CTRL {
     type Target = flash_ctrl::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*FLASH_CTRL::ptr() }
     }
@@ -1552,6 +1550,7 @@ impl SYSCTL {
 }
 impl Deref for SYSCTL {
     type Target = sysctl::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*SYSCTL::ptr() }
     }
@@ -1572,6 +1571,7 @@ impl UDMA {
 }
 impl Deref for UDMA {
     type Target = udma::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UDMA::ptr() }
     }
@@ -1707,6 +1707,7 @@ impl Peripherals {
         cortex_m::interrupt::free(|_| if unsafe { DEVICE_PERIPHERALS } { None } else { Some(unsafe { Peripherals::steal() }) })
     }
     #[doc = r"Unchecked version of `Peripherals::take`"]
+    #[inline]
     pub unsafe fn steal() -> Self {
         DEVICE_PERIPHERALS = true;
         Peripherals {

--- a/crates/tm4c123x/src/pwm0.rs
+++ b/crates/tm4c123x/src/pwm0.rs
@@ -180,7 +180,7 @@ pub struct RegisterBlock {
     #[doc = "0xfc0 - PWM Peripheral Properties"]
     pub pp: PP,
 }
-#[doc = "PWM Master Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctl](ctl) module"]
+#[doc = "PWM Master Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctl](ctl) module"]
 pub type CTL = crate::Reg<u32, _CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -191,7 +191,7 @@ impl crate::Readable for CTL {}
 impl crate::Writable for CTL {}
 #[doc = "PWM Master Control"]
 pub mod ctl;
-#[doc = "PWM Time Base Sync\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sync](sync) module"]
+#[doc = "PWM Time Base Sync\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sync](sync) module"]
 pub type SYNC = crate::Reg<u32, _SYNC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -202,7 +202,7 @@ impl crate::Readable for SYNC {}
 impl crate::Writable for SYNC {}
 #[doc = "PWM Time Base Sync"]
 pub mod sync;
-#[doc = "PWM Output Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [enable](enable) module"]
+#[doc = "PWM Output Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [enable](enable) module"]
 pub type ENABLE = crate::Reg<u32, _ENABLE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -213,7 +213,7 @@ impl crate::Readable for ENABLE {}
 impl crate::Writable for ENABLE {}
 #[doc = "PWM Output Enable"]
 pub mod enable;
-#[doc = "PWM Output Inversion\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [invert](invert) module"]
+#[doc = "PWM Output Inversion\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [invert](invert) module"]
 pub type INVERT = crate::Reg<u32, _INVERT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -224,7 +224,7 @@ impl crate::Readable for INVERT {}
 impl crate::Writable for INVERT {}
 #[doc = "PWM Output Inversion"]
 pub mod invert;
-#[doc = "PWM Output Fault\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fault](fault) module"]
+#[doc = "PWM Output Fault\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fault](fault) module"]
 pub type FAULT = crate::Reg<u32, _FAULT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -235,7 +235,7 @@ impl crate::Readable for FAULT {}
 impl crate::Writable for FAULT {}
 #[doc = "PWM Output Fault"]
 pub mod fault;
-#[doc = "PWM Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [inten](inten) module"]
+#[doc = "PWM Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [inten](inten) module"]
 pub type INTEN = crate::Reg<u32, _INTEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -246,7 +246,7 @@ impl crate::Readable for INTEN {}
 impl crate::Writable for INTEN {}
 #[doc = "PWM Interrupt Enable"]
 pub mod inten;
-#[doc = "PWM Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "PWM Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -255,7 +255,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "PWM Raw Interrupt Status"]
 pub mod ris;
-#[doc = "PWM Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [isc](isc) module"]
+#[doc = "PWM Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [isc](isc) module"]
 pub type ISC = crate::Reg<u32, _ISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -266,7 +266,7 @@ impl crate::Readable for ISC {}
 impl crate::Writable for ISC {}
 #[doc = "PWM Interrupt Status and Clear"]
 pub mod isc;
-#[doc = "PWM Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+#[doc = "PWM Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [status](status) module"]
 pub type STATUS = crate::Reg<u32, _STATUS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -275,7 +275,7 @@ pub struct _STATUS;
 impl crate::Readable for STATUS {}
 #[doc = "PWM Status"]
 pub mod status;
-#[doc = "PWM Fault Condition Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [faultval](faultval) module"]
+#[doc = "PWM Fault Condition Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [faultval](faultval) module"]
 pub type FAULTVAL = crate::Reg<u32, _FAULTVAL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -286,7 +286,7 @@ impl crate::Readable for FAULTVAL {}
 impl crate::Writable for FAULTVAL {}
 #[doc = "PWM Fault Condition Value"]
 pub mod faultval;
-#[doc = "PWM Enable Update\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [enupd](enupd) module"]
+#[doc = "PWM Enable Update\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [enupd](enupd) module"]
 pub type ENUPD = crate::Reg<u32, _ENUPD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -297,7 +297,7 @@ impl crate::Readable for ENUPD {}
 impl crate::Writable for ENUPD {}
 #[doc = "PWM Enable Update"]
 pub mod enupd;
-#[doc = "PWM0 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_ctl](_0_ctl) module"]
+#[doc = "PWM0 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_ctl](_0_ctl) module"]
 pub type _0_CTL = crate::Reg<u32, __0_CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -308,7 +308,7 @@ impl crate::Readable for _0_CTL {}
 impl crate::Writable for _0_CTL {}
 #[doc = "PWM0 Control"]
 pub mod _0_ctl;
-#[doc = "PWM0 Interrupt and Trigger Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_inten](_0_inten) module"]
+#[doc = "PWM0 Interrupt and Trigger Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_inten](_0_inten) module"]
 pub type _0_INTEN = crate::Reg<u32, __0_INTEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -319,7 +319,7 @@ impl crate::Readable for _0_INTEN {}
 impl crate::Writable for _0_INTEN {}
 #[doc = "PWM0 Interrupt and Trigger Enable"]
 pub mod _0_inten;
-#[doc = "PWM0 Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_ris](_0_ris) module"]
+#[doc = "PWM0 Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_ris](_0_ris) module"]
 pub type _0_RIS = crate::Reg<u32, __0_RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -328,7 +328,7 @@ pub struct __0_RIS;
 impl crate::Readable for _0_RIS {}
 #[doc = "PWM0 Raw Interrupt Status"]
 pub mod _0_ris;
-#[doc = "PWM0 Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_isc](_0_isc) module"]
+#[doc = "PWM0 Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_isc](_0_isc) module"]
 pub type _0_ISC = crate::Reg<u32, __0_ISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -339,7 +339,7 @@ impl crate::Readable for _0_ISC {}
 impl crate::Writable for _0_ISC {}
 #[doc = "PWM0 Interrupt Status and Clear"]
 pub mod _0_isc;
-#[doc = "PWM0 Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_load](_0_load) module"]
+#[doc = "PWM0 Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_load](_0_load) module"]
 pub type _0_LOAD = crate::Reg<u32, __0_LOAD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -350,7 +350,7 @@ impl crate::Readable for _0_LOAD {}
 impl crate::Writable for _0_LOAD {}
 #[doc = "PWM0 Load"]
 pub mod _0_load;
-#[doc = "PWM0 Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_count](_0_count) module"]
+#[doc = "PWM0 Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_count](_0_count) module"]
 pub type _0_COUNT = crate::Reg<u32, __0_COUNT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -359,7 +359,7 @@ pub struct __0_COUNT;
 impl crate::Readable for _0_COUNT {}
 #[doc = "PWM0 Counter"]
 pub mod _0_count;
-#[doc = "PWM0 Compare A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_cmpa](_0_cmpa) module"]
+#[doc = "PWM0 Compare A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_cmpa](_0_cmpa) module"]
 pub type _0_CMPA = crate::Reg<u32, __0_CMPA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -370,7 +370,7 @@ impl crate::Readable for _0_CMPA {}
 impl crate::Writable for _0_CMPA {}
 #[doc = "PWM0 Compare A"]
 pub mod _0_cmpa;
-#[doc = "PWM0 Compare B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_cmpb](_0_cmpb) module"]
+#[doc = "PWM0 Compare B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_cmpb](_0_cmpb) module"]
 pub type _0_CMPB = crate::Reg<u32, __0_CMPB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -381,7 +381,7 @@ impl crate::Readable for _0_CMPB {}
 impl crate::Writable for _0_CMPB {}
 #[doc = "PWM0 Compare B"]
 pub mod _0_cmpb;
-#[doc = "PWM0 Generator A Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_gena](_0_gena) module"]
+#[doc = "PWM0 Generator A Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_gena](_0_gena) module"]
 pub type _0_GENA = crate::Reg<u32, __0_GENA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -392,7 +392,7 @@ impl crate::Readable for _0_GENA {}
 impl crate::Writable for _0_GENA {}
 #[doc = "PWM0 Generator A Control"]
 pub mod _0_gena;
-#[doc = "PWM0 Generator B Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_genb](_0_genb) module"]
+#[doc = "PWM0 Generator B Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_genb](_0_genb) module"]
 pub type _0_GENB = crate::Reg<u32, __0_GENB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -403,7 +403,7 @@ impl crate::Readable for _0_GENB {}
 impl crate::Writable for _0_GENB {}
 #[doc = "PWM0 Generator B Control"]
 pub mod _0_genb;
-#[doc = "PWM0 Dead-Band Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_dbctl](_0_dbctl) module"]
+#[doc = "PWM0 Dead-Band Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_dbctl](_0_dbctl) module"]
 pub type _0_DBCTL = crate::Reg<u32, __0_DBCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -414,7 +414,7 @@ impl crate::Readable for _0_DBCTL {}
 impl crate::Writable for _0_DBCTL {}
 #[doc = "PWM0 Dead-Band Control"]
 pub mod _0_dbctl;
-#[doc = "PWM0 Dead-Band Rising-Edge Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_dbrise](_0_dbrise) module"]
+#[doc = "PWM0 Dead-Band Rising-Edge Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_dbrise](_0_dbrise) module"]
 pub type _0_DBRISE = crate::Reg<u32, __0_DBRISE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -425,7 +425,7 @@ impl crate::Readable for _0_DBRISE {}
 impl crate::Writable for _0_DBRISE {}
 #[doc = "PWM0 Dead-Band Rising-Edge Delay"]
 pub mod _0_dbrise;
-#[doc = "PWM0 Dead-Band Falling-Edge-Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_dbfall](_0_dbfall) module"]
+#[doc = "PWM0 Dead-Band Falling-Edge-Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_dbfall](_0_dbfall) module"]
 pub type _0_DBFALL = crate::Reg<u32, __0_DBFALL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -436,7 +436,7 @@ impl crate::Readable for _0_DBFALL {}
 impl crate::Writable for _0_DBFALL {}
 #[doc = "PWM0 Dead-Band Falling-Edge-Delay"]
 pub mod _0_dbfall;
-#[doc = "PWM0 Fault Source 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_fltsrc0](_0_fltsrc0) module"]
+#[doc = "PWM0 Fault Source 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_fltsrc0](_0_fltsrc0) module"]
 pub type _0_FLTSRC0 = crate::Reg<u32, __0_FLTSRC0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -447,7 +447,7 @@ impl crate::Readable for _0_FLTSRC0 {}
 impl crate::Writable for _0_FLTSRC0 {}
 #[doc = "PWM0 Fault Source 0"]
 pub mod _0_fltsrc0;
-#[doc = "PWM0 Fault Source 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_fltsrc1](_0_fltsrc1) module"]
+#[doc = "PWM0 Fault Source 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_fltsrc1](_0_fltsrc1) module"]
 pub type _0_FLTSRC1 = crate::Reg<u32, __0_FLTSRC1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -458,7 +458,7 @@ impl crate::Readable for _0_FLTSRC1 {}
 impl crate::Writable for _0_FLTSRC1 {}
 #[doc = "PWM0 Fault Source 1"]
 pub mod _0_fltsrc1;
-#[doc = "PWM0 Minimum Fault Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_minfltper](_0_minfltper) module"]
+#[doc = "PWM0 Minimum Fault Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_minfltper](_0_minfltper) module"]
 pub type _0_MINFLTPER = crate::Reg<u32, __0_MINFLTPER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -469,7 +469,7 @@ impl crate::Readable for _0_MINFLTPER {}
 impl crate::Writable for _0_MINFLTPER {}
 #[doc = "PWM0 Minimum Fault Period"]
 pub mod _0_minfltper;
-#[doc = "PWM1 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_ctl](_1_ctl) module"]
+#[doc = "PWM1 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_ctl](_1_ctl) module"]
 pub type _1_CTL = crate::Reg<u32, __1_CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -480,7 +480,7 @@ impl crate::Readable for _1_CTL {}
 impl crate::Writable for _1_CTL {}
 #[doc = "PWM1 Control"]
 pub mod _1_ctl;
-#[doc = "PWM1 Interrupt and Trigger Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_inten](_1_inten) module"]
+#[doc = "PWM1 Interrupt and Trigger Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_inten](_1_inten) module"]
 pub type _1_INTEN = crate::Reg<u32, __1_INTEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -491,7 +491,7 @@ impl crate::Readable for _1_INTEN {}
 impl crate::Writable for _1_INTEN {}
 #[doc = "PWM1 Interrupt and Trigger Enable"]
 pub mod _1_inten;
-#[doc = "PWM1 Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_ris](_1_ris) module"]
+#[doc = "PWM1 Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_ris](_1_ris) module"]
 pub type _1_RIS = crate::Reg<u32, __1_RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -500,7 +500,7 @@ pub struct __1_RIS;
 impl crate::Readable for _1_RIS {}
 #[doc = "PWM1 Raw Interrupt Status"]
 pub mod _1_ris;
-#[doc = "PWM1 Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_isc](_1_isc) module"]
+#[doc = "PWM1 Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_isc](_1_isc) module"]
 pub type _1_ISC = crate::Reg<u32, __1_ISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -511,7 +511,7 @@ impl crate::Readable for _1_ISC {}
 impl crate::Writable for _1_ISC {}
 #[doc = "PWM1 Interrupt Status and Clear"]
 pub mod _1_isc;
-#[doc = "PWM1 Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_load](_1_load) module"]
+#[doc = "PWM1 Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_load](_1_load) module"]
 pub type _1_LOAD = crate::Reg<u32, __1_LOAD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -522,7 +522,7 @@ impl crate::Readable for _1_LOAD {}
 impl crate::Writable for _1_LOAD {}
 #[doc = "PWM1 Load"]
 pub mod _1_load;
-#[doc = "PWM1 Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_count](_1_count) module"]
+#[doc = "PWM1 Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_count](_1_count) module"]
 pub type _1_COUNT = crate::Reg<u32, __1_COUNT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -531,7 +531,7 @@ pub struct __1_COUNT;
 impl crate::Readable for _1_COUNT {}
 #[doc = "PWM1 Counter"]
 pub mod _1_count;
-#[doc = "PWM1 Compare A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_cmpa](_1_cmpa) module"]
+#[doc = "PWM1 Compare A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_cmpa](_1_cmpa) module"]
 pub type _1_CMPA = crate::Reg<u32, __1_CMPA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -542,7 +542,7 @@ impl crate::Readable for _1_CMPA {}
 impl crate::Writable for _1_CMPA {}
 #[doc = "PWM1 Compare A"]
 pub mod _1_cmpa;
-#[doc = "PWM1 Compare B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_cmpb](_1_cmpb) module"]
+#[doc = "PWM1 Compare B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_cmpb](_1_cmpb) module"]
 pub type _1_CMPB = crate::Reg<u32, __1_CMPB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -553,7 +553,7 @@ impl crate::Readable for _1_CMPB {}
 impl crate::Writable for _1_CMPB {}
 #[doc = "PWM1 Compare B"]
 pub mod _1_cmpb;
-#[doc = "PWM1 Generator A Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_gena](_1_gena) module"]
+#[doc = "PWM1 Generator A Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_gena](_1_gena) module"]
 pub type _1_GENA = crate::Reg<u32, __1_GENA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -564,7 +564,7 @@ impl crate::Readable for _1_GENA {}
 impl crate::Writable for _1_GENA {}
 #[doc = "PWM1 Generator A Control"]
 pub mod _1_gena;
-#[doc = "PWM1 Generator B Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_genb](_1_genb) module"]
+#[doc = "PWM1 Generator B Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_genb](_1_genb) module"]
 pub type _1_GENB = crate::Reg<u32, __1_GENB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -575,7 +575,7 @@ impl crate::Readable for _1_GENB {}
 impl crate::Writable for _1_GENB {}
 #[doc = "PWM1 Generator B Control"]
 pub mod _1_genb;
-#[doc = "PWM1 Dead-Band Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_dbctl](_1_dbctl) module"]
+#[doc = "PWM1 Dead-Band Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_dbctl](_1_dbctl) module"]
 pub type _1_DBCTL = crate::Reg<u32, __1_DBCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -586,7 +586,7 @@ impl crate::Readable for _1_DBCTL {}
 impl crate::Writable for _1_DBCTL {}
 #[doc = "PWM1 Dead-Band Control"]
 pub mod _1_dbctl;
-#[doc = "PWM1 Dead-Band Rising-Edge Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_dbrise](_1_dbrise) module"]
+#[doc = "PWM1 Dead-Band Rising-Edge Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_dbrise](_1_dbrise) module"]
 pub type _1_DBRISE = crate::Reg<u32, __1_DBRISE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -597,7 +597,7 @@ impl crate::Readable for _1_DBRISE {}
 impl crate::Writable for _1_DBRISE {}
 #[doc = "PWM1 Dead-Band Rising-Edge Delay"]
 pub mod _1_dbrise;
-#[doc = "PWM1 Dead-Band Falling-Edge-Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_dbfall](_1_dbfall) module"]
+#[doc = "PWM1 Dead-Band Falling-Edge-Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_dbfall](_1_dbfall) module"]
 pub type _1_DBFALL = crate::Reg<u32, __1_DBFALL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -608,7 +608,7 @@ impl crate::Readable for _1_DBFALL {}
 impl crate::Writable for _1_DBFALL {}
 #[doc = "PWM1 Dead-Band Falling-Edge-Delay"]
 pub mod _1_dbfall;
-#[doc = "PWM1 Fault Source 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_fltsrc0](_1_fltsrc0) module"]
+#[doc = "PWM1 Fault Source 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_fltsrc0](_1_fltsrc0) module"]
 pub type _1_FLTSRC0 = crate::Reg<u32, __1_FLTSRC0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -619,7 +619,7 @@ impl crate::Readable for _1_FLTSRC0 {}
 impl crate::Writable for _1_FLTSRC0 {}
 #[doc = "PWM1 Fault Source 0"]
 pub mod _1_fltsrc0;
-#[doc = "PWM1 Fault Source 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_fltsrc1](_1_fltsrc1) module"]
+#[doc = "PWM1 Fault Source 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_fltsrc1](_1_fltsrc1) module"]
 pub type _1_FLTSRC1 = crate::Reg<u32, __1_FLTSRC1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -630,7 +630,7 @@ impl crate::Readable for _1_FLTSRC1 {}
 impl crate::Writable for _1_FLTSRC1 {}
 #[doc = "PWM1 Fault Source 1"]
 pub mod _1_fltsrc1;
-#[doc = "PWM1 Minimum Fault Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_minfltper](_1_minfltper) module"]
+#[doc = "PWM1 Minimum Fault Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_minfltper](_1_minfltper) module"]
 pub type _1_MINFLTPER = crate::Reg<u32, __1_MINFLTPER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -641,7 +641,7 @@ impl crate::Readable for _1_MINFLTPER {}
 impl crate::Writable for _1_MINFLTPER {}
 #[doc = "PWM1 Minimum Fault Period"]
 pub mod _1_minfltper;
-#[doc = "PWM2 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_ctl](_2_ctl) module"]
+#[doc = "PWM2 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_ctl](_2_ctl) module"]
 pub type _2_CTL = crate::Reg<u32, __2_CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -652,7 +652,7 @@ impl crate::Readable for _2_CTL {}
 impl crate::Writable for _2_CTL {}
 #[doc = "PWM2 Control"]
 pub mod _2_ctl;
-#[doc = "PWM2 Interrupt and Trigger Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_inten](_2_inten) module"]
+#[doc = "PWM2 Interrupt and Trigger Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_inten](_2_inten) module"]
 pub type _2_INTEN = crate::Reg<u32, __2_INTEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -663,7 +663,7 @@ impl crate::Readable for _2_INTEN {}
 impl crate::Writable for _2_INTEN {}
 #[doc = "PWM2 Interrupt and Trigger Enable"]
 pub mod _2_inten;
-#[doc = "PWM2 Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_ris](_2_ris) module"]
+#[doc = "PWM2 Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_ris](_2_ris) module"]
 pub type _2_RIS = crate::Reg<u32, __2_RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -672,7 +672,7 @@ pub struct __2_RIS;
 impl crate::Readable for _2_RIS {}
 #[doc = "PWM2 Raw Interrupt Status"]
 pub mod _2_ris;
-#[doc = "PWM2 Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_isc](_2_isc) module"]
+#[doc = "PWM2 Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_isc](_2_isc) module"]
 pub type _2_ISC = crate::Reg<u32, __2_ISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -683,7 +683,7 @@ impl crate::Readable for _2_ISC {}
 impl crate::Writable for _2_ISC {}
 #[doc = "PWM2 Interrupt Status and Clear"]
 pub mod _2_isc;
-#[doc = "PWM2 Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_load](_2_load) module"]
+#[doc = "PWM2 Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_load](_2_load) module"]
 pub type _2_LOAD = crate::Reg<u32, __2_LOAD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -694,7 +694,7 @@ impl crate::Readable for _2_LOAD {}
 impl crate::Writable for _2_LOAD {}
 #[doc = "PWM2 Load"]
 pub mod _2_load;
-#[doc = "PWM2 Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_count](_2_count) module"]
+#[doc = "PWM2 Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_count](_2_count) module"]
 pub type _2_COUNT = crate::Reg<u32, __2_COUNT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -703,7 +703,7 @@ pub struct __2_COUNT;
 impl crate::Readable for _2_COUNT {}
 #[doc = "PWM2 Counter"]
 pub mod _2_count;
-#[doc = "PWM2 Compare A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_cmpa](_2_cmpa) module"]
+#[doc = "PWM2 Compare A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_cmpa](_2_cmpa) module"]
 pub type _2_CMPA = crate::Reg<u32, __2_CMPA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -714,7 +714,7 @@ impl crate::Readable for _2_CMPA {}
 impl crate::Writable for _2_CMPA {}
 #[doc = "PWM2 Compare A"]
 pub mod _2_cmpa;
-#[doc = "PWM2 Compare B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_cmpb](_2_cmpb) module"]
+#[doc = "PWM2 Compare B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_cmpb](_2_cmpb) module"]
 pub type _2_CMPB = crate::Reg<u32, __2_CMPB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -725,7 +725,7 @@ impl crate::Readable for _2_CMPB {}
 impl crate::Writable for _2_CMPB {}
 #[doc = "PWM2 Compare B"]
 pub mod _2_cmpb;
-#[doc = "PWM2 Generator A Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_gena](_2_gena) module"]
+#[doc = "PWM2 Generator A Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_gena](_2_gena) module"]
 pub type _2_GENA = crate::Reg<u32, __2_GENA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -736,7 +736,7 @@ impl crate::Readable for _2_GENA {}
 impl crate::Writable for _2_GENA {}
 #[doc = "PWM2 Generator A Control"]
 pub mod _2_gena;
-#[doc = "PWM2 Generator B Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_genb](_2_genb) module"]
+#[doc = "PWM2 Generator B Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_genb](_2_genb) module"]
 pub type _2_GENB = crate::Reg<u32, __2_GENB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -747,7 +747,7 @@ impl crate::Readable for _2_GENB {}
 impl crate::Writable for _2_GENB {}
 #[doc = "PWM2 Generator B Control"]
 pub mod _2_genb;
-#[doc = "PWM2 Dead-Band Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_dbctl](_2_dbctl) module"]
+#[doc = "PWM2 Dead-Band Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_dbctl](_2_dbctl) module"]
 pub type _2_DBCTL = crate::Reg<u32, __2_DBCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -758,7 +758,7 @@ impl crate::Readable for _2_DBCTL {}
 impl crate::Writable for _2_DBCTL {}
 #[doc = "PWM2 Dead-Band Control"]
 pub mod _2_dbctl;
-#[doc = "PWM2 Dead-Band Rising-Edge Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_dbrise](_2_dbrise) module"]
+#[doc = "PWM2 Dead-Band Rising-Edge Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_dbrise](_2_dbrise) module"]
 pub type _2_DBRISE = crate::Reg<u32, __2_DBRISE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -769,7 +769,7 @@ impl crate::Readable for _2_DBRISE {}
 impl crate::Writable for _2_DBRISE {}
 #[doc = "PWM2 Dead-Band Rising-Edge Delay"]
 pub mod _2_dbrise;
-#[doc = "PWM2 Dead-Band Falling-Edge-Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_dbfall](_2_dbfall) module"]
+#[doc = "PWM2 Dead-Band Falling-Edge-Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_dbfall](_2_dbfall) module"]
 pub type _2_DBFALL = crate::Reg<u32, __2_DBFALL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -780,7 +780,7 @@ impl crate::Readable for _2_DBFALL {}
 impl crate::Writable for _2_DBFALL {}
 #[doc = "PWM2 Dead-Band Falling-Edge-Delay"]
 pub mod _2_dbfall;
-#[doc = "PWM2 Fault Source 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_fltsrc0](_2_fltsrc0) module"]
+#[doc = "PWM2 Fault Source 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_fltsrc0](_2_fltsrc0) module"]
 pub type _2_FLTSRC0 = crate::Reg<u32, __2_FLTSRC0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -791,7 +791,7 @@ impl crate::Readable for _2_FLTSRC0 {}
 impl crate::Writable for _2_FLTSRC0 {}
 #[doc = "PWM2 Fault Source 0"]
 pub mod _2_fltsrc0;
-#[doc = "PWM2 Fault Source 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_fltsrc1](_2_fltsrc1) module"]
+#[doc = "PWM2 Fault Source 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_fltsrc1](_2_fltsrc1) module"]
 pub type _2_FLTSRC1 = crate::Reg<u32, __2_FLTSRC1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -802,7 +802,7 @@ impl crate::Readable for _2_FLTSRC1 {}
 impl crate::Writable for _2_FLTSRC1 {}
 #[doc = "PWM2 Fault Source 1"]
 pub mod _2_fltsrc1;
-#[doc = "PWM2 Minimum Fault Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_minfltper](_2_minfltper) module"]
+#[doc = "PWM2 Minimum Fault Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_minfltper](_2_minfltper) module"]
 pub type _2_MINFLTPER = crate::Reg<u32, __2_MINFLTPER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -813,7 +813,7 @@ impl crate::Readable for _2_MINFLTPER {}
 impl crate::Writable for _2_MINFLTPER {}
 #[doc = "PWM2 Minimum Fault Period"]
 pub mod _2_minfltper;
-#[doc = "PWM3 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_ctl](_3_ctl) module"]
+#[doc = "PWM3 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_ctl](_3_ctl) module"]
 pub type _3_CTL = crate::Reg<u32, __3_CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -824,7 +824,7 @@ impl crate::Readable for _3_CTL {}
 impl crate::Writable for _3_CTL {}
 #[doc = "PWM3 Control"]
 pub mod _3_ctl;
-#[doc = "PWM3 Interrupt and Trigger Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_inten](_3_inten) module"]
+#[doc = "PWM3 Interrupt and Trigger Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_inten](_3_inten) module"]
 pub type _3_INTEN = crate::Reg<u32, __3_INTEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -835,7 +835,7 @@ impl crate::Readable for _3_INTEN {}
 impl crate::Writable for _3_INTEN {}
 #[doc = "PWM3 Interrupt and Trigger Enable"]
 pub mod _3_inten;
-#[doc = "PWM3 Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_ris](_3_ris) module"]
+#[doc = "PWM3 Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_ris](_3_ris) module"]
 pub type _3_RIS = crate::Reg<u32, __3_RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -844,7 +844,7 @@ pub struct __3_RIS;
 impl crate::Readable for _3_RIS {}
 #[doc = "PWM3 Raw Interrupt Status"]
 pub mod _3_ris;
-#[doc = "PWM3 Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_isc](_3_isc) module"]
+#[doc = "PWM3 Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_isc](_3_isc) module"]
 pub type _3_ISC = crate::Reg<u32, __3_ISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -855,7 +855,7 @@ impl crate::Readable for _3_ISC {}
 impl crate::Writable for _3_ISC {}
 #[doc = "PWM3 Interrupt Status and Clear"]
 pub mod _3_isc;
-#[doc = "PWM3 Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_load](_3_load) module"]
+#[doc = "PWM3 Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_load](_3_load) module"]
 pub type _3_LOAD = crate::Reg<u32, __3_LOAD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -866,7 +866,7 @@ impl crate::Readable for _3_LOAD {}
 impl crate::Writable for _3_LOAD {}
 #[doc = "PWM3 Load"]
 pub mod _3_load;
-#[doc = "PWM3 Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_count](_3_count) module"]
+#[doc = "PWM3 Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_count](_3_count) module"]
 pub type _3_COUNT = crate::Reg<u32, __3_COUNT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -875,7 +875,7 @@ pub struct __3_COUNT;
 impl crate::Readable for _3_COUNT {}
 #[doc = "PWM3 Counter"]
 pub mod _3_count;
-#[doc = "PWM3 Compare A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_cmpa](_3_cmpa) module"]
+#[doc = "PWM3 Compare A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_cmpa](_3_cmpa) module"]
 pub type _3_CMPA = crate::Reg<u32, __3_CMPA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -886,7 +886,7 @@ impl crate::Readable for _3_CMPA {}
 impl crate::Writable for _3_CMPA {}
 #[doc = "PWM3 Compare A"]
 pub mod _3_cmpa;
-#[doc = "PWM3 Compare B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_cmpb](_3_cmpb) module"]
+#[doc = "PWM3 Compare B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_cmpb](_3_cmpb) module"]
 pub type _3_CMPB = crate::Reg<u32, __3_CMPB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -897,7 +897,7 @@ impl crate::Readable for _3_CMPB {}
 impl crate::Writable for _3_CMPB {}
 #[doc = "PWM3 Compare B"]
 pub mod _3_cmpb;
-#[doc = "PWM3 Generator A Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_gena](_3_gena) module"]
+#[doc = "PWM3 Generator A Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_gena](_3_gena) module"]
 pub type _3_GENA = crate::Reg<u32, __3_GENA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -908,7 +908,7 @@ impl crate::Readable for _3_GENA {}
 impl crate::Writable for _3_GENA {}
 #[doc = "PWM3 Generator A Control"]
 pub mod _3_gena;
-#[doc = "PWM3 Generator B Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_genb](_3_genb) module"]
+#[doc = "PWM3 Generator B Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_genb](_3_genb) module"]
 pub type _3_GENB = crate::Reg<u32, __3_GENB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -919,7 +919,7 @@ impl crate::Readable for _3_GENB {}
 impl crate::Writable for _3_GENB {}
 #[doc = "PWM3 Generator B Control"]
 pub mod _3_genb;
-#[doc = "PWM3 Dead-Band Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_dbctl](_3_dbctl) module"]
+#[doc = "PWM3 Dead-Band Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_dbctl](_3_dbctl) module"]
 pub type _3_DBCTL = crate::Reg<u32, __3_DBCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -930,7 +930,7 @@ impl crate::Readable for _3_DBCTL {}
 impl crate::Writable for _3_DBCTL {}
 #[doc = "PWM3 Dead-Band Control"]
 pub mod _3_dbctl;
-#[doc = "PWM3 Dead-Band Rising-Edge Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_dbrise](_3_dbrise) module"]
+#[doc = "PWM3 Dead-Band Rising-Edge Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_dbrise](_3_dbrise) module"]
 pub type _3_DBRISE = crate::Reg<u32, __3_DBRISE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -941,7 +941,7 @@ impl crate::Readable for _3_DBRISE {}
 impl crate::Writable for _3_DBRISE {}
 #[doc = "PWM3 Dead-Band Rising-Edge Delay"]
 pub mod _3_dbrise;
-#[doc = "PWM3 Dead-Band Falling-Edge-Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_dbfall](_3_dbfall) module"]
+#[doc = "PWM3 Dead-Band Falling-Edge-Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_dbfall](_3_dbfall) module"]
 pub type _3_DBFALL = crate::Reg<u32, __3_DBFALL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -952,7 +952,7 @@ impl crate::Readable for _3_DBFALL {}
 impl crate::Writable for _3_DBFALL {}
 #[doc = "PWM3 Dead-Band Falling-Edge-Delay"]
 pub mod _3_dbfall;
-#[doc = "PWM3 Fault Source 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_fltsrc0](_3_fltsrc0) module"]
+#[doc = "PWM3 Fault Source 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_fltsrc0](_3_fltsrc0) module"]
 pub type _3_FLTSRC0 = crate::Reg<u32, __3_FLTSRC0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -963,7 +963,7 @@ impl crate::Readable for _3_FLTSRC0 {}
 impl crate::Writable for _3_FLTSRC0 {}
 #[doc = "PWM3 Fault Source 0"]
 pub mod _3_fltsrc0;
-#[doc = "PWM3 Fault Source 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_fltsrc1](_3_fltsrc1) module"]
+#[doc = "PWM3 Fault Source 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_fltsrc1](_3_fltsrc1) module"]
 pub type _3_FLTSRC1 = crate::Reg<u32, __3_FLTSRC1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -974,7 +974,7 @@ impl crate::Readable for _3_FLTSRC1 {}
 impl crate::Writable for _3_FLTSRC1 {}
 #[doc = "PWM3 Fault Source 1"]
 pub mod _3_fltsrc1;
-#[doc = "PWM3 Minimum Fault Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_minfltper](_3_minfltper) module"]
+#[doc = "PWM3 Minimum Fault Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_minfltper](_3_minfltper) module"]
 pub type _3_MINFLTPER = crate::Reg<u32, __3_MINFLTPER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -985,7 +985,7 @@ impl crate::Readable for _3_MINFLTPER {}
 impl crate::Writable for _3_MINFLTPER {}
 #[doc = "PWM3 Minimum Fault Period"]
 pub mod _3_minfltper;
-#[doc = "PWM0 Fault Pin Logic Sense\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_fltsen](_0_fltsen) module"]
+#[doc = "PWM0 Fault Pin Logic Sense\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_fltsen](_0_fltsen) module"]
 pub type _0_FLTSEN = crate::Reg<u32, __0_FLTSEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -996,7 +996,7 @@ impl crate::Readable for _0_FLTSEN {}
 impl crate::Writable for _0_FLTSEN {}
 #[doc = "PWM0 Fault Pin Logic Sense"]
 pub mod _0_fltsen;
-#[doc = "PWM0 Fault Status 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_fltstat0](_0_fltstat0) module"]
+#[doc = "PWM0 Fault Status 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_fltstat0](_0_fltstat0) module"]
 pub type _0_FLTSTAT0 = crate::Reg<u32, __0_FLTSTAT0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1007,7 +1007,7 @@ impl crate::Readable for _0_FLTSTAT0 {}
 impl crate::Writable for _0_FLTSTAT0 {}
 #[doc = "PWM0 Fault Status 0"]
 pub mod _0_fltstat0;
-#[doc = "PWM0 Fault Status 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_fltstat1](_0_fltstat1) module"]
+#[doc = "PWM0 Fault Status 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_fltstat1](_0_fltstat1) module"]
 pub type _0_FLTSTAT1 = crate::Reg<u32, __0_FLTSTAT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1018,7 +1018,7 @@ impl crate::Readable for _0_FLTSTAT1 {}
 impl crate::Writable for _0_FLTSTAT1 {}
 #[doc = "PWM0 Fault Status 1"]
 pub mod _0_fltstat1;
-#[doc = "PWM1 Fault Pin Logic Sense\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_fltsen](_1_fltsen) module"]
+#[doc = "PWM1 Fault Pin Logic Sense\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_fltsen](_1_fltsen) module"]
 pub type _1_FLTSEN = crate::Reg<u32, __1_FLTSEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1029,7 +1029,7 @@ impl crate::Readable for _1_FLTSEN {}
 impl crate::Writable for _1_FLTSEN {}
 #[doc = "PWM1 Fault Pin Logic Sense"]
 pub mod _1_fltsen;
-#[doc = "PWM1 Fault Status 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_fltstat0](_1_fltstat0) module"]
+#[doc = "PWM1 Fault Status 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_fltstat0](_1_fltstat0) module"]
 pub type _1_FLTSTAT0 = crate::Reg<u32, __1_FLTSTAT0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1040,7 +1040,7 @@ impl crate::Readable for _1_FLTSTAT0 {}
 impl crate::Writable for _1_FLTSTAT0 {}
 #[doc = "PWM1 Fault Status 0"]
 pub mod _1_fltstat0;
-#[doc = "PWM1 Fault Status 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_fltstat1](_1_fltstat1) module"]
+#[doc = "PWM1 Fault Status 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_fltstat1](_1_fltstat1) module"]
 pub type _1_FLTSTAT1 = crate::Reg<u32, __1_FLTSTAT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1051,7 +1051,7 @@ impl crate::Readable for _1_FLTSTAT1 {}
 impl crate::Writable for _1_FLTSTAT1 {}
 #[doc = "PWM1 Fault Status 1"]
 pub mod _1_fltstat1;
-#[doc = "PWM2 Fault Status 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_fltstat0](_2_fltstat0) module"]
+#[doc = "PWM2 Fault Status 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_fltstat0](_2_fltstat0) module"]
 pub type _2_FLTSTAT0 = crate::Reg<u32, __2_FLTSTAT0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1062,7 +1062,7 @@ impl crate::Readable for _2_FLTSTAT0 {}
 impl crate::Writable for _2_FLTSTAT0 {}
 #[doc = "PWM2 Fault Status 0"]
 pub mod _2_fltstat0;
-#[doc = "PWM2 Fault Status 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_fltstat1](_2_fltstat1) module"]
+#[doc = "PWM2 Fault Status 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_fltstat1](_2_fltstat1) module"]
 pub type _2_FLTSTAT1 = crate::Reg<u32, __2_FLTSTAT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1073,7 +1073,7 @@ impl crate::Readable for _2_FLTSTAT1 {}
 impl crate::Writable for _2_FLTSTAT1 {}
 #[doc = "PWM2 Fault Status 1"]
 pub mod _2_fltstat1;
-#[doc = "PWM3 Fault Status 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_fltstat0](_3_fltstat0) module"]
+#[doc = "PWM3 Fault Status 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_fltstat0](_3_fltstat0) module"]
 pub type _3_FLTSTAT0 = crate::Reg<u32, __3_FLTSTAT0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1084,7 +1084,7 @@ impl crate::Readable for _3_FLTSTAT0 {}
 impl crate::Writable for _3_FLTSTAT0 {}
 #[doc = "PWM3 Fault Status 0"]
 pub mod _3_fltstat0;
-#[doc = "PWM3 Fault Status 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_fltstat1](_3_fltstat1) module"]
+#[doc = "PWM3 Fault Status 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_fltstat1](_3_fltstat1) module"]
 pub type _3_FLTSTAT1 = crate::Reg<u32, __3_FLTSTAT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1095,7 +1095,7 @@ impl crate::Readable for _3_FLTSTAT1 {}
 impl crate::Writable for _3_FLTSTAT1 {}
 #[doc = "PWM3 Fault Status 1"]
 pub mod _3_fltstat1;
-#[doc = "PWM Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "PWM Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/pwm0/_0_ctl.rs
+++ b/crates/tm4c123x/src/pwm0/_0_ctl.rs
@@ -156,22 +156,19 @@ impl<'a> CMPBUPD_W<'a> {
 }
 #[doc = "PWMnGENA Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum GENAUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<GENAUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: GENAUPD_A) -> Self {
-        match variant {
-            GENAUPD_A::I => 0,
-            GENAUPD_A::LS => 2,
-            GENAUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `GENAUPD`"]
@@ -238,22 +235,19 @@ impl<'a> GENAUPD_W<'a> {
 }
 #[doc = "PWMnGENB Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum GENBUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<GENBUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: GENBUPD_A) -> Self {
-        match variant {
-            GENBUPD_A::I => 0,
-            GENBUPD_A::LS => 2,
-            GENBUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `GENBUPD`"]
@@ -320,22 +314,19 @@ impl<'a> GENBUPD_W<'a> {
 }
 #[doc = "PWMnDBCTL Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBCTLUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBCTLUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBCTLUPD_A) -> Self {
-        match variant {
-            DBCTLUPD_A::I => 0,
-            DBCTLUPD_A::LS => 2,
-            DBCTLUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBCTLUPD`"]
@@ -402,22 +393,19 @@ impl<'a> DBCTLUPD_W<'a> {
 }
 #[doc = "PWMnDBRISE Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBRISEUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBRISEUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBRISEUPD_A) -> Self {
-        match variant {
-            DBRISEUPD_A::I => 0,
-            DBRISEUPD_A::LS => 2,
-            DBRISEUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBRISEUPD`"]
@@ -484,22 +472,19 @@ impl<'a> DBRISEUPD_W<'a> {
 }
 #[doc = "PWMnDBFALL Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBFALLUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBFALLUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBFALLUPD_A) -> Self {
-        match variant {
-            DBFALLUPD_A::I => 0,
-            DBFALLUPD_A::LS => 2,
-            DBFALLUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBFALLUPD`"]

--- a/crates/tm4c123x/src/pwm0/_0_gena.rs
+++ b/crates/tm4c123x/src/pwm0/_0_gena.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::_0_GENA {
 }
 #[doc = "Action for Counter=0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTZERO_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTZERO_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTZERO_A) -> Self {
-        match variant {
-            ACTZERO_A::NONE => 0,
-            ACTZERO_A::INV => 1,
-            ACTZERO_A::ZERO => 2,
-            ACTZERO_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTZERO`"]
@@ -109,25 +105,21 @@ impl<'a> ACTZERO_W<'a> {
 }
 #[doc = "Action for Counter=LOAD\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTLOAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTLOAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTLOAD_A) -> Self {
-        match variant {
-            ACTLOAD_A::NONE => 0,
-            ACTLOAD_A::INV => 1,
-            ACTLOAD_A::ZERO => 2,
-            ACTLOAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTLOAD`"]
@@ -206,25 +198,21 @@ impl<'a> ACTLOAD_W<'a> {
 }
 #[doc = "Action for Comparator A Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAU_A) -> Self {
-        match variant {
-            ACTCMPAU_A::NONE => 0,
-            ACTCMPAU_A::INV => 1,
-            ACTCMPAU_A::ZERO => 2,
-            ACTCMPAU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAU`"]
@@ -303,25 +291,21 @@ impl<'a> ACTCMPAU_W<'a> {
 }
 #[doc = "Action for Comparator A Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAD_A) -> Self {
-        match variant {
-            ACTCMPAD_A::NONE => 0,
-            ACTCMPAD_A::INV => 1,
-            ACTCMPAD_A::ZERO => 2,
-            ACTCMPAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAD`"]
@@ -400,25 +384,21 @@ impl<'a> ACTCMPAD_W<'a> {
 }
 #[doc = "Action for Comparator B Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBU_A) -> Self {
-        match variant {
-            ACTCMPBU_A::NONE => 0,
-            ACTCMPBU_A::INV => 1,
-            ACTCMPBU_A::ZERO => 2,
-            ACTCMPBU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBU`"]
@@ -497,25 +477,21 @@ impl<'a> ACTCMPBU_W<'a> {
 }
 #[doc = "Action for Comparator B Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBD_A) -> Self {
-        match variant {
-            ACTCMPBD_A::NONE => 0,
-            ACTCMPBD_A::INV => 1,
-            ACTCMPBD_A::ZERO => 2,
-            ACTCMPBD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBD`"]

--- a/crates/tm4c123x/src/pwm0/_0_genb.rs
+++ b/crates/tm4c123x/src/pwm0/_0_genb.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::_0_GENB {
 }
 #[doc = "Action for Counter=0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTZERO_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTZERO_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTZERO_A) -> Self {
-        match variant {
-            ACTZERO_A::NONE => 0,
-            ACTZERO_A::INV => 1,
-            ACTZERO_A::ZERO => 2,
-            ACTZERO_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTZERO`"]
@@ -109,25 +105,21 @@ impl<'a> ACTZERO_W<'a> {
 }
 #[doc = "Action for Counter=LOAD\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTLOAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTLOAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTLOAD_A) -> Self {
-        match variant {
-            ACTLOAD_A::NONE => 0,
-            ACTLOAD_A::INV => 1,
-            ACTLOAD_A::ZERO => 2,
-            ACTLOAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTLOAD`"]
@@ -206,25 +198,21 @@ impl<'a> ACTLOAD_W<'a> {
 }
 #[doc = "Action for Comparator A Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAU_A) -> Self {
-        match variant {
-            ACTCMPAU_A::NONE => 0,
-            ACTCMPAU_A::INV => 1,
-            ACTCMPAU_A::ZERO => 2,
-            ACTCMPAU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAU`"]
@@ -303,25 +291,21 @@ impl<'a> ACTCMPAU_W<'a> {
 }
 #[doc = "Action for Comparator A Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAD_A) -> Self {
-        match variant {
-            ACTCMPAD_A::NONE => 0,
-            ACTCMPAD_A::INV => 1,
-            ACTCMPAD_A::ZERO => 2,
-            ACTCMPAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAD`"]
@@ -400,25 +384,21 @@ impl<'a> ACTCMPAD_W<'a> {
 }
 #[doc = "Action for Comparator B Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBU_A) -> Self {
-        match variant {
-            ACTCMPBU_A::NONE => 0,
-            ACTCMPBU_A::INV => 1,
-            ACTCMPBU_A::ZERO => 2,
-            ACTCMPBU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBU`"]
@@ -497,25 +477,21 @@ impl<'a> ACTCMPBU_W<'a> {
 }
 #[doc = "Action for Comparator B Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBD_A) -> Self {
-        match variant {
-            ACTCMPBD_A::NONE => 0,
-            ACTCMPBD_A::INV => 1,
-            ACTCMPBD_A::ZERO => 2,
-            ACTCMPBD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBD`"]

--- a/crates/tm4c123x/src/pwm0/_1_ctl.rs
+++ b/crates/tm4c123x/src/pwm0/_1_ctl.rs
@@ -156,22 +156,19 @@ impl<'a> CMPBUPD_W<'a> {
 }
 #[doc = "PWMnGENA Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum GENAUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<GENAUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: GENAUPD_A) -> Self {
-        match variant {
-            GENAUPD_A::I => 0,
-            GENAUPD_A::LS => 2,
-            GENAUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `GENAUPD`"]
@@ -238,22 +235,19 @@ impl<'a> GENAUPD_W<'a> {
 }
 #[doc = "PWMnGENB Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum GENBUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<GENBUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: GENBUPD_A) -> Self {
-        match variant {
-            GENBUPD_A::I => 0,
-            GENBUPD_A::LS => 2,
-            GENBUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `GENBUPD`"]
@@ -320,22 +314,19 @@ impl<'a> GENBUPD_W<'a> {
 }
 #[doc = "PWMnDBCTL Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBCTLUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBCTLUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBCTLUPD_A) -> Self {
-        match variant {
-            DBCTLUPD_A::I => 0,
-            DBCTLUPD_A::LS => 2,
-            DBCTLUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBCTLUPD`"]
@@ -402,22 +393,19 @@ impl<'a> DBCTLUPD_W<'a> {
 }
 #[doc = "PWMnDBRISE Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBRISEUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBRISEUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBRISEUPD_A) -> Self {
-        match variant {
-            DBRISEUPD_A::I => 0,
-            DBRISEUPD_A::LS => 2,
-            DBRISEUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBRISEUPD`"]
@@ -484,22 +472,19 @@ impl<'a> DBRISEUPD_W<'a> {
 }
 #[doc = "PWMnDBFALL Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBFALLUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBFALLUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBFALLUPD_A) -> Self {
-        match variant {
-            DBFALLUPD_A::I => 0,
-            DBFALLUPD_A::LS => 2,
-            DBFALLUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBFALLUPD`"]

--- a/crates/tm4c123x/src/pwm0/_1_gena.rs
+++ b/crates/tm4c123x/src/pwm0/_1_gena.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::_1_GENA {
 }
 #[doc = "Action for Counter=0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTZERO_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTZERO_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTZERO_A) -> Self {
-        match variant {
-            ACTZERO_A::NONE => 0,
-            ACTZERO_A::INV => 1,
-            ACTZERO_A::ZERO => 2,
-            ACTZERO_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTZERO`"]
@@ -109,25 +105,21 @@ impl<'a> ACTZERO_W<'a> {
 }
 #[doc = "Action for Counter=LOAD\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTLOAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTLOAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTLOAD_A) -> Self {
-        match variant {
-            ACTLOAD_A::NONE => 0,
-            ACTLOAD_A::INV => 1,
-            ACTLOAD_A::ZERO => 2,
-            ACTLOAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTLOAD`"]
@@ -206,25 +198,21 @@ impl<'a> ACTLOAD_W<'a> {
 }
 #[doc = "Action for Comparator A Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAU_A) -> Self {
-        match variant {
-            ACTCMPAU_A::NONE => 0,
-            ACTCMPAU_A::INV => 1,
-            ACTCMPAU_A::ZERO => 2,
-            ACTCMPAU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAU`"]
@@ -303,25 +291,21 @@ impl<'a> ACTCMPAU_W<'a> {
 }
 #[doc = "Action for Comparator A Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAD_A) -> Self {
-        match variant {
-            ACTCMPAD_A::NONE => 0,
-            ACTCMPAD_A::INV => 1,
-            ACTCMPAD_A::ZERO => 2,
-            ACTCMPAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAD`"]
@@ -400,25 +384,21 @@ impl<'a> ACTCMPAD_W<'a> {
 }
 #[doc = "Action for Comparator B Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBU_A) -> Self {
-        match variant {
-            ACTCMPBU_A::NONE => 0,
-            ACTCMPBU_A::INV => 1,
-            ACTCMPBU_A::ZERO => 2,
-            ACTCMPBU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBU`"]
@@ -497,25 +477,21 @@ impl<'a> ACTCMPBU_W<'a> {
 }
 #[doc = "Action for Comparator B Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBD_A) -> Self {
-        match variant {
-            ACTCMPBD_A::NONE => 0,
-            ACTCMPBD_A::INV => 1,
-            ACTCMPBD_A::ZERO => 2,
-            ACTCMPBD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBD`"]

--- a/crates/tm4c123x/src/pwm0/_1_genb.rs
+++ b/crates/tm4c123x/src/pwm0/_1_genb.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::_1_GENB {
 }
 #[doc = "Action for Counter=0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTZERO_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTZERO_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTZERO_A) -> Self {
-        match variant {
-            ACTZERO_A::NONE => 0,
-            ACTZERO_A::INV => 1,
-            ACTZERO_A::ZERO => 2,
-            ACTZERO_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTZERO`"]
@@ -109,25 +105,21 @@ impl<'a> ACTZERO_W<'a> {
 }
 #[doc = "Action for Counter=LOAD\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTLOAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTLOAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTLOAD_A) -> Self {
-        match variant {
-            ACTLOAD_A::NONE => 0,
-            ACTLOAD_A::INV => 1,
-            ACTLOAD_A::ZERO => 2,
-            ACTLOAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTLOAD`"]
@@ -206,25 +198,21 @@ impl<'a> ACTLOAD_W<'a> {
 }
 #[doc = "Action for Comparator A Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAU_A) -> Self {
-        match variant {
-            ACTCMPAU_A::NONE => 0,
-            ACTCMPAU_A::INV => 1,
-            ACTCMPAU_A::ZERO => 2,
-            ACTCMPAU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAU`"]
@@ -303,25 +291,21 @@ impl<'a> ACTCMPAU_W<'a> {
 }
 #[doc = "Action for Comparator A Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAD_A) -> Self {
-        match variant {
-            ACTCMPAD_A::NONE => 0,
-            ACTCMPAD_A::INV => 1,
-            ACTCMPAD_A::ZERO => 2,
-            ACTCMPAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAD`"]
@@ -400,25 +384,21 @@ impl<'a> ACTCMPAD_W<'a> {
 }
 #[doc = "Action for Comparator B Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBU_A) -> Self {
-        match variant {
-            ACTCMPBU_A::NONE => 0,
-            ACTCMPBU_A::INV => 1,
-            ACTCMPBU_A::ZERO => 2,
-            ACTCMPBU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBU`"]
@@ -497,25 +477,21 @@ impl<'a> ACTCMPBU_W<'a> {
 }
 #[doc = "Action for Comparator B Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBD_A) -> Self {
-        match variant {
-            ACTCMPBD_A::NONE => 0,
-            ACTCMPBD_A::INV => 1,
-            ACTCMPBD_A::ZERO => 2,
-            ACTCMPBD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBD`"]

--- a/crates/tm4c123x/src/pwm0/_2_ctl.rs
+++ b/crates/tm4c123x/src/pwm0/_2_ctl.rs
@@ -156,22 +156,19 @@ impl<'a> CMPBUPD_W<'a> {
 }
 #[doc = "PWMnGENA Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum GENAUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<GENAUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: GENAUPD_A) -> Self {
-        match variant {
-            GENAUPD_A::I => 0,
-            GENAUPD_A::LS => 2,
-            GENAUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `GENAUPD`"]
@@ -238,22 +235,19 @@ impl<'a> GENAUPD_W<'a> {
 }
 #[doc = "PWMnGENB Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum GENBUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<GENBUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: GENBUPD_A) -> Self {
-        match variant {
-            GENBUPD_A::I => 0,
-            GENBUPD_A::LS => 2,
-            GENBUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `GENBUPD`"]
@@ -320,22 +314,19 @@ impl<'a> GENBUPD_W<'a> {
 }
 #[doc = "PWMnDBCTL Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBCTLUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBCTLUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBCTLUPD_A) -> Self {
-        match variant {
-            DBCTLUPD_A::I => 0,
-            DBCTLUPD_A::LS => 2,
-            DBCTLUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBCTLUPD`"]
@@ -402,22 +393,19 @@ impl<'a> DBCTLUPD_W<'a> {
 }
 #[doc = "PWMnDBRISE Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBRISEUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBRISEUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBRISEUPD_A) -> Self {
-        match variant {
-            DBRISEUPD_A::I => 0,
-            DBRISEUPD_A::LS => 2,
-            DBRISEUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBRISEUPD`"]
@@ -484,22 +472,19 @@ impl<'a> DBRISEUPD_W<'a> {
 }
 #[doc = "PWMnDBFALL Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBFALLUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBFALLUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBFALLUPD_A) -> Self {
-        match variant {
-            DBFALLUPD_A::I => 0,
-            DBFALLUPD_A::LS => 2,
-            DBFALLUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBFALLUPD`"]

--- a/crates/tm4c123x/src/pwm0/_2_gena.rs
+++ b/crates/tm4c123x/src/pwm0/_2_gena.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::_2_GENA {
 }
 #[doc = "Action for Counter=0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTZERO_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTZERO_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTZERO_A) -> Self {
-        match variant {
-            ACTZERO_A::NONE => 0,
-            ACTZERO_A::INV => 1,
-            ACTZERO_A::ZERO => 2,
-            ACTZERO_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTZERO`"]
@@ -109,25 +105,21 @@ impl<'a> ACTZERO_W<'a> {
 }
 #[doc = "Action for Counter=LOAD\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTLOAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTLOAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTLOAD_A) -> Self {
-        match variant {
-            ACTLOAD_A::NONE => 0,
-            ACTLOAD_A::INV => 1,
-            ACTLOAD_A::ZERO => 2,
-            ACTLOAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTLOAD`"]
@@ -206,25 +198,21 @@ impl<'a> ACTLOAD_W<'a> {
 }
 #[doc = "Action for Comparator A Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAU_A) -> Self {
-        match variant {
-            ACTCMPAU_A::NONE => 0,
-            ACTCMPAU_A::INV => 1,
-            ACTCMPAU_A::ZERO => 2,
-            ACTCMPAU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAU`"]
@@ -303,25 +291,21 @@ impl<'a> ACTCMPAU_W<'a> {
 }
 #[doc = "Action for Comparator A Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAD_A) -> Self {
-        match variant {
-            ACTCMPAD_A::NONE => 0,
-            ACTCMPAD_A::INV => 1,
-            ACTCMPAD_A::ZERO => 2,
-            ACTCMPAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAD`"]
@@ -400,25 +384,21 @@ impl<'a> ACTCMPAD_W<'a> {
 }
 #[doc = "Action for Comparator B Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBU_A) -> Self {
-        match variant {
-            ACTCMPBU_A::NONE => 0,
-            ACTCMPBU_A::INV => 1,
-            ACTCMPBU_A::ZERO => 2,
-            ACTCMPBU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBU`"]
@@ -497,25 +477,21 @@ impl<'a> ACTCMPBU_W<'a> {
 }
 #[doc = "Action for Comparator B Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBD_A) -> Self {
-        match variant {
-            ACTCMPBD_A::NONE => 0,
-            ACTCMPBD_A::INV => 1,
-            ACTCMPBD_A::ZERO => 2,
-            ACTCMPBD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBD`"]

--- a/crates/tm4c123x/src/pwm0/_2_genb.rs
+++ b/crates/tm4c123x/src/pwm0/_2_genb.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::_2_GENB {
 }
 #[doc = "Action for Counter=0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTZERO_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTZERO_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTZERO_A) -> Self {
-        match variant {
-            ACTZERO_A::NONE => 0,
-            ACTZERO_A::INV => 1,
-            ACTZERO_A::ZERO => 2,
-            ACTZERO_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTZERO`"]
@@ -109,25 +105,21 @@ impl<'a> ACTZERO_W<'a> {
 }
 #[doc = "Action for Counter=LOAD\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTLOAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTLOAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTLOAD_A) -> Self {
-        match variant {
-            ACTLOAD_A::NONE => 0,
-            ACTLOAD_A::INV => 1,
-            ACTLOAD_A::ZERO => 2,
-            ACTLOAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTLOAD`"]
@@ -206,25 +198,21 @@ impl<'a> ACTLOAD_W<'a> {
 }
 #[doc = "Action for Comparator A Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAU_A) -> Self {
-        match variant {
-            ACTCMPAU_A::NONE => 0,
-            ACTCMPAU_A::INV => 1,
-            ACTCMPAU_A::ZERO => 2,
-            ACTCMPAU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAU`"]
@@ -303,25 +291,21 @@ impl<'a> ACTCMPAU_W<'a> {
 }
 #[doc = "Action for Comparator A Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAD_A) -> Self {
-        match variant {
-            ACTCMPAD_A::NONE => 0,
-            ACTCMPAD_A::INV => 1,
-            ACTCMPAD_A::ZERO => 2,
-            ACTCMPAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAD`"]
@@ -400,25 +384,21 @@ impl<'a> ACTCMPAD_W<'a> {
 }
 #[doc = "Action for Comparator B Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBU_A) -> Self {
-        match variant {
-            ACTCMPBU_A::NONE => 0,
-            ACTCMPBU_A::INV => 1,
-            ACTCMPBU_A::ZERO => 2,
-            ACTCMPBU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBU`"]
@@ -497,25 +477,21 @@ impl<'a> ACTCMPBU_W<'a> {
 }
 #[doc = "Action for Comparator B Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBD_A) -> Self {
-        match variant {
-            ACTCMPBD_A::NONE => 0,
-            ACTCMPBD_A::INV => 1,
-            ACTCMPBD_A::ZERO => 2,
-            ACTCMPBD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBD`"]

--- a/crates/tm4c123x/src/pwm0/_3_ctl.rs
+++ b/crates/tm4c123x/src/pwm0/_3_ctl.rs
@@ -156,22 +156,19 @@ impl<'a> CMPBUPD_W<'a> {
 }
 #[doc = "PWMnGENA Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum GENAUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<GENAUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: GENAUPD_A) -> Self {
-        match variant {
-            GENAUPD_A::I => 0,
-            GENAUPD_A::LS => 2,
-            GENAUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `GENAUPD`"]
@@ -238,22 +235,19 @@ impl<'a> GENAUPD_W<'a> {
 }
 #[doc = "PWMnGENB Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum GENBUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<GENBUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: GENBUPD_A) -> Self {
-        match variant {
-            GENBUPD_A::I => 0,
-            GENBUPD_A::LS => 2,
-            GENBUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `GENBUPD`"]
@@ -320,22 +314,19 @@ impl<'a> GENBUPD_W<'a> {
 }
 #[doc = "PWMnDBCTL Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBCTLUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBCTLUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBCTLUPD_A) -> Self {
-        match variant {
-            DBCTLUPD_A::I => 0,
-            DBCTLUPD_A::LS => 2,
-            DBCTLUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBCTLUPD`"]
@@ -402,22 +393,19 @@ impl<'a> DBCTLUPD_W<'a> {
 }
 #[doc = "PWMnDBRISE Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBRISEUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBRISEUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBRISEUPD_A) -> Self {
-        match variant {
-            DBRISEUPD_A::I => 0,
-            DBRISEUPD_A::LS => 2,
-            DBRISEUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBRISEUPD`"]
@@ -484,22 +472,19 @@ impl<'a> DBRISEUPD_W<'a> {
 }
 #[doc = "PWMnDBFALL Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBFALLUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBFALLUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBFALLUPD_A) -> Self {
-        match variant {
-            DBFALLUPD_A::I => 0,
-            DBFALLUPD_A::LS => 2,
-            DBFALLUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBFALLUPD`"]

--- a/crates/tm4c123x/src/pwm0/_3_gena.rs
+++ b/crates/tm4c123x/src/pwm0/_3_gena.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::_3_GENA {
 }
 #[doc = "Action for Counter=0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTZERO_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTZERO_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTZERO_A) -> Self {
-        match variant {
-            ACTZERO_A::NONE => 0,
-            ACTZERO_A::INV => 1,
-            ACTZERO_A::ZERO => 2,
-            ACTZERO_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTZERO`"]
@@ -109,25 +105,21 @@ impl<'a> ACTZERO_W<'a> {
 }
 #[doc = "Action for Counter=LOAD\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTLOAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTLOAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTLOAD_A) -> Self {
-        match variant {
-            ACTLOAD_A::NONE => 0,
-            ACTLOAD_A::INV => 1,
-            ACTLOAD_A::ZERO => 2,
-            ACTLOAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTLOAD`"]
@@ -206,25 +198,21 @@ impl<'a> ACTLOAD_W<'a> {
 }
 #[doc = "Action for Comparator A Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAU_A) -> Self {
-        match variant {
-            ACTCMPAU_A::NONE => 0,
-            ACTCMPAU_A::INV => 1,
-            ACTCMPAU_A::ZERO => 2,
-            ACTCMPAU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAU`"]
@@ -303,25 +291,21 @@ impl<'a> ACTCMPAU_W<'a> {
 }
 #[doc = "Action for Comparator A Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAD_A) -> Self {
-        match variant {
-            ACTCMPAD_A::NONE => 0,
-            ACTCMPAD_A::INV => 1,
-            ACTCMPAD_A::ZERO => 2,
-            ACTCMPAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAD`"]
@@ -400,25 +384,21 @@ impl<'a> ACTCMPAD_W<'a> {
 }
 #[doc = "Action for Comparator B Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBU_A) -> Self {
-        match variant {
-            ACTCMPBU_A::NONE => 0,
-            ACTCMPBU_A::INV => 1,
-            ACTCMPBU_A::ZERO => 2,
-            ACTCMPBU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBU`"]
@@ -497,25 +477,21 @@ impl<'a> ACTCMPBU_W<'a> {
 }
 #[doc = "Action for Comparator B Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBD_A) -> Self {
-        match variant {
-            ACTCMPBD_A::NONE => 0,
-            ACTCMPBD_A::INV => 1,
-            ACTCMPBD_A::ZERO => 2,
-            ACTCMPBD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBD`"]

--- a/crates/tm4c123x/src/pwm0/_3_genb.rs
+++ b/crates/tm4c123x/src/pwm0/_3_genb.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::_3_GENB {
 }
 #[doc = "Action for Counter=0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTZERO_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTZERO_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTZERO_A) -> Self {
-        match variant {
-            ACTZERO_A::NONE => 0,
-            ACTZERO_A::INV => 1,
-            ACTZERO_A::ZERO => 2,
-            ACTZERO_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTZERO`"]
@@ -109,25 +105,21 @@ impl<'a> ACTZERO_W<'a> {
 }
 #[doc = "Action for Counter=LOAD\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTLOAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTLOAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTLOAD_A) -> Self {
-        match variant {
-            ACTLOAD_A::NONE => 0,
-            ACTLOAD_A::INV => 1,
-            ACTLOAD_A::ZERO => 2,
-            ACTLOAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTLOAD`"]
@@ -206,25 +198,21 @@ impl<'a> ACTLOAD_W<'a> {
 }
 #[doc = "Action for Comparator A Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAU_A) -> Self {
-        match variant {
-            ACTCMPAU_A::NONE => 0,
-            ACTCMPAU_A::INV => 1,
-            ACTCMPAU_A::ZERO => 2,
-            ACTCMPAU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAU`"]
@@ -303,25 +291,21 @@ impl<'a> ACTCMPAU_W<'a> {
 }
 #[doc = "Action for Comparator A Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAD_A) -> Self {
-        match variant {
-            ACTCMPAD_A::NONE => 0,
-            ACTCMPAD_A::INV => 1,
-            ACTCMPAD_A::ZERO => 2,
-            ACTCMPAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAD`"]
@@ -400,25 +384,21 @@ impl<'a> ACTCMPAD_W<'a> {
 }
 #[doc = "Action for Comparator B Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBU_A) -> Self {
-        match variant {
-            ACTCMPBU_A::NONE => 0,
-            ACTCMPBU_A::INV => 1,
-            ACTCMPBU_A::ZERO => 2,
-            ACTCMPBU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBU`"]
@@ -497,25 +477,21 @@ impl<'a> ACTCMPBU_W<'a> {
 }
 #[doc = "Action for Comparator B Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBD_A) -> Self {
-        match variant {
-            ACTCMPBD_A::NONE => 0,
-            ACTCMPBD_A::INV => 1,
-            ACTCMPBD_A::ZERO => 2,
-            ACTCMPBD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBD`"]

--- a/crates/tm4c123x/src/pwm0/enupd.rs
+++ b/crates/tm4c123x/src/pwm0/enupd.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::ENUPD {
 }
 #[doc = "MnPWM0 Enable Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ENUPD0_A {
     #[doc = "0: Immediate"]
-    IMM,
+    IMM = 0,
     #[doc = "2: Locally Synchronized"]
-    LSYNC,
+    LSYNC = 2,
     #[doc = "3: Globally Synchronized"]
-    GSYNC,
+    GSYNC = 3,
 }
 impl From<ENUPD0_A> for u8 {
     #[inline(always)]
     fn from(variant: ENUPD0_A) -> Self {
-        match variant {
-            ENUPD0_A::IMM => 0,
-            ENUPD0_A::LSYNC => 2,
-            ENUPD0_A::GSYNC => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ENUPD0`"]
@@ -94,22 +91,19 @@ impl<'a> ENUPD0_W<'a> {
 }
 #[doc = "MnPWM1 Enable Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ENUPD1_A {
     #[doc = "0: Immediate"]
-    IMM,
+    IMM = 0,
     #[doc = "2: Locally Synchronized"]
-    LSYNC,
+    LSYNC = 2,
     #[doc = "3: Globally Synchronized"]
-    GSYNC,
+    GSYNC = 3,
 }
 impl From<ENUPD1_A> for u8 {
     #[inline(always)]
     fn from(variant: ENUPD1_A) -> Self {
-        match variant {
-            ENUPD1_A::IMM => 0,
-            ENUPD1_A::LSYNC => 2,
-            ENUPD1_A::GSYNC => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ENUPD1`"]
@@ -176,22 +170,19 @@ impl<'a> ENUPD1_W<'a> {
 }
 #[doc = "MnPWM2 Enable Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ENUPD2_A {
     #[doc = "0: Immediate"]
-    IMM,
+    IMM = 0,
     #[doc = "2: Locally Synchronized"]
-    LSYNC,
+    LSYNC = 2,
     #[doc = "3: Globally Synchronized"]
-    GSYNC,
+    GSYNC = 3,
 }
 impl From<ENUPD2_A> for u8 {
     #[inline(always)]
     fn from(variant: ENUPD2_A) -> Self {
-        match variant {
-            ENUPD2_A::IMM => 0,
-            ENUPD2_A::LSYNC => 2,
-            ENUPD2_A::GSYNC => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ENUPD2`"]
@@ -258,22 +249,19 @@ impl<'a> ENUPD2_W<'a> {
 }
 #[doc = "MnPWM3 Enable Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ENUPD3_A {
     #[doc = "0: Immediate"]
-    IMM,
+    IMM = 0,
     #[doc = "2: Locally Synchronized"]
-    LSYNC,
+    LSYNC = 2,
     #[doc = "3: Globally Synchronized"]
-    GSYNC,
+    GSYNC = 3,
 }
 impl From<ENUPD3_A> for u8 {
     #[inline(always)]
     fn from(variant: ENUPD3_A) -> Self {
-        match variant {
-            ENUPD3_A::IMM => 0,
-            ENUPD3_A::LSYNC => 2,
-            ENUPD3_A::GSYNC => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ENUPD3`"]
@@ -340,22 +328,19 @@ impl<'a> ENUPD3_W<'a> {
 }
 #[doc = "MnPWM4 Enable Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ENUPD4_A {
     #[doc = "0: Immediate"]
-    IMM,
+    IMM = 0,
     #[doc = "2: Locally Synchronized"]
-    LSYNC,
+    LSYNC = 2,
     #[doc = "3: Globally Synchronized"]
-    GSYNC,
+    GSYNC = 3,
 }
 impl From<ENUPD4_A> for u8 {
     #[inline(always)]
     fn from(variant: ENUPD4_A) -> Self {
-        match variant {
-            ENUPD4_A::IMM => 0,
-            ENUPD4_A::LSYNC => 2,
-            ENUPD4_A::GSYNC => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ENUPD4`"]
@@ -422,22 +407,19 @@ impl<'a> ENUPD4_W<'a> {
 }
 #[doc = "MnPWM5 Enable Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ENUPD5_A {
     #[doc = "0: Immediate"]
-    IMM,
+    IMM = 0,
     #[doc = "2: Locally Synchronized"]
-    LSYNC,
+    LSYNC = 2,
     #[doc = "3: Globally Synchronized"]
-    GSYNC,
+    GSYNC = 3,
 }
 impl From<ENUPD5_A> for u8 {
     #[inline(always)]
     fn from(variant: ENUPD5_A) -> Self {
-        match variant {
-            ENUPD5_A::IMM => 0,
-            ENUPD5_A::LSYNC => 2,
-            ENUPD5_A::GSYNC => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ENUPD5`"]
@@ -504,22 +486,19 @@ impl<'a> ENUPD5_W<'a> {
 }
 #[doc = "MnPWM6 Enable Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ENUPD6_A {
     #[doc = "0: Immediate"]
-    IMM,
+    IMM = 0,
     #[doc = "2: Locally Synchronized"]
-    LSYNC,
+    LSYNC = 2,
     #[doc = "3: Globally Synchronized"]
-    GSYNC,
+    GSYNC = 3,
 }
 impl From<ENUPD6_A> for u8 {
     #[inline(always)]
     fn from(variant: ENUPD6_A) -> Self {
-        match variant {
-            ENUPD6_A::IMM => 0,
-            ENUPD6_A::LSYNC => 2,
-            ENUPD6_A::GSYNC => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ENUPD6`"]
@@ -586,22 +565,19 @@ impl<'a> ENUPD6_W<'a> {
 }
 #[doc = "MnPWM7 Enable Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ENUPD7_A {
     #[doc = "0: Immediate"]
-    IMM,
+    IMM = 0,
     #[doc = "2: Locally Synchronized"]
-    LSYNC,
+    LSYNC = 2,
     #[doc = "3: Globally Synchronized"]
-    GSYNC,
+    GSYNC = 3,
 }
 impl From<ENUPD7_A> for u8 {
     #[inline(always)]
     fn from(variant: ENUPD7_A) -> Self {
-        match variant {
-            ENUPD7_A::IMM => 0,
-            ENUPD7_A::LSYNC => 2,
-            ENUPD7_A::GSYNC => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ENUPD7`"]

--- a/crates/tm4c123x/src/qei0.rs
+++ b/crates/tm4c123x/src/qei0.rs
@@ -24,7 +24,7 @@ pub struct RegisterBlock {
     #[doc = "0x28 - QEI Interrupt Status and Clear"]
     pub isc: ISC,
 }
-#[doc = "QEI Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctl](ctl) module"]
+#[doc = "QEI Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctl](ctl) module"]
 pub type CTL = crate::Reg<u32, _CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -35,7 +35,7 @@ impl crate::Readable for CTL {}
 impl crate::Writable for CTL {}
 #[doc = "QEI Control"]
 pub mod ctl;
-#[doc = "QEI Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [stat](stat) module"]
+#[doc = "QEI Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [stat](stat) module"]
 pub type STAT = crate::Reg<u32, _STAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -44,7 +44,7 @@ pub struct _STAT;
 impl crate::Readable for STAT {}
 #[doc = "QEI Status"]
 pub mod stat;
-#[doc = "QEI Position\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pos](pos) module"]
+#[doc = "QEI Position\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pos](pos) module"]
 pub type POS = crate::Reg<u32, _POS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -55,7 +55,7 @@ impl crate::Readable for POS {}
 impl crate::Writable for POS {}
 #[doc = "QEI Position"]
 pub mod pos;
-#[doc = "QEI Maximum Position\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [maxpos](maxpos) module"]
+#[doc = "QEI Maximum Position\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [maxpos](maxpos) module"]
 pub type MAXPOS = crate::Reg<u32, _MAXPOS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -66,7 +66,7 @@ impl crate::Readable for MAXPOS {}
 impl crate::Writable for MAXPOS {}
 #[doc = "QEI Maximum Position"]
 pub mod maxpos;
-#[doc = "QEI Timer Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [load](load) module"]
+#[doc = "QEI Timer Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [load](load) module"]
 pub type LOAD = crate::Reg<u32, _LOAD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -77,7 +77,7 @@ impl crate::Readable for LOAD {}
 impl crate::Writable for LOAD {}
 #[doc = "QEI Timer Load"]
 pub mod load;
-#[doc = "QEI Timer\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [time](time) module"]
+#[doc = "QEI Timer\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [time](time) module"]
 pub type TIME = crate::Reg<u32, _TIME>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -86,7 +86,7 @@ pub struct _TIME;
 impl crate::Readable for TIME {}
 #[doc = "QEI Timer"]
 pub mod time;
-#[doc = "QEI Velocity Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [count](count) module"]
+#[doc = "QEI Velocity Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [count](count) module"]
 pub type COUNT = crate::Reg<u32, _COUNT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -95,7 +95,7 @@ pub struct _COUNT;
 impl crate::Readable for COUNT {}
 #[doc = "QEI Velocity Counter"]
 pub mod count;
-#[doc = "QEI Velocity\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [speed](speed) module"]
+#[doc = "QEI Velocity\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [speed](speed) module"]
 pub type SPEED = crate::Reg<u32, _SPEED>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -104,7 +104,7 @@ pub struct _SPEED;
 impl crate::Readable for SPEED {}
 #[doc = "QEI Velocity"]
 pub mod speed;
-#[doc = "QEI Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [inten](inten) module"]
+#[doc = "QEI Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [inten](inten) module"]
 pub type INTEN = crate::Reg<u32, _INTEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -115,7 +115,7 @@ impl crate::Readable for INTEN {}
 impl crate::Writable for INTEN {}
 #[doc = "QEI Interrupt Enable"]
 pub mod inten;
-#[doc = "QEI Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "QEI Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -124,7 +124,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "QEI Raw Interrupt Status"]
 pub mod ris;
-#[doc = "QEI Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [isc](isc) module"]
+#[doc = "QEI Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [isc](isc) module"]
 pub type ISC = crate::Reg<u32, _ISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/qei0/ctl.rs
+++ b/crates/tm4c123x/src/qei0/ctl.rs
@@ -156,37 +156,29 @@ impl<'a> VELEN_W<'a> {
 }
 #[doc = "Predivide Velocity\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum VELDIV_A {
     #[doc = "0: QEI clock /1"]
-    _1,
+    _1 = 0,
     #[doc = "1: QEI clock /2"]
-    _2,
+    _2 = 1,
     #[doc = "2: QEI clock /4"]
-    _4,
+    _4 = 2,
     #[doc = "3: QEI clock /8"]
-    _8,
+    _8 = 3,
     #[doc = "4: QEI clock /16"]
-    _16,
+    _16 = 4,
     #[doc = "5: QEI clock /32"]
-    _32,
+    _32 = 5,
     #[doc = "6: QEI clock /64"]
-    _64,
+    _64 = 6,
     #[doc = "7: QEI clock /128"]
-    _128,
+    _128 = 7,
 }
 impl From<VELDIV_A> for u8 {
     #[inline(always)]
     fn from(variant: VELDIV_A) -> Self {
-        match variant {
-            VELDIV_A::_1 => 0,
-            VELDIV_A::_2 => 1,
-            VELDIV_A::_4 => 2,
-            VELDIV_A::_8 => 3,
-            VELDIV_A::_16 => 4,
-            VELDIV_A::_32 => 5,
-            VELDIV_A::_64 => 6,
-            VELDIV_A::_128 => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `VELDIV`"]

--- a/crates/tm4c123x/src/ssi0.rs
+++ b/crates/tm4c123x/src/ssi0.rs
@@ -25,7 +25,7 @@ pub struct RegisterBlock {
     #[doc = "0xfc8 - SSI Clock Configuration"]
     pub cc: CC,
 }
-#[doc = "SSI Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cr0](cr0) module"]
+#[doc = "SSI Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cr0](cr0) module"]
 pub type CR0 = crate::Reg<u32, _CR0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -36,7 +36,7 @@ impl crate::Readable for CR0 {}
 impl crate::Writable for CR0 {}
 #[doc = "SSI Control 0"]
 pub mod cr0;
-#[doc = "SSI Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cr1](cr1) module"]
+#[doc = "SSI Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cr1](cr1) module"]
 pub type CR1 = crate::Reg<u32, _CR1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -47,7 +47,7 @@ impl crate::Readable for CR1 {}
 impl crate::Writable for CR1 {}
 #[doc = "SSI Control 1"]
 pub mod cr1;
-#[doc = "SSI Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dr](dr) module"]
+#[doc = "SSI Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dr](dr) module"]
 pub type DR = crate::Reg<u32, _DR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -58,7 +58,7 @@ impl crate::Readable for DR {}
 impl crate::Writable for DR {}
 #[doc = "SSI Data"]
 pub mod dr;
-#[doc = "SSI Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sr](sr) module"]
+#[doc = "SSI Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sr](sr) module"]
 pub type SR = crate::Reg<u32, _SR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -67,7 +67,7 @@ pub struct _SR;
 impl crate::Readable for SR {}
 #[doc = "SSI Status"]
 pub mod sr;
-#[doc = "SSI Clock Prescale\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cpsr](cpsr) module"]
+#[doc = "SSI Clock Prescale\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cpsr](cpsr) module"]
 pub type CPSR = crate::Reg<u32, _CPSR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -78,7 +78,7 @@ impl crate::Readable for CPSR {}
 impl crate::Writable for CPSR {}
 #[doc = "SSI Clock Prescale"]
 pub mod cpsr;
-#[doc = "SSI Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [im](im) module"]
+#[doc = "SSI Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [im](im) module"]
 pub type IM = crate::Reg<u32, _IM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -89,7 +89,7 @@ impl crate::Readable for IM {}
 impl crate::Writable for IM {}
 #[doc = "SSI Interrupt Mask"]
 pub mod im;
-#[doc = "SSI Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "SSI Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -98,7 +98,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "SSI Raw Interrupt Status"]
 pub mod ris;
-#[doc = "SSI Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mis](mis) module"]
+#[doc = "SSI Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mis](mis) module"]
 pub type MIS = crate::Reg<u32, _MIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -107,7 +107,7 @@ pub struct _MIS;
 impl crate::Readable for MIS {}
 #[doc = "SSI Masked Interrupt Status"]
 pub mod mis;
-#[doc = "SSI Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [icr](icr) module"]
+#[doc = "SSI Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [icr](icr) module"]
 pub type ICR = crate::Reg<u32, _ICR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -116,7 +116,7 @@ pub struct _ICR;
 impl crate::Writable for ICR {}
 #[doc = "SSI Interrupt Clear"]
 pub mod icr;
-#[doc = "SSI DMA Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmactl](dmactl) module"]
+#[doc = "SSI DMA Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmactl](dmactl) module"]
 pub type DMACTL = crate::Reg<u32, _DMACTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -127,7 +127,7 @@ impl crate::Readable for DMACTL {}
 impl crate::Writable for DMACTL {}
 #[doc = "SSI DMA Control"]
 pub mod dmactl;
-#[doc = "SSI Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc](cc) module"]
+#[doc = "SSI Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cc](cc) module"]
 pub type CC = crate::Reg<u32, _CC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/ssi0/cc.rs
+++ b/crates/tm4c123x/src/ssi0/cc.rs
@@ -12,19 +12,17 @@ impl crate::ResetValue for super::CC {
 }
 #[doc = "SSI Baud Clock Source\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CS_A {
     #[doc = "0: System clock (based on clock source and divisor factor)"]
-    SYSPLL,
+    SYSPLL = 0,
     #[doc = "5: PIOSC"]
-    PIOSC,
+    PIOSC = 5,
 }
 impl From<CS_A> for u8 {
     #[inline(always)]
     fn from(variant: CS_A) -> Self {
-        match variant {
-            CS_A::SYSPLL => 0,
-            CS_A::PIOSC => 5,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CS`"]

--- a/crates/tm4c123x/src/ssi0/cr0.rs
+++ b/crates/tm4c123x/src/ssi0/cr0.rs
@@ -12,52 +12,39 @@ impl crate::ResetValue for super::CR0 {
 }
 #[doc = "SSI Data Size Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DSS_A {
     #[doc = "3: 4-bit data"]
-    _4,
+    _4 = 3,
     #[doc = "4: 5-bit data"]
-    _5,
+    _5 = 4,
     #[doc = "5: 6-bit data"]
-    _6,
+    _6 = 5,
     #[doc = "6: 7-bit data"]
-    _7,
+    _7 = 6,
     #[doc = "7: 8-bit data"]
-    _8,
+    _8 = 7,
     #[doc = "8: 9-bit data"]
-    _9,
+    _9 = 8,
     #[doc = "9: 10-bit data"]
-    _10,
+    _10 = 9,
     #[doc = "10: 11-bit data"]
-    _11,
+    _11 = 10,
     #[doc = "11: 12-bit data"]
-    _12,
+    _12 = 11,
     #[doc = "12: 13-bit data"]
-    _13,
+    _13 = 12,
     #[doc = "13: 14-bit data"]
-    _14,
+    _14 = 13,
     #[doc = "14: 15-bit data"]
-    _15,
+    _15 = 14,
     #[doc = "15: 16-bit data"]
-    _16,
+    _16 = 15,
 }
 impl From<DSS_A> for u8 {
     #[inline(always)]
     fn from(variant: DSS_A) -> Self {
-        match variant {
-            DSS_A::_4 => 3,
-            DSS_A::_5 => 4,
-            DSS_A::_6 => 5,
-            DSS_A::_7 => 6,
-            DSS_A::_8 => 7,
-            DSS_A::_9 => 8,
-            DSS_A::_10 => 9,
-            DSS_A::_11 => 10,
-            DSS_A::_12 => 11,
-            DSS_A::_13 => 12,
-            DSS_A::_14 => 13,
-            DSS_A::_15 => 14,
-            DSS_A::_16 => 15,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DSS`"]
@@ -234,22 +221,19 @@ impl<'a> DSS_W<'a> {
 }
 #[doc = "SSI Frame Format Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum FRF_A {
     #[doc = "0: Freescale SPI Frame Format"]
-    MOTO,
+    MOTO = 0,
     #[doc = "1: Synchronous Serial Frame Format"]
-    TI,
+    TI = 1,
     #[doc = "2: MICROWIRE Frame Format"]
-    NMW,
+    NMW = 2,
 }
 impl From<FRF_A> for u8 {
     #[inline(always)]
     fn from(variant: FRF_A) -> Self {
-        match variant {
-            FRF_A::MOTO => 0,
-            FRF_A::TI => 1,
-            FRF_A::NMW => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `FRF`"]

--- a/crates/tm4c123x/src/sysctl.rs
+++ b/crates/tm4c123x/src/sysctl.rs
@@ -329,7 +329,7 @@ pub struct RegisterBlock {
     #[doc = "0xa5c - 32/64-Bit Wide General-Purpose Timer Peripheral Ready"]
     pub prwtimer: PRWTIMER,
 }
-#[doc = "Device Identification 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [did0](did0) module"]
+#[doc = "Device Identification 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [did0](did0) module"]
 pub type DID0 = crate::Reg<u32, _DID0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -338,7 +338,7 @@ pub struct _DID0;
 impl crate::Readable for DID0 {}
 #[doc = "Device Identification 0"]
 pub mod did0;
-#[doc = "Device Identification 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [did1](did1) module"]
+#[doc = "Device Identification 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [did1](did1) module"]
 pub type DID1 = crate::Reg<u32, _DID1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -347,7 +347,7 @@ pub struct _DID1;
 impl crate::Readable for DID1 {}
 #[doc = "Device Identification 1"]
 pub mod did1;
-#[doc = "Device Capabilities 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dc0](dc0) module"]
+#[doc = "Device Capabilities 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dc0](dc0) module"]
 pub type DC0 = crate::Reg<u32, _DC0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -356,7 +356,7 @@ pub struct _DC0;
 impl crate::Readable for DC0 {}
 #[doc = "Device Capabilities 0"]
 pub mod dc0;
-#[doc = "Device Capabilities 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dc1](dc1) module"]
+#[doc = "Device Capabilities 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dc1](dc1) module"]
 pub type DC1 = crate::Reg<u32, _DC1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -365,7 +365,7 @@ pub struct _DC1;
 impl crate::Readable for DC1 {}
 #[doc = "Device Capabilities 1"]
 pub mod dc1;
-#[doc = "Device Capabilities 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dc2](dc2) module"]
+#[doc = "Device Capabilities 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dc2](dc2) module"]
 pub type DC2 = crate::Reg<u32, _DC2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -374,7 +374,7 @@ pub struct _DC2;
 impl crate::Readable for DC2 {}
 #[doc = "Device Capabilities 2"]
 pub mod dc2;
-#[doc = "Device Capabilities 3\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dc3](dc3) module"]
+#[doc = "Device Capabilities 3\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dc3](dc3) module"]
 pub type DC3 = crate::Reg<u32, _DC3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -383,7 +383,7 @@ pub struct _DC3;
 impl crate::Readable for DC3 {}
 #[doc = "Device Capabilities 3"]
 pub mod dc3;
-#[doc = "Device Capabilities 4\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dc4](dc4) module"]
+#[doc = "Device Capabilities 4\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dc4](dc4) module"]
 pub type DC4 = crate::Reg<u32, _DC4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -392,7 +392,7 @@ pub struct _DC4;
 impl crate::Readable for DC4 {}
 #[doc = "Device Capabilities 4"]
 pub mod dc4;
-#[doc = "Device Capabilities 5\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dc5](dc5) module"]
+#[doc = "Device Capabilities 5\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dc5](dc5) module"]
 pub type DC5 = crate::Reg<u32, _DC5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -401,7 +401,7 @@ pub struct _DC5;
 impl crate::Readable for DC5 {}
 #[doc = "Device Capabilities 5"]
 pub mod dc5;
-#[doc = "Device Capabilities 6\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dc6](dc6) module"]
+#[doc = "Device Capabilities 6\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dc6](dc6) module"]
 pub type DC6 = crate::Reg<u32, _DC6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -410,7 +410,7 @@ pub struct _DC6;
 impl crate::Readable for DC6 {}
 #[doc = "Device Capabilities 6"]
 pub mod dc6;
-#[doc = "Device Capabilities 7\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dc7](dc7) module"]
+#[doc = "Device Capabilities 7\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dc7](dc7) module"]
 pub type DC7 = crate::Reg<u32, _DC7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -419,7 +419,7 @@ pub struct _DC7;
 impl crate::Readable for DC7 {}
 #[doc = "Device Capabilities 7"]
 pub mod dc7;
-#[doc = "Device Capabilities 8\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dc8](dc8) module"]
+#[doc = "Device Capabilities 8\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dc8](dc8) module"]
 pub type DC8 = crate::Reg<u32, _DC8>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -428,7 +428,7 @@ pub struct _DC8;
 impl crate::Readable for DC8 {}
 #[doc = "Device Capabilities 8"]
 pub mod dc8;
-#[doc = "Brown-Out Reset Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pborctl](pborctl) module"]
+#[doc = "Brown-Out Reset Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pborctl](pborctl) module"]
 pub type PBORCTL = crate::Reg<u32, _PBORCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -439,7 +439,7 @@ impl crate::Readable for PBORCTL {}
 impl crate::Writable for PBORCTL {}
 #[doc = "Brown-Out Reset Control"]
 pub mod pborctl;
-#[doc = "Software Reset Control 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srcr0](srcr0) module"]
+#[doc = "Software Reset Control 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srcr0](srcr0) module"]
 pub type SRCR0 = crate::Reg<u32, _SRCR0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -448,7 +448,7 @@ pub struct _SRCR0;
 impl crate::Readable for SRCR0 {}
 #[doc = "Software Reset Control 0"]
 pub mod srcr0;
-#[doc = "Software Reset Control 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srcr1](srcr1) module"]
+#[doc = "Software Reset Control 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srcr1](srcr1) module"]
 pub type SRCR1 = crate::Reg<u32, _SRCR1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -457,7 +457,7 @@ pub struct _SRCR1;
 impl crate::Readable for SRCR1 {}
 #[doc = "Software Reset Control 1"]
 pub mod srcr1;
-#[doc = "Software Reset Control 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srcr2](srcr2) module"]
+#[doc = "Software Reset Control 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srcr2](srcr2) module"]
 pub type SRCR2 = crate::Reg<u32, _SRCR2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -466,7 +466,7 @@ pub struct _SRCR2;
 impl crate::Readable for SRCR2 {}
 #[doc = "Software Reset Control 2"]
 pub mod srcr2;
-#[doc = "Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -475,7 +475,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "Raw Interrupt Status"]
 pub mod ris;
-#[doc = "Interrupt Mask Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [imc](imc) module"]
+#[doc = "Interrupt Mask Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [imc](imc) module"]
 pub type IMC = crate::Reg<u32, _IMC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -486,7 +486,7 @@ impl crate::Readable for IMC {}
 impl crate::Writable for IMC {}
 #[doc = "Interrupt Mask Control"]
 pub mod imc;
-#[doc = "Masked Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [misc](misc) module"]
+#[doc = "Masked Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [misc](misc) module"]
 pub type MISC = crate::Reg<u32, _MISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -497,7 +497,7 @@ impl crate::Readable for MISC {}
 impl crate::Writable for MISC {}
 #[doc = "Masked Interrupt Status and Clear"]
 pub mod misc;
-#[doc = "Reset Cause\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [resc](resc) module"]
+#[doc = "Reset Cause\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [resc](resc) module"]
 pub type RESC = crate::Reg<u32, _RESC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -508,7 +508,7 @@ impl crate::Readable for RESC {}
 impl crate::Writable for RESC {}
 #[doc = "Reset Cause"]
 pub mod resc;
-#[doc = "Run-Mode Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcc](rcc) module"]
+#[doc = "Run-Mode Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcc](rcc) module"]
 pub type RCC = crate::Reg<u32, _RCC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -519,7 +519,7 @@ impl crate::Readable for RCC {}
 impl crate::Writable for RCC {}
 #[doc = "Run-Mode Clock Configuration"]
 pub mod rcc;
-#[doc = "GPIO High-Performance Bus Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [gpiohbctl](gpiohbctl) module"]
+#[doc = "GPIO High-Performance Bus Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [gpiohbctl](gpiohbctl) module"]
 pub type GPIOHBCTL = crate::Reg<u32, _GPIOHBCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -530,7 +530,7 @@ impl crate::Readable for GPIOHBCTL {}
 impl crate::Writable for GPIOHBCTL {}
 #[doc = "GPIO High-Performance Bus Control"]
 pub mod gpiohbctl;
-#[doc = "Run-Mode Clock Configuration 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcc2](rcc2) module"]
+#[doc = "Run-Mode Clock Configuration 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcc2](rcc2) module"]
 pub type RCC2 = crate::Reg<u32, _RCC2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -541,7 +541,7 @@ impl crate::Readable for RCC2 {}
 impl crate::Writable for RCC2 {}
 #[doc = "Run-Mode Clock Configuration 2"]
 pub mod rcc2;
-#[doc = "Main Oscillator Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [moscctl](moscctl) module"]
+#[doc = "Main Oscillator Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [moscctl](moscctl) module"]
 pub type MOSCCTL = crate::Reg<u32, _MOSCCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -552,7 +552,7 @@ impl crate::Readable for MOSCCTL {}
 impl crate::Writable for MOSCCTL {}
 #[doc = "Main Oscillator Control"]
 pub mod moscctl;
-#[doc = "Run Mode Clock Gating Control Register 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgc0](rcgc0) module"]
+#[doc = "Run Mode Clock Gating Control Register 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgc0](rcgc0) module"]
 pub type RCGC0 = crate::Reg<u32, _RCGC0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -561,7 +561,7 @@ pub struct _RCGC0;
 impl crate::Readable for RCGC0 {}
 #[doc = "Run Mode Clock Gating Control Register 0"]
 pub mod rcgc0;
-#[doc = "Run Mode Clock Gating Control Register 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgc1](rcgc1) module"]
+#[doc = "Run Mode Clock Gating Control Register 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgc1](rcgc1) module"]
 pub type RCGC1 = crate::Reg<u32, _RCGC1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -570,7 +570,7 @@ pub struct _RCGC1;
 impl crate::Readable for RCGC1 {}
 #[doc = "Run Mode Clock Gating Control Register 1"]
 pub mod rcgc1;
-#[doc = "Run Mode Clock Gating Control Register 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgc2](rcgc2) module"]
+#[doc = "Run Mode Clock Gating Control Register 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgc2](rcgc2) module"]
 pub type RCGC2 = crate::Reg<u32, _RCGC2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -579,7 +579,7 @@ pub struct _RCGC2;
 impl crate::Readable for RCGC2 {}
 #[doc = "Run Mode Clock Gating Control Register 2"]
 pub mod rcgc2;
-#[doc = "Sleep Mode Clock Gating Control Register 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgc0](scgc0) module"]
+#[doc = "Sleep Mode Clock Gating Control Register 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgc0](scgc0) module"]
 pub type SCGC0 = crate::Reg<u32, _SCGC0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -588,7 +588,7 @@ pub struct _SCGC0;
 impl crate::Readable for SCGC0 {}
 #[doc = "Sleep Mode Clock Gating Control Register 0"]
 pub mod scgc0;
-#[doc = "Sleep Mode Clock Gating Control Register 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgc1](scgc1) module"]
+#[doc = "Sleep Mode Clock Gating Control Register 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgc1](scgc1) module"]
 pub type SCGC1 = crate::Reg<u32, _SCGC1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -597,7 +597,7 @@ pub struct _SCGC1;
 impl crate::Readable for SCGC1 {}
 #[doc = "Sleep Mode Clock Gating Control Register 1"]
 pub mod scgc1;
-#[doc = "Sleep Mode Clock Gating Control Register 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgc2](scgc2) module"]
+#[doc = "Sleep Mode Clock Gating Control Register 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgc2](scgc2) module"]
 pub type SCGC2 = crate::Reg<u32, _SCGC2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -606,7 +606,7 @@ pub struct _SCGC2;
 impl crate::Readable for SCGC2 {}
 #[doc = "Sleep Mode Clock Gating Control Register 2"]
 pub mod scgc2;
-#[doc = "Deep Sleep Mode Clock Gating Control Register 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgc0](dcgc0) module"]
+#[doc = "Deep Sleep Mode Clock Gating Control Register 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgc0](dcgc0) module"]
 pub type DCGC0 = crate::Reg<u32, _DCGC0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -615,7 +615,7 @@ pub struct _DCGC0;
 impl crate::Readable for DCGC0 {}
 #[doc = "Deep Sleep Mode Clock Gating Control Register 0"]
 pub mod dcgc0;
-#[doc = "Deep-Sleep Mode Clock Gating Control Register 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgc1](dcgc1) module"]
+#[doc = "Deep-Sleep Mode Clock Gating Control Register 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgc1](dcgc1) module"]
 pub type DCGC1 = crate::Reg<u32, _DCGC1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -624,7 +624,7 @@ pub struct _DCGC1;
 impl crate::Readable for DCGC1 {}
 #[doc = "Deep-Sleep Mode Clock Gating Control Register 1"]
 pub mod dcgc1;
-#[doc = "Deep Sleep Mode Clock Gating Control Register 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgc2](dcgc2) module"]
+#[doc = "Deep Sleep Mode Clock Gating Control Register 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgc2](dcgc2) module"]
 pub type DCGC2 = crate::Reg<u32, _DCGC2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -633,7 +633,7 @@ pub struct _DCGC2;
 impl crate::Readable for DCGC2 {}
 #[doc = "Deep Sleep Mode Clock Gating Control Register 2"]
 pub mod dcgc2;
-#[doc = "Deep Sleep Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dslpclkcfg](dslpclkcfg) module"]
+#[doc = "Deep Sleep Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dslpclkcfg](dslpclkcfg) module"]
 pub type DSLPCLKCFG = crate::Reg<u32, _DSLPCLKCFG>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -644,7 +644,7 @@ impl crate::Readable for DSLPCLKCFG {}
 impl crate::Writable for DSLPCLKCFG {}
 #[doc = "Deep Sleep Clock Configuration"]
 pub mod dslpclkcfg;
-#[doc = "System Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sysprop](sysprop) module"]
+#[doc = "System Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sysprop](sysprop) module"]
 pub type SYSPROP = crate::Reg<u32, _SYSPROP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -653,7 +653,7 @@ pub struct _SYSPROP;
 impl crate::Readable for SYSPROP {}
 #[doc = "System Properties"]
 pub mod sysprop;
-#[doc = "Precision Internal Oscillator Calibration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [piosccal](piosccal) module"]
+#[doc = "Precision Internal Oscillator Calibration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [piosccal](piosccal) module"]
 pub type PIOSCCAL = crate::Reg<u32, _PIOSCCAL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -664,7 +664,7 @@ impl crate::Readable for PIOSCCAL {}
 impl crate::Writable for PIOSCCAL {}
 #[doc = "Precision Internal Oscillator Calibration"]
 pub mod piosccal;
-#[doc = "Precision Internal Oscillator Statistics\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pioscstat](pioscstat) module"]
+#[doc = "Precision Internal Oscillator Statistics\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pioscstat](pioscstat) module"]
 pub type PIOSCSTAT = crate::Reg<u32, _PIOSCSTAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -673,7 +673,7 @@ pub struct _PIOSCSTAT;
 impl crate::Readable for PIOSCSTAT {}
 #[doc = "Precision Internal Oscillator Statistics"]
 pub mod pioscstat;
-#[doc = "PLL Frequency 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pllfreq0](pllfreq0) module"]
+#[doc = "PLL Frequency 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pllfreq0](pllfreq0) module"]
 pub type PLLFREQ0 = crate::Reg<u32, _PLLFREQ0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -684,7 +684,7 @@ impl crate::Readable for PLLFREQ0 {}
 impl crate::Writable for PLLFREQ0 {}
 #[doc = "PLL Frequency 0"]
 pub mod pllfreq0;
-#[doc = "PLL Frequency 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pllfreq1](pllfreq1) module"]
+#[doc = "PLL Frequency 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pllfreq1](pllfreq1) module"]
 pub type PLLFREQ1 = crate::Reg<u32, _PLLFREQ1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -695,7 +695,7 @@ impl crate::Readable for PLLFREQ1 {}
 impl crate::Writable for PLLFREQ1 {}
 #[doc = "PLL Frequency 1"]
 pub mod pllfreq1;
-#[doc = "PLL Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pllstat](pllstat) module"]
+#[doc = "PLL Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pllstat](pllstat) module"]
 pub type PLLSTAT = crate::Reg<u32, _PLLSTAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -704,7 +704,7 @@ pub struct _PLLSTAT;
 impl crate::Readable for PLLSTAT {}
 #[doc = "PLL Status"]
 pub mod pllstat;
-#[doc = "Sleep Power Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [slppwrcfg](slppwrcfg) module"]
+#[doc = "Sleep Power Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [slppwrcfg](slppwrcfg) module"]
 pub type SLPPWRCFG = crate::Reg<u32, _SLPPWRCFG>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -715,7 +715,7 @@ impl crate::Readable for SLPPWRCFG {}
 impl crate::Writable for SLPPWRCFG {}
 #[doc = "Sleep Power Configuration"]
 pub mod slppwrcfg;
-#[doc = "Deep-Sleep Power Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dslppwrcfg](dslppwrcfg) module"]
+#[doc = "Deep-Sleep Power Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dslppwrcfg](dslppwrcfg) module"]
 pub type DSLPPWRCFG = crate::Reg<u32, _DSLPPWRCFG>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -726,7 +726,7 @@ impl crate::Readable for DSLPPWRCFG {}
 impl crate::Writable for DSLPPWRCFG {}
 #[doc = "Deep-Sleep Power Configuration"]
 pub mod dslppwrcfg;
-#[doc = "Device Capabilities 9\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dc9](dc9) module"]
+#[doc = "Device Capabilities 9\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dc9](dc9) module"]
 pub type DC9 = crate::Reg<u32, _DC9>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -735,7 +735,7 @@ pub struct _DC9;
 impl crate::Readable for DC9 {}
 #[doc = "Device Capabilities 9"]
 pub mod dc9;
-#[doc = "Non-Volatile Memory Information\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [nvmstat](nvmstat) module"]
+#[doc = "Non-Volatile Memory Information\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [nvmstat](nvmstat) module"]
 pub type NVMSTAT = crate::Reg<u32, _NVMSTAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -744,7 +744,7 @@ pub struct _NVMSTAT;
 impl crate::Readable for NVMSTAT {}
 #[doc = "Non-Volatile Memory Information"]
 pub mod nvmstat;
-#[doc = "LDO Sleep Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ldospctl](ldospctl) module"]
+#[doc = "LDO Sleep Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ldospctl](ldospctl) module"]
 pub type LDOSPCTL = crate::Reg<u32, _LDOSPCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -755,7 +755,7 @@ impl crate::Readable for LDOSPCTL {}
 impl crate::Writable for LDOSPCTL {}
 #[doc = "LDO Sleep Power Control"]
 pub mod ldospctl;
-#[doc = "LDO Deep-Sleep Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ldodpctl](ldodpctl) module"]
+#[doc = "LDO Deep-Sleep Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ldodpctl](ldodpctl) module"]
 pub type LDODPCTL = crate::Reg<u32, _LDODPCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -766,7 +766,7 @@ impl crate::Readable for LDODPCTL {}
 impl crate::Writable for LDODPCTL {}
 #[doc = "LDO Deep-Sleep Power Control"]
 pub mod ldodpctl;
-#[doc = "Watchdog Timer Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppwd](ppwd) module"]
+#[doc = "Watchdog Timer Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppwd](ppwd) module"]
 pub type PPWD = crate::Reg<u32, _PPWD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -775,7 +775,7 @@ pub struct _PPWD;
 impl crate::Readable for PPWD {}
 #[doc = "Watchdog Timer Peripheral Present"]
 pub mod ppwd;
-#[doc = "16/32-Bit General-Purpose Timer Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pptimer](pptimer) module"]
+#[doc = "16/32-Bit General-Purpose Timer Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pptimer](pptimer) module"]
 pub type PPTIMER = crate::Reg<u32, _PPTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -784,7 +784,7 @@ pub struct _PPTIMER;
 impl crate::Readable for PPTIMER {}
 #[doc = "16/32-Bit General-Purpose Timer Peripheral Present"]
 pub mod pptimer;
-#[doc = "General-Purpose Input/Output Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppgpio](ppgpio) module"]
+#[doc = "General-Purpose Input/Output Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppgpio](ppgpio) module"]
 pub type PPGPIO = crate::Reg<u32, _PPGPIO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -793,7 +793,7 @@ pub struct _PPGPIO;
 impl crate::Readable for PPGPIO {}
 #[doc = "General-Purpose Input/Output Peripheral Present"]
 pub mod ppgpio;
-#[doc = "Micro Direct Memory Access Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppdma](ppdma) module"]
+#[doc = "Micro Direct Memory Access Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppdma](ppdma) module"]
 pub type PPDMA = crate::Reg<u32, _PPDMA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -802,7 +802,7 @@ pub struct _PPDMA;
 impl crate::Readable for PPDMA {}
 #[doc = "Micro Direct Memory Access Peripheral Present"]
 pub mod ppdma;
-#[doc = "Hibernation Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pphib](pphib) module"]
+#[doc = "Hibernation Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pphib](pphib) module"]
 pub type PPHIB = crate::Reg<u32, _PPHIB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -811,7 +811,7 @@ pub struct _PPHIB;
 impl crate::Readable for PPHIB {}
 #[doc = "Hibernation Peripheral Present"]
 pub mod pphib;
-#[doc = "Universal Asynchronous Receiver/Transmitter Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppuart](ppuart) module"]
+#[doc = "Universal Asynchronous Receiver/Transmitter Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppuart](ppuart) module"]
 pub type PPUART = crate::Reg<u32, _PPUART>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -820,7 +820,7 @@ pub struct _PPUART;
 impl crate::Readable for PPUART {}
 #[doc = "Universal Asynchronous Receiver/Transmitter Peripheral Present"]
 pub mod ppuart;
-#[doc = "Synchronous Serial Interface Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppssi](ppssi) module"]
+#[doc = "Synchronous Serial Interface Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppssi](ppssi) module"]
 pub type PPSSI = crate::Reg<u32, _PPSSI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -829,7 +829,7 @@ pub struct _PPSSI;
 impl crate::Readable for PPSSI {}
 #[doc = "Synchronous Serial Interface Peripheral Present"]
 pub mod ppssi;
-#[doc = "Inter-Integrated Circuit Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppi2c](ppi2c) module"]
+#[doc = "Inter-Integrated Circuit Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppi2c](ppi2c) module"]
 pub type PPI2C = crate::Reg<u32, _PPI2C>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -838,7 +838,7 @@ pub struct _PPI2C;
 impl crate::Readable for PPI2C {}
 #[doc = "Inter-Integrated Circuit Peripheral Present"]
 pub mod ppi2c;
-#[doc = "Universal Serial Bus Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppusb](ppusb) module"]
+#[doc = "Universal Serial Bus Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppusb](ppusb) module"]
 pub type PPUSB = crate::Reg<u32, _PPUSB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -847,7 +847,7 @@ pub struct _PPUSB;
 impl crate::Readable for PPUSB {}
 #[doc = "Universal Serial Bus Peripheral Present"]
 pub mod ppusb;
-#[doc = "Controller Area Network Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppcan](ppcan) module"]
+#[doc = "Controller Area Network Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppcan](ppcan) module"]
 pub type PPCAN = crate::Reg<u32, _PPCAN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -856,7 +856,7 @@ pub struct _PPCAN;
 impl crate::Readable for PPCAN {}
 #[doc = "Controller Area Network Peripheral Present"]
 pub mod ppcan;
-#[doc = "Analog-to-Digital Converter Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppadc](ppadc) module"]
+#[doc = "Analog-to-Digital Converter Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppadc](ppadc) module"]
 pub type PPADC = crate::Reg<u32, _PPADC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -865,7 +865,7 @@ pub struct _PPADC;
 impl crate::Readable for PPADC {}
 #[doc = "Analog-to-Digital Converter Peripheral Present"]
 pub mod ppadc;
-#[doc = "Analog Comparator Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppacmp](ppacmp) module"]
+#[doc = "Analog Comparator Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppacmp](ppacmp) module"]
 pub type PPACMP = crate::Reg<u32, _PPACMP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -874,7 +874,7 @@ pub struct _PPACMP;
 impl crate::Readable for PPACMP {}
 #[doc = "Analog Comparator Peripheral Present"]
 pub mod ppacmp;
-#[doc = "Pulse Width Modulator Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pppwm](pppwm) module"]
+#[doc = "Pulse Width Modulator Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pppwm](pppwm) module"]
 pub type PPPWM = crate::Reg<u32, _PPPWM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -883,7 +883,7 @@ pub struct _PPPWM;
 impl crate::Readable for PPPWM {}
 #[doc = "Pulse Width Modulator Peripheral Present"]
 pub mod pppwm;
-#[doc = "Quadrature Encoder Interface Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppqei](ppqei) module"]
+#[doc = "Quadrature Encoder Interface Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppqei](ppqei) module"]
 pub type PPQEI = crate::Reg<u32, _PPQEI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -892,7 +892,7 @@ pub struct _PPQEI;
 impl crate::Readable for PPQEI {}
 #[doc = "Quadrature Encoder Interface Peripheral Present"]
 pub mod ppqei;
-#[doc = "EEPROM Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppeeprom](ppeeprom) module"]
+#[doc = "EEPROM Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppeeprom](ppeeprom) module"]
 pub type PPEEPROM = crate::Reg<u32, _PPEEPROM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -901,7 +901,7 @@ pub struct _PPEEPROM;
 impl crate::Readable for PPEEPROM {}
 #[doc = "EEPROM Peripheral Present"]
 pub mod ppeeprom;
-#[doc = "32/64-Bit Wide General-Purpose Timer Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppwtimer](ppwtimer) module"]
+#[doc = "32/64-Bit Wide General-Purpose Timer Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppwtimer](ppwtimer) module"]
 pub type PPWTIMER = crate::Reg<u32, _PPWTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -910,7 +910,7 @@ pub struct _PPWTIMER;
 impl crate::Readable for PPWTIMER {}
 #[doc = "32/64-Bit Wide General-Purpose Timer Peripheral Present"]
 pub mod ppwtimer;
-#[doc = "Watchdog Timer Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srwd](srwd) module"]
+#[doc = "Watchdog Timer Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srwd](srwd) module"]
 pub type SRWD = crate::Reg<u32, _SRWD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -921,7 +921,7 @@ impl crate::Readable for SRWD {}
 impl crate::Writable for SRWD {}
 #[doc = "Watchdog Timer Software Reset"]
 pub mod srwd;
-#[doc = "16/32-Bit General-Purpose Timer Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srtimer](srtimer) module"]
+#[doc = "16/32-Bit General-Purpose Timer Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srtimer](srtimer) module"]
 pub type SRTIMER = crate::Reg<u32, _SRTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -932,7 +932,7 @@ impl crate::Readable for SRTIMER {}
 impl crate::Writable for SRTIMER {}
 #[doc = "16/32-Bit General-Purpose Timer Software Reset"]
 pub mod srtimer;
-#[doc = "General-Purpose Input/Output Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srgpio](srgpio) module"]
+#[doc = "General-Purpose Input/Output Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srgpio](srgpio) module"]
 pub type SRGPIO = crate::Reg<u32, _SRGPIO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -943,7 +943,7 @@ impl crate::Readable for SRGPIO {}
 impl crate::Writable for SRGPIO {}
 #[doc = "General-Purpose Input/Output Software Reset"]
 pub mod srgpio;
-#[doc = "Micro Direct Memory Access Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srdma](srdma) module"]
+#[doc = "Micro Direct Memory Access Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srdma](srdma) module"]
 pub type SRDMA = crate::Reg<u32, _SRDMA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -954,7 +954,7 @@ impl crate::Readable for SRDMA {}
 impl crate::Writable for SRDMA {}
 #[doc = "Micro Direct Memory Access Software Reset"]
 pub mod srdma;
-#[doc = "Hibernation Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srhib](srhib) module"]
+#[doc = "Hibernation Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srhib](srhib) module"]
 pub type SRHIB = crate::Reg<u32, _SRHIB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -965,7 +965,7 @@ impl crate::Readable for SRHIB {}
 impl crate::Writable for SRHIB {}
 #[doc = "Hibernation Software Reset"]
 pub mod srhib;
-#[doc = "Universal Asynchronous Receiver/Transmitter Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sruart](sruart) module"]
+#[doc = "Universal Asynchronous Receiver/Transmitter Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sruart](sruart) module"]
 pub type SRUART = crate::Reg<u32, _SRUART>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -976,7 +976,7 @@ impl crate::Readable for SRUART {}
 impl crate::Writable for SRUART {}
 #[doc = "Universal Asynchronous Receiver/Transmitter Software Reset"]
 pub mod sruart;
-#[doc = "Synchronous Serial Interface Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srssi](srssi) module"]
+#[doc = "Synchronous Serial Interface Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srssi](srssi) module"]
 pub type SRSSI = crate::Reg<u32, _SRSSI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -987,7 +987,7 @@ impl crate::Readable for SRSSI {}
 impl crate::Writable for SRSSI {}
 #[doc = "Synchronous Serial Interface Software Reset"]
 pub mod srssi;
-#[doc = "Inter-Integrated Circuit Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sri2c](sri2c) module"]
+#[doc = "Inter-Integrated Circuit Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sri2c](sri2c) module"]
 pub type SRI2C = crate::Reg<u32, _SRI2C>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -998,7 +998,7 @@ impl crate::Readable for SRI2C {}
 impl crate::Writable for SRI2C {}
 #[doc = "Inter-Integrated Circuit Software Reset"]
 pub mod sri2c;
-#[doc = "Universal Serial Bus Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srusb](srusb) module"]
+#[doc = "Universal Serial Bus Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srusb](srusb) module"]
 pub type SRUSB = crate::Reg<u32, _SRUSB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1009,7 +1009,7 @@ impl crate::Readable for SRUSB {}
 impl crate::Writable for SRUSB {}
 #[doc = "Universal Serial Bus Software Reset"]
 pub mod srusb;
-#[doc = "Controller Area Network Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srcan](srcan) module"]
+#[doc = "Controller Area Network Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srcan](srcan) module"]
 pub type SRCAN = crate::Reg<u32, _SRCAN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1020,7 +1020,7 @@ impl crate::Readable for SRCAN {}
 impl crate::Writable for SRCAN {}
 #[doc = "Controller Area Network Software Reset"]
 pub mod srcan;
-#[doc = "Analog-to-Digital Converter Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sradc](sradc) module"]
+#[doc = "Analog-to-Digital Converter Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sradc](sradc) module"]
 pub type SRADC = crate::Reg<u32, _SRADC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1031,7 +1031,7 @@ impl crate::Readable for SRADC {}
 impl crate::Writable for SRADC {}
 #[doc = "Analog-to-Digital Converter Software Reset"]
 pub mod sradc;
-#[doc = "Analog Comparator Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sracmp](sracmp) module"]
+#[doc = "Analog Comparator Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sracmp](sracmp) module"]
 pub type SRACMP = crate::Reg<u32, _SRACMP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1042,7 +1042,7 @@ impl crate::Readable for SRACMP {}
 impl crate::Writable for SRACMP {}
 #[doc = "Analog Comparator Software Reset"]
 pub mod sracmp;
-#[doc = "Pulse Width Modulator Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srpwm](srpwm) module"]
+#[doc = "Pulse Width Modulator Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srpwm](srpwm) module"]
 pub type SRPWM = crate::Reg<u32, _SRPWM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1053,7 +1053,7 @@ impl crate::Readable for SRPWM {}
 impl crate::Writable for SRPWM {}
 #[doc = "Pulse Width Modulator Software Reset"]
 pub mod srpwm;
-#[doc = "Quadrature Encoder Interface Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srqei](srqei) module"]
+#[doc = "Quadrature Encoder Interface Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srqei](srqei) module"]
 pub type SRQEI = crate::Reg<u32, _SRQEI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1064,7 +1064,7 @@ impl crate::Readable for SRQEI {}
 impl crate::Writable for SRQEI {}
 #[doc = "Quadrature Encoder Interface Software Reset"]
 pub mod srqei;
-#[doc = "EEPROM Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sreeprom](sreeprom) module"]
+#[doc = "EEPROM Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sreeprom](sreeprom) module"]
 pub type SREEPROM = crate::Reg<u32, _SREEPROM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1075,7 +1075,7 @@ impl crate::Readable for SREEPROM {}
 impl crate::Writable for SREEPROM {}
 #[doc = "EEPROM Software Reset"]
 pub mod sreeprom;
-#[doc = "32/64-Bit Wide General-Purpose Timer Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srwtimer](srwtimer) module"]
+#[doc = "32/64-Bit Wide General-Purpose Timer Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srwtimer](srwtimer) module"]
 pub type SRWTIMER = crate::Reg<u32, _SRWTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1086,7 +1086,7 @@ impl crate::Readable for SRWTIMER {}
 impl crate::Writable for SRWTIMER {}
 #[doc = "32/64-Bit Wide General-Purpose Timer Software Reset"]
 pub mod srwtimer;
-#[doc = "Watchdog Timer Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcwd](rcgcwd) module"]
+#[doc = "Watchdog Timer Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcwd](rcgcwd) module"]
 pub type RCGCWD = crate::Reg<u32, _RCGCWD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1097,7 +1097,7 @@ impl crate::Readable for RCGCWD {}
 impl crate::Writable for RCGCWD {}
 #[doc = "Watchdog Timer Run Mode Clock Gating Control"]
 pub mod rcgcwd;
-#[doc = "16/32-Bit General-Purpose Timer Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgctimer](rcgctimer) module"]
+#[doc = "16/32-Bit General-Purpose Timer Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgctimer](rcgctimer) module"]
 pub type RCGCTIMER = crate::Reg<u32, _RCGCTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1108,7 +1108,7 @@ impl crate::Readable for RCGCTIMER {}
 impl crate::Writable for RCGCTIMER {}
 #[doc = "16/32-Bit General-Purpose Timer Run Mode Clock Gating Control"]
 pub mod rcgctimer;
-#[doc = "General-Purpose Input/Output Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcgpio](rcgcgpio) module"]
+#[doc = "General-Purpose Input/Output Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcgpio](rcgcgpio) module"]
 pub type RCGCGPIO = crate::Reg<u32, _RCGCGPIO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1119,7 +1119,7 @@ impl crate::Readable for RCGCGPIO {}
 impl crate::Writable for RCGCGPIO {}
 #[doc = "General-Purpose Input/Output Run Mode Clock Gating Control"]
 pub mod rcgcgpio;
-#[doc = "Micro Direct Memory Access Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcdma](rcgcdma) module"]
+#[doc = "Micro Direct Memory Access Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcdma](rcgcdma) module"]
 pub type RCGCDMA = crate::Reg<u32, _RCGCDMA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1130,7 +1130,7 @@ impl crate::Readable for RCGCDMA {}
 impl crate::Writable for RCGCDMA {}
 #[doc = "Micro Direct Memory Access Run Mode Clock Gating Control"]
 pub mod rcgcdma;
-#[doc = "Hibernation Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgchib](rcgchib) module"]
+#[doc = "Hibernation Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgchib](rcgchib) module"]
 pub type RCGCHIB = crate::Reg<u32, _RCGCHIB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1141,7 +1141,7 @@ impl crate::Readable for RCGCHIB {}
 impl crate::Writable for RCGCHIB {}
 #[doc = "Hibernation Run Mode Clock Gating Control"]
 pub mod rcgchib;
-#[doc = "Universal Asynchronous Receiver/Transmitter Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcuart](rcgcuart) module"]
+#[doc = "Universal Asynchronous Receiver/Transmitter Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcuart](rcgcuart) module"]
 pub type RCGCUART = crate::Reg<u32, _RCGCUART>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1152,7 +1152,7 @@ impl crate::Readable for RCGCUART {}
 impl crate::Writable for RCGCUART {}
 #[doc = "Universal Asynchronous Receiver/Transmitter Run Mode Clock Gating Control"]
 pub mod rcgcuart;
-#[doc = "Synchronous Serial Interface Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcssi](rcgcssi) module"]
+#[doc = "Synchronous Serial Interface Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcssi](rcgcssi) module"]
 pub type RCGCSSI = crate::Reg<u32, _RCGCSSI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1163,7 +1163,7 @@ impl crate::Readable for RCGCSSI {}
 impl crate::Writable for RCGCSSI {}
 #[doc = "Synchronous Serial Interface Run Mode Clock Gating Control"]
 pub mod rcgcssi;
-#[doc = "Inter-Integrated Circuit Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgci2c](rcgci2c) module"]
+#[doc = "Inter-Integrated Circuit Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgci2c](rcgci2c) module"]
 pub type RCGCI2C = crate::Reg<u32, _RCGCI2C>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1174,7 +1174,7 @@ impl crate::Readable for RCGCI2C {}
 impl crate::Writable for RCGCI2C {}
 #[doc = "Inter-Integrated Circuit Run Mode Clock Gating Control"]
 pub mod rcgci2c;
-#[doc = "Universal Serial Bus Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcusb](rcgcusb) module"]
+#[doc = "Universal Serial Bus Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcusb](rcgcusb) module"]
 pub type RCGCUSB = crate::Reg<u32, _RCGCUSB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1185,7 +1185,7 @@ impl crate::Readable for RCGCUSB {}
 impl crate::Writable for RCGCUSB {}
 #[doc = "Universal Serial Bus Run Mode Clock Gating Control"]
 pub mod rcgcusb;
-#[doc = "Controller Area Network Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgccan](rcgccan) module"]
+#[doc = "Controller Area Network Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgccan](rcgccan) module"]
 pub type RCGCCAN = crate::Reg<u32, _RCGCCAN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1196,7 +1196,7 @@ impl crate::Readable for RCGCCAN {}
 impl crate::Writable for RCGCCAN {}
 #[doc = "Controller Area Network Run Mode Clock Gating Control"]
 pub mod rcgccan;
-#[doc = "Analog-to-Digital Converter Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcadc](rcgcadc) module"]
+#[doc = "Analog-to-Digital Converter Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcadc](rcgcadc) module"]
 pub type RCGCADC = crate::Reg<u32, _RCGCADC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1207,7 +1207,7 @@ impl crate::Readable for RCGCADC {}
 impl crate::Writable for RCGCADC {}
 #[doc = "Analog-to-Digital Converter Run Mode Clock Gating Control"]
 pub mod rcgcadc;
-#[doc = "Analog Comparator Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcacmp](rcgcacmp) module"]
+#[doc = "Analog Comparator Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcacmp](rcgcacmp) module"]
 pub type RCGCACMP = crate::Reg<u32, _RCGCACMP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1218,7 +1218,7 @@ impl crate::Readable for RCGCACMP {}
 impl crate::Writable for RCGCACMP {}
 #[doc = "Analog Comparator Run Mode Clock Gating Control"]
 pub mod rcgcacmp;
-#[doc = "Pulse Width Modulator Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcpwm](rcgcpwm) module"]
+#[doc = "Pulse Width Modulator Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcpwm](rcgcpwm) module"]
 pub type RCGCPWM = crate::Reg<u32, _RCGCPWM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1229,7 +1229,7 @@ impl crate::Readable for RCGCPWM {}
 impl crate::Writable for RCGCPWM {}
 #[doc = "Pulse Width Modulator Run Mode Clock Gating Control"]
 pub mod rcgcpwm;
-#[doc = "Quadrature Encoder Interface Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcqei](rcgcqei) module"]
+#[doc = "Quadrature Encoder Interface Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcqei](rcgcqei) module"]
 pub type RCGCQEI = crate::Reg<u32, _RCGCQEI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1240,7 +1240,7 @@ impl crate::Readable for RCGCQEI {}
 impl crate::Writable for RCGCQEI {}
 #[doc = "Quadrature Encoder Interface Run Mode Clock Gating Control"]
 pub mod rcgcqei;
-#[doc = "EEPROM Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgceeprom](rcgceeprom) module"]
+#[doc = "EEPROM Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgceeprom](rcgceeprom) module"]
 pub type RCGCEEPROM = crate::Reg<u32, _RCGCEEPROM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1251,7 +1251,7 @@ impl crate::Readable for RCGCEEPROM {}
 impl crate::Writable for RCGCEEPROM {}
 #[doc = "EEPROM Run Mode Clock Gating Control"]
 pub mod rcgceeprom;
-#[doc = "32/64-Bit Wide General-Purpose Timer Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcwtimer](rcgcwtimer) module"]
+#[doc = "32/64-Bit Wide General-Purpose Timer Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcwtimer](rcgcwtimer) module"]
 pub type RCGCWTIMER = crate::Reg<u32, _RCGCWTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1262,7 +1262,7 @@ impl crate::Readable for RCGCWTIMER {}
 impl crate::Writable for RCGCWTIMER {}
 #[doc = "32/64-Bit Wide General-Purpose Timer Run Mode Clock Gating Control"]
 pub mod rcgcwtimer;
-#[doc = "Watchdog Timer Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcwd](scgcwd) module"]
+#[doc = "Watchdog Timer Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcwd](scgcwd) module"]
 pub type SCGCWD = crate::Reg<u32, _SCGCWD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1273,7 +1273,7 @@ impl crate::Readable for SCGCWD {}
 impl crate::Writable for SCGCWD {}
 #[doc = "Watchdog Timer Sleep Mode Clock Gating Control"]
 pub mod scgcwd;
-#[doc = "16/32-Bit General-Purpose Timer Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgctimer](scgctimer) module"]
+#[doc = "16/32-Bit General-Purpose Timer Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgctimer](scgctimer) module"]
 pub type SCGCTIMER = crate::Reg<u32, _SCGCTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1284,7 +1284,7 @@ impl crate::Readable for SCGCTIMER {}
 impl crate::Writable for SCGCTIMER {}
 #[doc = "16/32-Bit General-Purpose Timer Sleep Mode Clock Gating Control"]
 pub mod scgctimer;
-#[doc = "General-Purpose Input/Output Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcgpio](scgcgpio) module"]
+#[doc = "General-Purpose Input/Output Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcgpio](scgcgpio) module"]
 pub type SCGCGPIO = crate::Reg<u32, _SCGCGPIO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1295,7 +1295,7 @@ impl crate::Readable for SCGCGPIO {}
 impl crate::Writable for SCGCGPIO {}
 #[doc = "General-Purpose Input/Output Sleep Mode Clock Gating Control"]
 pub mod scgcgpio;
-#[doc = "Micro Direct Memory Access Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcdma](scgcdma) module"]
+#[doc = "Micro Direct Memory Access Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcdma](scgcdma) module"]
 pub type SCGCDMA = crate::Reg<u32, _SCGCDMA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1306,7 +1306,7 @@ impl crate::Readable for SCGCDMA {}
 impl crate::Writable for SCGCDMA {}
 #[doc = "Micro Direct Memory Access Sleep Mode Clock Gating Control"]
 pub mod scgcdma;
-#[doc = "Hibernation Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgchib](scgchib) module"]
+#[doc = "Hibernation Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgchib](scgchib) module"]
 pub type SCGCHIB = crate::Reg<u32, _SCGCHIB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1317,7 +1317,7 @@ impl crate::Readable for SCGCHIB {}
 impl crate::Writable for SCGCHIB {}
 #[doc = "Hibernation Sleep Mode Clock Gating Control"]
 pub mod scgchib;
-#[doc = "Universal Asynchronous Receiver/Transmitter Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcuart](scgcuart) module"]
+#[doc = "Universal Asynchronous Receiver/Transmitter Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcuart](scgcuart) module"]
 pub type SCGCUART = crate::Reg<u32, _SCGCUART>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1328,7 +1328,7 @@ impl crate::Readable for SCGCUART {}
 impl crate::Writable for SCGCUART {}
 #[doc = "Universal Asynchronous Receiver/Transmitter Sleep Mode Clock Gating Control"]
 pub mod scgcuart;
-#[doc = "Synchronous Serial Interface Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcssi](scgcssi) module"]
+#[doc = "Synchronous Serial Interface Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcssi](scgcssi) module"]
 pub type SCGCSSI = crate::Reg<u32, _SCGCSSI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1339,7 +1339,7 @@ impl crate::Readable for SCGCSSI {}
 impl crate::Writable for SCGCSSI {}
 #[doc = "Synchronous Serial Interface Sleep Mode Clock Gating Control"]
 pub mod scgcssi;
-#[doc = "Inter-Integrated Circuit Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgci2c](scgci2c) module"]
+#[doc = "Inter-Integrated Circuit Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgci2c](scgci2c) module"]
 pub type SCGCI2C = crate::Reg<u32, _SCGCI2C>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1350,7 +1350,7 @@ impl crate::Readable for SCGCI2C {}
 impl crate::Writable for SCGCI2C {}
 #[doc = "Inter-Integrated Circuit Sleep Mode Clock Gating Control"]
 pub mod scgci2c;
-#[doc = "Universal Serial Bus Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcusb](scgcusb) module"]
+#[doc = "Universal Serial Bus Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcusb](scgcusb) module"]
 pub type SCGCUSB = crate::Reg<u32, _SCGCUSB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1361,7 +1361,7 @@ impl crate::Readable for SCGCUSB {}
 impl crate::Writable for SCGCUSB {}
 #[doc = "Universal Serial Bus Sleep Mode Clock Gating Control"]
 pub mod scgcusb;
-#[doc = "Controller Area Network Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgccan](scgccan) module"]
+#[doc = "Controller Area Network Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgccan](scgccan) module"]
 pub type SCGCCAN = crate::Reg<u32, _SCGCCAN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1372,7 +1372,7 @@ impl crate::Readable for SCGCCAN {}
 impl crate::Writable for SCGCCAN {}
 #[doc = "Controller Area Network Sleep Mode Clock Gating Control"]
 pub mod scgccan;
-#[doc = "Analog-to-Digital Converter Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcadc](scgcadc) module"]
+#[doc = "Analog-to-Digital Converter Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcadc](scgcadc) module"]
 pub type SCGCADC = crate::Reg<u32, _SCGCADC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1383,7 +1383,7 @@ impl crate::Readable for SCGCADC {}
 impl crate::Writable for SCGCADC {}
 #[doc = "Analog-to-Digital Converter Sleep Mode Clock Gating Control"]
 pub mod scgcadc;
-#[doc = "Analog Comparator Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcacmp](scgcacmp) module"]
+#[doc = "Analog Comparator Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcacmp](scgcacmp) module"]
 pub type SCGCACMP = crate::Reg<u32, _SCGCACMP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1394,7 +1394,7 @@ impl crate::Readable for SCGCACMP {}
 impl crate::Writable for SCGCACMP {}
 #[doc = "Analog Comparator Sleep Mode Clock Gating Control"]
 pub mod scgcacmp;
-#[doc = "Pulse Width Modulator Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcpwm](scgcpwm) module"]
+#[doc = "Pulse Width Modulator Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcpwm](scgcpwm) module"]
 pub type SCGCPWM = crate::Reg<u32, _SCGCPWM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1405,7 +1405,7 @@ impl crate::Readable for SCGCPWM {}
 impl crate::Writable for SCGCPWM {}
 #[doc = "Pulse Width Modulator Sleep Mode Clock Gating Control"]
 pub mod scgcpwm;
-#[doc = "Quadrature Encoder Interface Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcqei](scgcqei) module"]
+#[doc = "Quadrature Encoder Interface Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcqei](scgcqei) module"]
 pub type SCGCQEI = crate::Reg<u32, _SCGCQEI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1416,7 +1416,7 @@ impl crate::Readable for SCGCQEI {}
 impl crate::Writable for SCGCQEI {}
 #[doc = "Quadrature Encoder Interface Sleep Mode Clock Gating Control"]
 pub mod scgcqei;
-#[doc = "EEPROM Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgceeprom](scgceeprom) module"]
+#[doc = "EEPROM Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgceeprom](scgceeprom) module"]
 pub type SCGCEEPROM = crate::Reg<u32, _SCGCEEPROM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1427,7 +1427,7 @@ impl crate::Readable for SCGCEEPROM {}
 impl crate::Writable for SCGCEEPROM {}
 #[doc = "EEPROM Sleep Mode Clock Gating Control"]
 pub mod scgceeprom;
-#[doc = "32/64-Bit Wide General-Purpose Timer Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcwtimer](scgcwtimer) module"]
+#[doc = "32/64-Bit Wide General-Purpose Timer Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcwtimer](scgcwtimer) module"]
 pub type SCGCWTIMER = crate::Reg<u32, _SCGCWTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1438,7 +1438,7 @@ impl crate::Readable for SCGCWTIMER {}
 impl crate::Writable for SCGCWTIMER {}
 #[doc = "32/64-Bit Wide General-Purpose Timer Sleep Mode Clock Gating Control"]
 pub mod scgcwtimer;
-#[doc = "Watchdog Timer Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcwd](dcgcwd) module"]
+#[doc = "Watchdog Timer Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcwd](dcgcwd) module"]
 pub type DCGCWD = crate::Reg<u32, _DCGCWD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1449,7 +1449,7 @@ impl crate::Readable for DCGCWD {}
 impl crate::Writable for DCGCWD {}
 #[doc = "Watchdog Timer Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcwd;
-#[doc = "16/32-Bit General-Purpose Timer Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgctimer](dcgctimer) module"]
+#[doc = "16/32-Bit General-Purpose Timer Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgctimer](dcgctimer) module"]
 pub type DCGCTIMER = crate::Reg<u32, _DCGCTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1460,7 +1460,7 @@ impl crate::Readable for DCGCTIMER {}
 impl crate::Writable for DCGCTIMER {}
 #[doc = "16/32-Bit General-Purpose Timer Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgctimer;
-#[doc = "General-Purpose Input/Output Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcgpio](dcgcgpio) module"]
+#[doc = "General-Purpose Input/Output Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcgpio](dcgcgpio) module"]
 pub type DCGCGPIO = crate::Reg<u32, _DCGCGPIO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1471,7 +1471,7 @@ impl crate::Readable for DCGCGPIO {}
 impl crate::Writable for DCGCGPIO {}
 #[doc = "General-Purpose Input/Output Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcgpio;
-#[doc = "Micro Direct Memory Access Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcdma](dcgcdma) module"]
+#[doc = "Micro Direct Memory Access Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcdma](dcgcdma) module"]
 pub type DCGCDMA = crate::Reg<u32, _DCGCDMA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1482,7 +1482,7 @@ impl crate::Readable for DCGCDMA {}
 impl crate::Writable for DCGCDMA {}
 #[doc = "Micro Direct Memory Access Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcdma;
-#[doc = "Hibernation Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgchib](dcgchib) module"]
+#[doc = "Hibernation Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgchib](dcgchib) module"]
 pub type DCGCHIB = crate::Reg<u32, _DCGCHIB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1493,7 +1493,7 @@ impl crate::Readable for DCGCHIB {}
 impl crate::Writable for DCGCHIB {}
 #[doc = "Hibernation Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgchib;
-#[doc = "Universal Asynchronous Receiver/Transmitter Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcuart](dcgcuart) module"]
+#[doc = "Universal Asynchronous Receiver/Transmitter Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcuart](dcgcuart) module"]
 pub type DCGCUART = crate::Reg<u32, _DCGCUART>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1504,7 +1504,7 @@ impl crate::Readable for DCGCUART {}
 impl crate::Writable for DCGCUART {}
 #[doc = "Universal Asynchronous Receiver/Transmitter Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcuart;
-#[doc = "Synchronous Serial Interface Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcssi](dcgcssi) module"]
+#[doc = "Synchronous Serial Interface Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcssi](dcgcssi) module"]
 pub type DCGCSSI = crate::Reg<u32, _DCGCSSI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1515,7 +1515,7 @@ impl crate::Readable for DCGCSSI {}
 impl crate::Writable for DCGCSSI {}
 #[doc = "Synchronous Serial Interface Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcssi;
-#[doc = "Inter-Integrated Circuit Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgci2c](dcgci2c) module"]
+#[doc = "Inter-Integrated Circuit Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgci2c](dcgci2c) module"]
 pub type DCGCI2C = crate::Reg<u32, _DCGCI2C>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1526,7 +1526,7 @@ impl crate::Readable for DCGCI2C {}
 impl crate::Writable for DCGCI2C {}
 #[doc = "Inter-Integrated Circuit Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgci2c;
-#[doc = "Universal Serial Bus Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcusb](dcgcusb) module"]
+#[doc = "Universal Serial Bus Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcusb](dcgcusb) module"]
 pub type DCGCUSB = crate::Reg<u32, _DCGCUSB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1537,7 +1537,7 @@ impl crate::Readable for DCGCUSB {}
 impl crate::Writable for DCGCUSB {}
 #[doc = "Universal Serial Bus Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcusb;
-#[doc = "Controller Area Network Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgccan](dcgccan) module"]
+#[doc = "Controller Area Network Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgccan](dcgccan) module"]
 pub type DCGCCAN = crate::Reg<u32, _DCGCCAN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1548,7 +1548,7 @@ impl crate::Readable for DCGCCAN {}
 impl crate::Writable for DCGCCAN {}
 #[doc = "Controller Area Network Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgccan;
-#[doc = "Analog-to-Digital Converter Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcadc](dcgcadc) module"]
+#[doc = "Analog-to-Digital Converter Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcadc](dcgcadc) module"]
 pub type DCGCADC = crate::Reg<u32, _DCGCADC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1559,7 +1559,7 @@ impl crate::Readable for DCGCADC {}
 impl crate::Writable for DCGCADC {}
 #[doc = "Analog-to-Digital Converter Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcadc;
-#[doc = "Analog Comparator Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcacmp](dcgcacmp) module"]
+#[doc = "Analog Comparator Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcacmp](dcgcacmp) module"]
 pub type DCGCACMP = crate::Reg<u32, _DCGCACMP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1570,7 +1570,7 @@ impl crate::Readable for DCGCACMP {}
 impl crate::Writable for DCGCACMP {}
 #[doc = "Analog Comparator Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcacmp;
-#[doc = "Pulse Width Modulator Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcpwm](dcgcpwm) module"]
+#[doc = "Pulse Width Modulator Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcpwm](dcgcpwm) module"]
 pub type DCGCPWM = crate::Reg<u32, _DCGCPWM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1581,7 +1581,7 @@ impl crate::Readable for DCGCPWM {}
 impl crate::Writable for DCGCPWM {}
 #[doc = "Pulse Width Modulator Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcpwm;
-#[doc = "Quadrature Encoder Interface Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcqei](dcgcqei) module"]
+#[doc = "Quadrature Encoder Interface Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcqei](dcgcqei) module"]
 pub type DCGCQEI = crate::Reg<u32, _DCGCQEI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1592,7 +1592,7 @@ impl crate::Readable for DCGCQEI {}
 impl crate::Writable for DCGCQEI {}
 #[doc = "Quadrature Encoder Interface Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcqei;
-#[doc = "EEPROM Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgceeprom](dcgceeprom) module"]
+#[doc = "EEPROM Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgceeprom](dcgceeprom) module"]
 pub type DCGCEEPROM = crate::Reg<u32, _DCGCEEPROM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1603,7 +1603,7 @@ impl crate::Readable for DCGCEEPROM {}
 impl crate::Writable for DCGCEEPROM {}
 #[doc = "EEPROM Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgceeprom;
-#[doc = "32/64-Bit Wide General-Purpose Timer Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcwtimer](dcgcwtimer) module"]
+#[doc = "32/64-Bit Wide General-Purpose Timer Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcwtimer](dcgcwtimer) module"]
 pub type DCGCWTIMER = crate::Reg<u32, _DCGCWTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1614,7 +1614,7 @@ impl crate::Readable for DCGCWTIMER {}
 impl crate::Writable for DCGCWTIMER {}
 #[doc = "32/64-Bit Wide General-Purpose Timer Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcwtimer;
-#[doc = "Watchdog Timer Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prwd](prwd) module"]
+#[doc = "Watchdog Timer Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prwd](prwd) module"]
 pub type PRWD = crate::Reg<u32, _PRWD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1623,7 +1623,7 @@ pub struct _PRWD;
 impl crate::Readable for PRWD {}
 #[doc = "Watchdog Timer Peripheral Ready"]
 pub mod prwd;
-#[doc = "16/32-Bit General-Purpose Timer Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prtimer](prtimer) module"]
+#[doc = "16/32-Bit General-Purpose Timer Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prtimer](prtimer) module"]
 pub type PRTIMER = crate::Reg<u32, _PRTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1632,7 +1632,7 @@ pub struct _PRTIMER;
 impl crate::Readable for PRTIMER {}
 #[doc = "16/32-Bit General-Purpose Timer Peripheral Ready"]
 pub mod prtimer;
-#[doc = "General-Purpose Input/Output Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prgpio](prgpio) module"]
+#[doc = "General-Purpose Input/Output Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prgpio](prgpio) module"]
 pub type PRGPIO = crate::Reg<u32, _PRGPIO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1641,7 +1641,7 @@ pub struct _PRGPIO;
 impl crate::Readable for PRGPIO {}
 #[doc = "General-Purpose Input/Output Peripheral Ready"]
 pub mod prgpio;
-#[doc = "Micro Direct Memory Access Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prdma](prdma) module"]
+#[doc = "Micro Direct Memory Access Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prdma](prdma) module"]
 pub type PRDMA = crate::Reg<u32, _PRDMA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1650,7 +1650,7 @@ pub struct _PRDMA;
 impl crate::Readable for PRDMA {}
 #[doc = "Micro Direct Memory Access Peripheral Ready"]
 pub mod prdma;
-#[doc = "Hibernation Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prhib](prhib) module"]
+#[doc = "Hibernation Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prhib](prhib) module"]
 pub type PRHIB = crate::Reg<u32, _PRHIB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1659,7 +1659,7 @@ pub struct _PRHIB;
 impl crate::Readable for PRHIB {}
 #[doc = "Hibernation Peripheral Ready"]
 pub mod prhib;
-#[doc = "Universal Asynchronous Receiver/Transmitter Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pruart](pruart) module"]
+#[doc = "Universal Asynchronous Receiver/Transmitter Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pruart](pruart) module"]
 pub type PRUART = crate::Reg<u32, _PRUART>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1668,7 +1668,7 @@ pub struct _PRUART;
 impl crate::Readable for PRUART {}
 #[doc = "Universal Asynchronous Receiver/Transmitter Peripheral Ready"]
 pub mod pruart;
-#[doc = "Synchronous Serial Interface Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prssi](prssi) module"]
+#[doc = "Synchronous Serial Interface Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prssi](prssi) module"]
 pub type PRSSI = crate::Reg<u32, _PRSSI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1677,7 +1677,7 @@ pub struct _PRSSI;
 impl crate::Readable for PRSSI {}
 #[doc = "Synchronous Serial Interface Peripheral Ready"]
 pub mod prssi;
-#[doc = "Inter-Integrated Circuit Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pri2c](pri2c) module"]
+#[doc = "Inter-Integrated Circuit Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pri2c](pri2c) module"]
 pub type PRI2C = crate::Reg<u32, _PRI2C>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1686,7 +1686,7 @@ pub struct _PRI2C;
 impl crate::Readable for PRI2C {}
 #[doc = "Inter-Integrated Circuit Peripheral Ready"]
 pub mod pri2c;
-#[doc = "Universal Serial Bus Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prusb](prusb) module"]
+#[doc = "Universal Serial Bus Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prusb](prusb) module"]
 pub type PRUSB = crate::Reg<u32, _PRUSB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1695,7 +1695,7 @@ pub struct _PRUSB;
 impl crate::Readable for PRUSB {}
 #[doc = "Universal Serial Bus Peripheral Ready"]
 pub mod prusb;
-#[doc = "Controller Area Network Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prcan](prcan) module"]
+#[doc = "Controller Area Network Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prcan](prcan) module"]
 pub type PRCAN = crate::Reg<u32, _PRCAN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1704,7 +1704,7 @@ pub struct _PRCAN;
 impl crate::Readable for PRCAN {}
 #[doc = "Controller Area Network Peripheral Ready"]
 pub mod prcan;
-#[doc = "Analog-to-Digital Converter Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pradc](pradc) module"]
+#[doc = "Analog-to-Digital Converter Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pradc](pradc) module"]
 pub type PRADC = crate::Reg<u32, _PRADC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1713,7 +1713,7 @@ pub struct _PRADC;
 impl crate::Readable for PRADC {}
 #[doc = "Analog-to-Digital Converter Peripheral Ready"]
 pub mod pradc;
-#[doc = "Analog Comparator Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pracmp](pracmp) module"]
+#[doc = "Analog Comparator Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pracmp](pracmp) module"]
 pub type PRACMP = crate::Reg<u32, _PRACMP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1722,7 +1722,7 @@ pub struct _PRACMP;
 impl crate::Readable for PRACMP {}
 #[doc = "Analog Comparator Peripheral Ready"]
 pub mod pracmp;
-#[doc = "Pulse Width Modulator Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prpwm](prpwm) module"]
+#[doc = "Pulse Width Modulator Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prpwm](prpwm) module"]
 pub type PRPWM = crate::Reg<u32, _PRPWM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1731,7 +1731,7 @@ pub struct _PRPWM;
 impl crate::Readable for PRPWM {}
 #[doc = "Pulse Width Modulator Peripheral Ready"]
 pub mod prpwm;
-#[doc = "Quadrature Encoder Interface Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prqei](prqei) module"]
+#[doc = "Quadrature Encoder Interface Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prqei](prqei) module"]
 pub type PRQEI = crate::Reg<u32, _PRQEI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1740,7 +1740,7 @@ pub struct _PRQEI;
 impl crate::Readable for PRQEI {}
 #[doc = "Quadrature Encoder Interface Peripheral Ready"]
 pub mod prqei;
-#[doc = "EEPROM Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [preeprom](preeprom) module"]
+#[doc = "EEPROM Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [preeprom](preeprom) module"]
 pub type PREEPROM = crate::Reg<u32, _PREEPROM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1749,7 +1749,7 @@ pub struct _PREEPROM;
 impl crate::Readable for PREEPROM {}
 #[doc = "EEPROM Peripheral Ready"]
 pub mod preeprom;
-#[doc = "32/64-Bit Wide General-Purpose Timer Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prwtimer](prwtimer) module"]
+#[doc = "32/64-Bit Wide General-Purpose Timer Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prwtimer](prwtimer) module"]
 pub type PRWTIMER = crate::Reg<u32, _PRWTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/sysctl/dc0.rs
+++ b/crates/tm4c123x/src/sysctl/dc0.rs
@@ -2,37 +2,29 @@
 pub type R = crate::R<u32, super::DC0>;
 #[doc = "Flash Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u16)]
 pub enum FLASHSZ_A {
     #[doc = "3: 8 KB of Flash"]
-    _8KB,
+    _8KB = 3,
     #[doc = "7: 16 KB of Flash"]
-    _16KB,
+    _16KB = 7,
     #[doc = "15: 32 KB of Flash"]
-    _32KB,
+    _32KB = 15,
     #[doc = "31: 64 KB of Flash"]
-    _64KB,
+    _64KB = 31,
     #[doc = "47: 96 KB of Flash"]
-    _96KB,
+    _96KB = 47,
     #[doc = "63: 128 KB of Flash"]
-    _128K,
+    _128K = 63,
     #[doc = "95: 192 KB of Flash"]
-    _192K,
+    _192K = 95,
     #[doc = "127: 256 KB of Flash"]
-    _256K,
+    _256K = 127,
 }
 impl From<FLASHSZ_A> for u16 {
     #[inline(always)]
     fn from(variant: FLASHSZ_A) -> Self {
-        match variant {
-            FLASHSZ_A::_8KB => 3,
-            FLASHSZ_A::_16KB => 7,
-            FLASHSZ_A::_32KB => 15,
-            FLASHSZ_A::_64KB => 31,
-            FLASHSZ_A::_96KB => 47,
-            FLASHSZ_A::_128K => 63,
-            FLASHSZ_A::_192K => 95,
-            FLASHSZ_A::_256K => 127,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `FLASHSZ`"]
@@ -97,40 +89,31 @@ impl FLASHSZ_R {
 }
 #[doc = "SRAM Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u16)]
 pub enum SRAMSZ_A {
     #[doc = "7: 2 KB of SRAM"]
-    _2KB,
+    _2KB = 7,
     #[doc = "15: 4 KB of SRAM"]
-    _4KB,
+    _4KB = 15,
     #[doc = "23: 6 KB of SRAM"]
-    _6KB,
+    _6KB = 23,
     #[doc = "31: 8 KB of SRAM"]
-    _8KB,
+    _8KB = 31,
     #[doc = "47: 12 KB of SRAM"]
-    _12KB,
+    _12KB = 47,
     #[doc = "63: 16 KB of SRAM"]
-    _16KB,
+    _16KB = 63,
     #[doc = "79: 20 KB of SRAM"]
-    _20KB,
+    _20KB = 79,
     #[doc = "95: 24 KB of SRAM"]
-    _24KB,
+    _24KB = 95,
     #[doc = "127: 32 KB of SRAM"]
-    _32KB,
+    _32KB = 127,
 }
 impl From<SRAMSZ_A> for u16 {
     #[inline(always)]
     fn from(variant: SRAMSZ_A) -> Self {
-        match variant {
-            SRAMSZ_A::_2KB => 7,
-            SRAMSZ_A::_4KB => 15,
-            SRAMSZ_A::_6KB => 23,
-            SRAMSZ_A::_8KB => 31,
-            SRAMSZ_A::_12KB => 47,
-            SRAMSZ_A::_16KB => 63,
-            SRAMSZ_A::_20KB => 79,
-            SRAMSZ_A::_24KB => 95,
-            SRAMSZ_A::_32KB => 127,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SRAMSZ`"]

--- a/crates/tm4c123x/src/sysctl/dc1.rs
+++ b/crates/tm4c123x/src/sysctl/dc1.rs
@@ -18,25 +18,21 @@ pub type HIB_R = crate::R<bool, bool>;
 pub type MPU_R = crate::R<bool, bool>;
 #[doc = "Max ADC0 Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ADC0SPD_A {
     #[doc = "0: 125K samples/second"]
-    _125K,
+    _125K = 0,
     #[doc = "1: 250K samples/second"]
-    _250K,
+    _250K = 1,
     #[doc = "2: 500K samples/second"]
-    _500K,
+    _500K = 2,
     #[doc = "3: 1M samples/second"]
-    _1M,
+    _1M = 3,
 }
 impl From<ADC0SPD_A> for u8 {
     #[inline(always)]
     fn from(variant: ADC0SPD_A) -> Self {
-        match variant {
-            ADC0SPD_A::_125K => 0,
-            ADC0SPD_A::_250K => 1,
-            ADC0SPD_A::_500K => 2,
-            ADC0SPD_A::_1M => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ADC0SPD`"]
@@ -76,25 +72,21 @@ impl ADC0SPD_R {
 }
 #[doc = "Max ADC1 Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ADC1SPD_A {
     #[doc = "0: 125K samples/second"]
-    _125K,
+    _125K = 0,
     #[doc = "1: 250K samples/second"]
-    _250K,
+    _250K = 1,
     #[doc = "2: 500K samples/second"]
-    _500K,
+    _500K = 2,
     #[doc = "3: 1M samples/second"]
-    _1M,
+    _1M = 3,
 }
 impl From<ADC1SPD_A> for u8 {
     #[inline(always)]
     fn from(variant: ADC1SPD_A) -> Self {
-        match variant {
-            ADC1SPD_A::_125K => 0,
-            ADC1SPD_A::_250K => 1,
-            ADC1SPD_A::_500K => 2,
-            ADC1SPD_A::_1M => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ADC1SPD`"]
@@ -134,28 +126,23 @@ impl ADC1SPD_R {
 }
 #[doc = "System Clock Divider\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MINSYSDIV_A {
     #[doc = "2: Specifies an 80-MHz CPU clock with a PLL divider of 2.5"]
-    _80,
+    _80 = 2,
     #[doc = "3: Specifies a 50-MHz CPU clock with a PLL divider of 4"]
-    _50,
+    _50 = 3,
     #[doc = "4: Specifies a 40-MHz CPU clock with a PLL divider of 5"]
-    _40,
+    _40 = 4,
     #[doc = "7: Specifies a 25-MHz clock with a PLL divider of 8"]
-    _25,
+    _25 = 7,
     #[doc = "9: Specifies a 20-MHz clock with a PLL divider of 10"]
-    _20,
+    _20 = 9,
 }
 impl From<MINSYSDIV_A> for u8 {
     #[inline(always)]
     fn from(variant: MINSYSDIV_A) -> Self {
-        match variant {
-            MINSYSDIV_A::_80 => 2,
-            MINSYSDIV_A::_50 => 3,
-            MINSYSDIV_A::_40 => 4,
-            MINSYSDIV_A::_25 => 7,
-            MINSYSDIV_A::_20 => 9,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MINSYSDIV`"]

--- a/crates/tm4c123x/src/sysctl/dc6.rs
+++ b/crates/tm4c123x/src/sysctl/dc6.rs
@@ -2,22 +2,19 @@
 pub type R = crate::R<u32, super::DC6>;
 #[doc = "USB Module 0 Present\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum USB0_A {
     #[doc = "1: USB0 is Device Only"]
-    DEV,
+    DEV = 1,
     #[doc = "2: USB is Device or Host"]
-    HOSTDEV,
+    HOSTDEV = 2,
     #[doc = "3: USB0 is OTG"]
-    OTG,
+    OTG = 3,
 }
 impl From<USB0_A> for u8 {
     #[inline(always)]
     fn from(variant: USB0_A) -> Self {
-        match variant {
-            USB0_A::DEV => 1,
-            USB0_A::HOSTDEV => 2,
-            USB0_A::OTG => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `USB0`"]

--- a/crates/tm4c123x/src/sysctl/did0.rs
+++ b/crates/tm4c123x/src/sysctl/did0.rs
@@ -2,22 +2,19 @@
 pub type R = crate::R<u32, super::DID0>;
 #[doc = "Minor Revision\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MIN_A {
     #[doc = "0: Initial device, or a major revision update"]
-    _0,
+    _0 = 0,
     #[doc = "1: First metal layer change"]
-    _1,
+    _1 = 1,
     #[doc = "2: Second metal layer change"]
-    _2,
+    _2 = 2,
 }
 impl From<MIN_A> for u8 {
     #[inline(always)]
     fn from(variant: MIN_A) -> Self {
-        match variant {
-            MIN_A::_0 => 0,
-            MIN_A::_1 => 1,
-            MIN_A::_2 => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MIN`"]
@@ -52,22 +49,19 @@ impl MIN_R {
 }
 #[doc = "Major Revision\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MAJ_A {
     #[doc = "0: Revision A (initial device)"]
-    REVA,
+    REVA = 0,
     #[doc = "1: Revision B (first base layer revision)"]
-    REVB,
+    REVB = 1,
     #[doc = "2: Revision C (second base layer revision)"]
-    REVC,
+    REVC = 2,
 }
 impl From<MAJ_A> for u8 {
     #[inline(always)]
     fn from(variant: MAJ_A) -> Self {
-        match variant {
-            MAJ_A::REVA => 0,
-            MAJ_A::REVB => 1,
-            MAJ_A::REVC => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MAJ`"]
@@ -102,16 +96,15 @@ impl MAJ_R {
 }
 #[doc = "Device Class\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CLASS_A {
     #[doc = "5: Tiva TM4C123x and TM4E123x microcontrollers"]
-    TM4C123,
+    TM4C123 = 5,
 }
 impl From<CLASS_A> for u8 {
     #[inline(always)]
     fn from(variant: CLASS_A) -> Self {
-        match variant {
-            CLASS_A::TM4C123 => 5,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CLASS`"]
@@ -134,16 +127,15 @@ impl CLASS_R {
 }
 #[doc = "DID0 Version\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum VER_A {
     #[doc = "1: Second version of the DID0 register format."]
-    _1,
+    _1 = 1,
 }
 impl From<VER_A> for u8 {
     #[inline(always)]
     fn from(variant: VER_A) -> Self {
-        match variant {
-            VER_A::_1 => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `VER`"]

--- a/crates/tm4c123x/src/sysctl/did1.rs
+++ b/crates/tm4c123x/src/sysctl/did1.rs
@@ -2,22 +2,19 @@
 pub type R = crate::R<u32, super::DID1>;
 #[doc = "Qualification Status\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum QUAL_A {
     #[doc = "0: Engineering Sample (unqualified)"]
-    ES,
+    ES = 0,
     #[doc = "1: Pilot Production (unqualified)"]
-    PP,
+    PP = 1,
     #[doc = "2: Fully Qualified"]
-    FQ,
+    FQ = 2,
 }
 impl From<QUAL_A> for u8 {
     #[inline(always)]
     fn from(variant: QUAL_A) -> Self {
-        match variant {
-            QUAL_A::ES => 0,
-            QUAL_A::PP => 1,
-            QUAL_A::FQ => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `QUAL`"]
@@ -54,19 +51,17 @@ impl QUAL_R {
 pub type ROHS_R = crate::R<bool, bool>;
 #[doc = "Package Type\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PKG_A {
     #[doc = "1: QFP package"]
-    QFP,
+    QFP = 1,
     #[doc = "2: BGA package"]
-    BGA,
+    BGA = 2,
 }
 impl From<PKG_A> for u8 {
     #[inline(always)]
     fn from(variant: PKG_A) -> Self {
-        match variant {
-            PKG_A::QFP => 1,
-            PKG_A::BGA => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PKG`"]
@@ -95,22 +90,19 @@ impl PKG_R {
 }
 #[doc = "Temperature Range\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TEMP_A {
     #[doc = "1: Industrial temperature range"]
-    I,
+    I = 1,
     #[doc = "2: Extended temperature range"]
-    E,
+    E = 2,
     #[doc = "3: Available in both industrial temperature range (-40C to 85C) and extended temperature range (-40C to 105C) devices. See"]
-    IE,
+    IE = 3,
 }
 impl From<TEMP_A> for u8 {
     #[inline(always)]
     fn from(variant: TEMP_A) -> Self {
-        match variant {
-            TEMP_A::I => 1,
-            TEMP_A::E => 2,
-            TEMP_A::IE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TEMP`"]
@@ -145,28 +137,23 @@ impl TEMP_R {
 }
 #[doc = "Package Pin Count\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PINCNT_A {
     #[doc = "2: 100-pin LQFP package"]
-    _100,
+    _100 = 2,
     #[doc = "3: 64-pin LQFP package"]
-    _64,
+    _64 = 3,
     #[doc = "4: 144-pin LQFP package"]
-    _144,
+    _144 = 4,
     #[doc = "5: 157-pin BGA package"]
-    _157,
+    _157 = 5,
     #[doc = "6: 128-pin TQFP package"]
-    _128,
+    _128 = 6,
 }
 impl From<PINCNT_A> for u8 {
     #[inline(always)]
     fn from(variant: PINCNT_A) -> Self {
-        match variant {
-            PINCNT_A::_100 => 2,
-            PINCNT_A::_64 => 3,
-            PINCNT_A::_144 => 4,
-            PINCNT_A::_157 => 5,
-            PINCNT_A::_128 => 6,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PINCNT`"]

--- a/crates/tm4c123x/src/sysctl/dslpclkcfg.rs
+++ b/crates/tm4c123x/src/sysctl/dslpclkcfg.rs
@@ -36,25 +36,21 @@ impl<'a> PIOSCPD_W<'a> {
 }
 #[doc = "Clock Source\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum O_A {
     #[doc = "0: MOSC"]
-    IGN,
+    IGN = 0,
     #[doc = "1: PIOSC"]
-    IO,
+    IO = 1,
     #[doc = "3: LFIOSC"]
-    _30,
+    _30 = 3,
     #[doc = "7: 32.768 kHz"]
-    _32,
+    _32 = 7,
 }
 impl From<O_A> for u8 {
     #[inline(always)]
     fn from(variant: O_A) -> Self {
-        match variant {
-            O_A::IGN => 0,
-            O_A::IO => 1,
-            O_A::_30 => 3,
-            O_A::_32 => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `O`"]

--- a/crates/tm4c123x/src/sysctl/dslppwrcfg.rs
+++ b/crates/tm4c123x/src/sysctl/dslppwrcfg.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::DSLPPWRCFG {
 }
 #[doc = "SRAM Power Modes\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SRAMPM_A {
     #[doc = "0: Active Mode"]
-    NRM,
+    NRM = 0,
     #[doc = "1: Standby Mode"]
-    SBY,
+    SBY = 1,
     #[doc = "3: Low Power Mode"]
-    LP,
+    LP = 3,
 }
 impl From<SRAMPM_A> for u8 {
     #[inline(always)]
     fn from(variant: SRAMPM_A) -> Self {
-        match variant {
-            SRAMPM_A::NRM => 0,
-            SRAMPM_A::SBY => 1,
-            SRAMPM_A::LP => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SRAMPM`"]
@@ -94,19 +91,17 @@ impl<'a> SRAMPM_W<'a> {
 }
 #[doc = "Flash Power Modes\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum FLASHPM_A {
     #[doc = "0: Active Mode"]
-    NRM,
+    NRM = 0,
     #[doc = "2: Low Power Mode"]
-    SLP,
+    SLP = 2,
 }
 impl From<FLASHPM_A> for u8 {
     #[inline(always)]
     fn from(variant: FLASHPM_A) -> Self {
-        match variant {
-            FLASHPM_A::NRM => 0,
-            FLASHPM_A::SLP => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `FLASHPM`"]

--- a/crates/tm4c123x/src/sysctl/ldodpctl.rs
+++ b/crates/tm4c123x/src/sysctl/ldodpctl.rs
@@ -12,34 +12,27 @@ impl crate::ResetValue for super::LDODPCTL {
 }
 #[doc = "LDO Output Voltage\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum VLDO_A {
     #[doc = "18: 0.90 V"]
-    _0_90V,
+    _0_90V = 18,
     #[doc = "19: 0.95 V"]
-    _0_95V,
+    _0_95V = 19,
     #[doc = "20: 1.00 V"]
-    _1_00V,
+    _1_00V = 20,
     #[doc = "21: 1.05 V"]
-    _1_05V,
+    _1_05V = 21,
     #[doc = "22: 1.10 V"]
-    _1_10V,
+    _1_10V = 22,
     #[doc = "23: 1.15 V"]
-    _1_15V,
+    _1_15V = 23,
     #[doc = "24: 1.20 V"]
-    _1_20V,
+    _1_20V = 24,
 }
 impl From<VLDO_A> for u8 {
     #[inline(always)]
     fn from(variant: VLDO_A) -> Self {
-        match variant {
-            VLDO_A::_0_90V => 18,
-            VLDO_A::_0_95V => 19,
-            VLDO_A::_1_00V => 20,
-            VLDO_A::_1_05V => 21,
-            VLDO_A::_1_10V => 22,
-            VLDO_A::_1_15V => 23,
-            VLDO_A::_1_20V => 24,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `VLDO`"]

--- a/crates/tm4c123x/src/sysctl/ldospctl.rs
+++ b/crates/tm4c123x/src/sysctl/ldospctl.rs
@@ -12,34 +12,27 @@ impl crate::ResetValue for super::LDOSPCTL {
 }
 #[doc = "LDO Output Voltage\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum VLDO_A {
     #[doc = "18: 0.90 V"]
-    _0_90V,
+    _0_90V = 18,
     #[doc = "19: 0.95 V"]
-    _0_95V,
+    _0_95V = 19,
     #[doc = "20: 1.00 V"]
-    _1_00V,
+    _1_00V = 20,
     #[doc = "21: 1.05 V"]
-    _1_05V,
+    _1_05V = 21,
     #[doc = "22: 1.10 V"]
-    _1_10V,
+    _1_10V = 22,
     #[doc = "23: 1.15 V"]
-    _1_15V,
+    _1_15V = 23,
     #[doc = "24: 1.20 V"]
-    _1_20V,
+    _1_20V = 24,
 }
 impl From<VLDO_A> for u8 {
     #[inline(always)]
     fn from(variant: VLDO_A) -> Self {
-        match variant {
-            VLDO_A::_0_90V => 18,
-            VLDO_A::_0_95V => 19,
-            VLDO_A::_1_00V => 20,
-            VLDO_A::_1_05V => 21,
-            VLDO_A::_1_10V => 22,
-            VLDO_A::_1_15V => 23,
-            VLDO_A::_1_20V => 24,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `VLDO`"]

--- a/crates/tm4c123x/src/sysctl/pioscstat.rs
+++ b/crates/tm4c123x/src/sysctl/pioscstat.rs
@@ -4,22 +4,19 @@ pub type R = crate::R<u32, super::PIOSCSTAT>;
 pub type CT_R = crate::R<u8, u8>;
 #[doc = "Calibration Result\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CR_A {
     #[doc = "0: Calibration has not been attempted"]
-    CRNONE,
+    CRNONE = 0,
     #[doc = "1: The last calibration operation completed to meet 1% accuracy"]
-    CRPASS,
+    CRPASS = 1,
     #[doc = "2: The last calibration operation failed to meet 1% accuracy"]
-    CRFAIL,
+    CRFAIL = 2,
 }
 impl From<CR_A> for u8 {
     #[inline(always)]
     fn from(variant: CR_A) -> Self {
-        match variant {
-            CR_A::CRNONE => 0,
-            CR_A::CRPASS => 1,
-            CR_A::CRFAIL => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CR`"]

--- a/crates/tm4c123x/src/sysctl/rcc.rs
+++ b/crates/tm4c123x/src/sysctl/rcc.rs
@@ -36,25 +36,21 @@ impl<'a> MOSCDIS_W<'a> {
 }
 #[doc = "Oscillator Source\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum OSCSRC_A {
     #[doc = "0: MOSC"]
-    MAIN,
+    MAIN = 0,
     #[doc = "1: IOSC"]
-    INT,
+    INT = 1,
     #[doc = "2: IOSC/4"]
-    INT4,
+    INT4 = 2,
     #[doc = "3: LFIOSC"]
-    _30,
+    _30 = 3,
 }
 impl From<OSCSRC_A> for u8 {
     #[inline(always)]
     fn from(variant: OSCSRC_A) -> Self {
-        match variant {
-            OSCSRC_A::MAIN => 0,
-            OSCSRC_A::INT => 1,
-            OSCSRC_A::INT4 => 2,
-            OSCSRC_A::_30 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `OSCSRC`"]
@@ -133,76 +129,55 @@ impl<'a> OSCSRC_W<'a> {
 }
 #[doc = "Crystal Value\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum XTAL_A {
     #[doc = "6: 4 MHz"]
-    _4MHZ,
+    _4MHZ = 6,
     #[doc = "7: 4.096 MHz"]
-    _4_09MHZ,
+    _4_09MHZ = 7,
     #[doc = "8: 4.9152 MHz"]
-    _4_91MHZ,
+    _4_91MHZ = 8,
     #[doc = "9: 5 MHz"]
-    _5MHZ,
+    _5MHZ = 9,
     #[doc = "10: 5.12 MHz"]
-    _5_12MHZ,
+    _5_12MHZ = 10,
     #[doc = "11: 6 MHz"]
-    _6MHZ,
+    _6MHZ = 11,
     #[doc = "12: 6.144 MHz"]
-    _6_14MHZ,
+    _6_14MHZ = 12,
     #[doc = "13: 7.3728 MHz"]
-    _7_37MHZ,
+    _7_37MHZ = 13,
     #[doc = "14: 8 MHz"]
-    _8MHZ,
+    _8MHZ = 14,
     #[doc = "15: 8.192 MHz"]
-    _8_19MHZ,
+    _8_19MHZ = 15,
     #[doc = "16: 10 MHz"]
-    _10MHZ,
+    _10MHZ = 16,
     #[doc = "17: 12 MHz"]
-    _12MHZ,
+    _12MHZ = 17,
     #[doc = "18: 12.288 MHz"]
-    _12_2MHZ,
+    _12_2MHZ = 18,
     #[doc = "19: 13.56 MHz"]
-    _13_5MHZ,
+    _13_5MHZ = 19,
     #[doc = "20: 14.31818 MHz"]
-    _14_3MHZ,
+    _14_3MHZ = 20,
     #[doc = "21: 16 MHz"]
-    _16MHZ,
+    _16MHZ = 21,
     #[doc = "22: 16.384 MHz"]
-    _16_3MHZ,
+    _16_3MHZ = 22,
     #[doc = "23: 18.0 MHz (USB)"]
-    _18MHZ,
+    _18MHZ = 23,
     #[doc = "24: 20.0 MHz (USB)"]
-    _20MHZ,
+    _20MHZ = 24,
     #[doc = "25: 24.0 MHz (USB)"]
-    _24MHZ,
+    _24MHZ = 25,
     #[doc = "26: 25.0 MHz (USB)"]
-    _25MHZ,
+    _25MHZ = 26,
 }
 impl From<XTAL_A> for u8 {
     #[inline(always)]
     fn from(variant: XTAL_A) -> Self {
-        match variant {
-            XTAL_A::_4MHZ => 6,
-            XTAL_A::_4_09MHZ => 7,
-            XTAL_A::_4_91MHZ => 8,
-            XTAL_A::_5MHZ => 9,
-            XTAL_A::_5_12MHZ => 10,
-            XTAL_A::_6MHZ => 11,
-            XTAL_A::_6_14MHZ => 12,
-            XTAL_A::_7_37MHZ => 13,
-            XTAL_A::_8MHZ => 14,
-            XTAL_A::_8_19MHZ => 15,
-            XTAL_A::_10MHZ => 16,
-            XTAL_A::_12MHZ => 17,
-            XTAL_A::_12_2MHZ => 18,
-            XTAL_A::_13_5MHZ => 19,
-            XTAL_A::_14_3MHZ => 20,
-            XTAL_A::_16MHZ => 21,
-            XTAL_A::_16_3MHZ => 22,
-            XTAL_A::_18MHZ => 23,
-            XTAL_A::_20MHZ => 24,
-            XTAL_A::_24MHZ => 25,
-            XTAL_A::_25MHZ => 26,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `XTAL`"]
@@ -515,31 +490,25 @@ impl<'a> PWRDN_W<'a> {
 }
 #[doc = "PWM Unit Clock Divisor\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PWMDIV_A {
     #[doc = "0: PWM clock /2"]
-    _2,
+    _2 = 0,
     #[doc = "1: PWM clock /4"]
-    _4,
+    _4 = 1,
     #[doc = "2: PWM clock /8"]
-    _8,
+    _8 = 2,
     #[doc = "3: PWM clock /16"]
-    _16,
+    _16 = 3,
     #[doc = "4: PWM clock /32"]
-    _32,
+    _32 = 4,
     #[doc = "5: PWM clock /64"]
-    _64,
+    _64 = 5,
 }
 impl From<PWMDIV_A> for u8 {
     #[inline(always)]
     fn from(variant: PWMDIV_A) -> Self {
-        match variant {
-            PWMDIV_A::_2 => 0,
-            PWMDIV_A::_4 => 1,
-            PWMDIV_A::_8 => 2,
-            PWMDIV_A::_16 => 3,
-            PWMDIV_A::_32 => 4,
-            PWMDIV_A::_64 => 5,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PWMDIV`"]

--- a/crates/tm4c123x/src/sysctl/rcc2.rs
+++ b/crates/tm4c123x/src/sysctl/rcc2.rs
@@ -12,28 +12,23 @@ impl crate::ResetValue for super::RCC2 {
 }
 #[doc = "Oscillator Source 2\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum OSCSRC2_A {
     #[doc = "0: MOSC"]
-    MO,
+    MO = 0,
     #[doc = "1: PIOSC"]
-    IO,
+    IO = 1,
     #[doc = "2: PIOSC/4"]
-    IO4,
+    IO4 = 2,
     #[doc = "3: LFIOSC"]
-    _30,
+    _30 = 3,
     #[doc = "7: 32.768 kHz"]
-    _32,
+    _32 = 7,
 }
 impl From<OSCSRC2_A> for u8 {
     #[inline(always)]
     fn from(variant: OSCSRC2_A) -> Self {
-        match variant {
-            OSCSRC2_A::MO => 0,
-            OSCSRC2_A::IO => 1,
-            OSCSRC2_A::IO4 => 2,
-            OSCSRC2_A::_30 => 3,
-            OSCSRC2_A::_32 => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `OSCSRC2`"]

--- a/crates/tm4c123x/src/sysctl/rcgc0.rs
+++ b/crates/tm4c123x/src/sysctl/rcgc0.rs
@@ -6,25 +6,21 @@ pub type WDT0_R = crate::R<bool, bool>;
 pub type HIB_R = crate::R<bool, bool>;
 #[doc = "ADC0 Sample Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ADC0SPD_A {
     #[doc = "0: 125K samples/second"]
-    _125K,
+    _125K = 0,
     #[doc = "1: 250K samples/second"]
-    _250K,
+    _250K = 1,
     #[doc = "2: 500K samples/second"]
-    _500K,
+    _500K = 2,
     #[doc = "3: 1M samples/second"]
-    _1M,
+    _1M = 3,
 }
 impl From<ADC0SPD_A> for u8 {
     #[inline(always)]
     fn from(variant: ADC0SPD_A) -> Self {
-        match variant {
-            ADC0SPD_A::_125K => 0,
-            ADC0SPD_A::_250K => 1,
-            ADC0SPD_A::_500K => 2,
-            ADC0SPD_A::_1M => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ADC0SPD`"]
@@ -64,25 +60,21 @@ impl ADC0SPD_R {
 }
 #[doc = "ADC1 Sample Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ADC1SPD_A {
     #[doc = "0: 125K samples/second"]
-    _125K,
+    _125K = 0,
     #[doc = "1: 250K samples/second"]
-    _250K,
+    _250K = 1,
     #[doc = "2: 500K samples/second"]
-    _500K,
+    _500K = 2,
     #[doc = "3: 1M samples/second"]
-    _1M,
+    _1M = 3,
 }
 impl From<ADC1SPD_A> for u8 {
     #[inline(always)]
     fn from(variant: ADC1SPD_A) -> Self {
-        match variant {
-            ADC1SPD_A::_125K => 0,
-            ADC1SPD_A::_250K => 1,
-            ADC1SPD_A::_500K => 2,
-            ADC1SPD_A::_1M => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ADC1SPD`"]

--- a/crates/tm4c123x/src/sysctl/slppwrcfg.rs
+++ b/crates/tm4c123x/src/sysctl/slppwrcfg.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::SLPPWRCFG {
 }
 #[doc = "SRAM Power Modes\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SRAMPM_A {
     #[doc = "0: Active Mode"]
-    NRM,
+    NRM = 0,
     #[doc = "1: Standby Mode"]
-    SBY,
+    SBY = 1,
     #[doc = "3: Low Power Mode"]
-    LP,
+    LP = 3,
 }
 impl From<SRAMPM_A> for u8 {
     #[inline(always)]
     fn from(variant: SRAMPM_A) -> Self {
-        match variant {
-            SRAMPM_A::NRM => 0,
-            SRAMPM_A::SBY => 1,
-            SRAMPM_A::LP => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SRAMPM`"]
@@ -94,19 +91,17 @@ impl<'a> SRAMPM_W<'a> {
 }
 #[doc = "Flash Power Modes\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum FLASHPM_A {
     #[doc = "0: Active Mode"]
-    NRM,
+    NRM = 0,
     #[doc = "2: Low Power Mode"]
-    SLP,
+    SLP = 2,
 }
 impl From<FLASHPM_A> for u8 {
     #[inline(always)]
     fn from(variant: FLASHPM_A) -> Self {
-        match variant {
-            FLASHPM_A::NRM => 0,
-            FLASHPM_A::SLP => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `FLASHPM`"]

--- a/crates/tm4c123x/src/sysexc.rs
+++ b/crates/tm4c123x/src/sysexc.rs
@@ -10,7 +10,7 @@ pub struct RegisterBlock {
     #[doc = "0x0c - System Exception Interrupt Clear"]
     pub ic: IC,
 }
-#[doc = "System Exception Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "System Exception Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -19,7 +19,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "System Exception Raw Interrupt Status"]
 pub mod ris;
-#[doc = "System Exception Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [im](im) module"]
+#[doc = "System Exception Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [im](im) module"]
 pub type IM = crate::Reg<u32, _IM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -30,7 +30,7 @@ impl crate::Readable for IM {}
 impl crate::Writable for IM {}
 #[doc = "System Exception Interrupt Mask"]
 pub mod im;
-#[doc = "System Exception Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mis](mis) module"]
+#[doc = "System Exception Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mis](mis) module"]
 pub type MIS = crate::Reg<u32, _MIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -39,7 +39,7 @@ pub struct _MIS;
 impl crate::Readable for MIS {}
 #[doc = "System Exception Masked Interrupt Status"]
 pub mod mis;
-#[doc = "System Exception Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ic](ic) module"]
+#[doc = "System Exception Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ic](ic) module"]
 pub type IC = crate::Reg<u32, _IC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/timer0.rs
+++ b/crates/tm4c123x/src/timer0.rs
@@ -69,7 +69,7 @@ impl crate::Readable for CFG {}
 impl crate::Writable for CFG {}
 #[doc = "GPTM Configuration"]
 pub mod cfg;
-#[doc = "GPTM Timer A Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tamr](tamr) module"]
+#[doc = "GPTM Timer A Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tamr](tamr) module"]
 pub type TAMR = crate::Reg<u32, _TAMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -80,7 +80,7 @@ impl crate::Readable for TAMR {}
 impl crate::Writable for TAMR {}
 #[doc = "GPTM Timer A Mode"]
 pub mod tamr;
-#[doc = "GPTM Timer B Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbmr](tbmr) module"]
+#[doc = "GPTM Timer B Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbmr](tbmr) module"]
 pub type TBMR = crate::Reg<u32, _TBMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -91,7 +91,7 @@ impl crate::Readable for TBMR {}
 impl crate::Writable for TBMR {}
 #[doc = "GPTM Timer B Mode"]
 pub mod tbmr;
-#[doc = "GPTM Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctl](ctl) module"]
+#[doc = "GPTM Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctl](ctl) module"]
 pub type CTL = crate::Reg<u32, _CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -102,7 +102,7 @@ impl crate::Readable for CTL {}
 impl crate::Writable for CTL {}
 #[doc = "GPTM Control"]
 pub mod ctl;
-#[doc = "GPTM Synchronize\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sync](sync) module"]
+#[doc = "GPTM Synchronize\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sync](sync) module"]
 pub type SYNC = crate::Reg<u32, _SYNC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -113,7 +113,7 @@ impl crate::Readable for SYNC {}
 impl crate::Writable for SYNC {}
 #[doc = "GPTM Synchronize"]
 pub mod sync;
-#[doc = "GPTM Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [imr](imr) module"]
+#[doc = "GPTM Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [imr](imr) module"]
 pub type IMR = crate::Reg<u32, _IMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -124,7 +124,7 @@ impl crate::Readable for IMR {}
 impl crate::Writable for IMR {}
 #[doc = "GPTM Interrupt Mask"]
 pub mod imr;
-#[doc = "GPTM Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "GPTM Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -133,7 +133,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "GPTM Raw Interrupt Status"]
 pub mod ris;
-#[doc = "GPTM Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mis](mis) module"]
+#[doc = "GPTM Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mis](mis) module"]
 pub type MIS = crate::Reg<u32, _MIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -142,7 +142,7 @@ pub struct _MIS;
 impl crate::Readable for MIS {}
 #[doc = "GPTM Masked Interrupt Status"]
 pub mod mis;
-#[doc = "GPTM Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [icr](icr) module"]
+#[doc = "GPTM Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [icr](icr) module"]
 pub type ICR = crate::Reg<u32, _ICR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -151,7 +151,7 @@ pub struct _ICR;
 impl crate::Writable for ICR {}
 #[doc = "GPTM Interrupt Clear"]
 pub mod icr;
-#[doc = "GPTM Timer A Interval Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tailr](tailr) module"]
+#[doc = "GPTM Timer A Interval Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tailr](tailr) module"]
 pub type TAILR = crate::Reg<u32, _TAILR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -162,7 +162,7 @@ impl crate::Readable for TAILR {}
 impl crate::Writable for TAILR {}
 #[doc = "GPTM Timer A Interval Load"]
 pub mod tailr;
-#[doc = "GPTM Timer B Interval Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbilr](tbilr) module"]
+#[doc = "GPTM Timer B Interval Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbilr](tbilr) module"]
 pub type TBILR = crate::Reg<u32, _TBILR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -173,7 +173,7 @@ impl crate::Readable for TBILR {}
 impl crate::Writable for TBILR {}
 #[doc = "GPTM Timer B Interval Load"]
 pub mod tbilr;
-#[doc = "GPTM Timer A Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tamatchr](tamatchr) module"]
+#[doc = "GPTM Timer A Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tamatchr](tamatchr) module"]
 pub type TAMATCHR = crate::Reg<u32, _TAMATCHR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -184,7 +184,7 @@ impl crate::Readable for TAMATCHR {}
 impl crate::Writable for TAMATCHR {}
 #[doc = "GPTM Timer A Match"]
 pub mod tamatchr;
-#[doc = "GPTM Timer B Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbmatchr](tbmatchr) module"]
+#[doc = "GPTM Timer B Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbmatchr](tbmatchr) module"]
 pub type TBMATCHR = crate::Reg<u32, _TBMATCHR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -195,7 +195,7 @@ impl crate::Readable for TBMATCHR {}
 impl crate::Writable for TBMATCHR {}
 #[doc = "GPTM Timer B Match"]
 pub mod tbmatchr;
-#[doc = "GPTM Timer A Prescale\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tapr](tapr) module"]
+#[doc = "GPTM Timer A Prescale\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tapr](tapr) module"]
 pub type TAPR = crate::Reg<u32, _TAPR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -206,7 +206,7 @@ impl crate::Readable for TAPR {}
 impl crate::Writable for TAPR {}
 #[doc = "GPTM Timer A Prescale"]
 pub mod tapr;
-#[doc = "GPTM Timer B Prescale\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbpr](tbpr) module"]
+#[doc = "GPTM Timer B Prescale\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbpr](tbpr) module"]
 pub type TBPR = crate::Reg<u32, _TBPR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -217,7 +217,7 @@ impl crate::Readable for TBPR {}
 impl crate::Writable for TBPR {}
 #[doc = "GPTM Timer B Prescale"]
 pub mod tbpr;
-#[doc = "GPTM TimerA Prescale Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tapmr](tapmr) module"]
+#[doc = "GPTM TimerA Prescale Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tapmr](tapmr) module"]
 pub type TAPMR = crate::Reg<u32, _TAPMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -228,7 +228,7 @@ impl crate::Readable for TAPMR {}
 impl crate::Writable for TAPMR {}
 #[doc = "GPTM TimerA Prescale Match"]
 pub mod tapmr;
-#[doc = "GPTM TimerB Prescale Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbpmr](tbpmr) module"]
+#[doc = "GPTM TimerB Prescale Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbpmr](tbpmr) module"]
 pub type TBPMR = crate::Reg<u32, _TBPMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -239,7 +239,7 @@ impl crate::Readable for TBPMR {}
 impl crate::Writable for TBPMR {}
 #[doc = "GPTM TimerB Prescale Match"]
 pub mod tbpmr;
-#[doc = "GPTM Timer A\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tar](tar) module"]
+#[doc = "GPTM Timer A\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tar](tar) module"]
 pub type TAR = crate::Reg<u32, _TAR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -248,7 +248,7 @@ pub struct _TAR;
 impl crate::Readable for TAR {}
 #[doc = "GPTM Timer A"]
 pub mod tar;
-#[doc = "GPTM Timer B\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbr](tbr) module"]
+#[doc = "GPTM Timer B\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbr](tbr) module"]
 pub type TBR = crate::Reg<u32, _TBR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -257,7 +257,7 @@ pub struct _TBR;
 impl crate::Readable for TBR {}
 #[doc = "GPTM Timer B"]
 pub mod tbr;
-#[doc = "GPTM Timer A Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tav](tav) module"]
+#[doc = "GPTM Timer A Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tav](tav) module"]
 pub type TAV = crate::Reg<u32, _TAV>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -268,7 +268,7 @@ impl crate::Readable for TAV {}
 impl crate::Writable for TAV {}
 #[doc = "GPTM Timer A Value"]
 pub mod tav;
-#[doc = "GPTM Timer B Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbv](tbv) module"]
+#[doc = "GPTM Timer B Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbv](tbv) module"]
 pub type TBV = crate::Reg<u32, _TBV>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -279,7 +279,7 @@ impl crate::Readable for TBV {}
 impl crate::Writable for TBV {}
 #[doc = "GPTM Timer B Value"]
 pub mod tbv;
-#[doc = "GPTM RTC Predivide\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rtcpd](rtcpd) module"]
+#[doc = "GPTM RTC Predivide\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rtcpd](rtcpd) module"]
 pub type RTCPD = crate::Reg<u32, _RTCPD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -288,7 +288,7 @@ pub struct _RTCPD;
 impl crate::Readable for RTCPD {}
 #[doc = "GPTM RTC Predivide"]
 pub mod rtcpd;
-#[doc = "GPTM Timer A Prescale Snapshot\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [taps](taps) module"]
+#[doc = "GPTM Timer A Prescale Snapshot\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [taps](taps) module"]
 pub type TAPS = crate::Reg<u32, _TAPS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -297,7 +297,7 @@ pub struct _TAPS;
 impl crate::Readable for TAPS {}
 #[doc = "GPTM Timer A Prescale Snapshot"]
 pub mod taps;
-#[doc = "GPTM Timer B Prescale Snapshot\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbps](tbps) module"]
+#[doc = "GPTM Timer B Prescale Snapshot\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbps](tbps) module"]
 pub type TBPS = crate::Reg<u32, _TBPS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -306,7 +306,7 @@ pub struct _TBPS;
 impl crate::Readable for TBPS {}
 #[doc = "GPTM Timer B Prescale Snapshot"]
 pub mod tbps;
-#[doc = "GPTM Timer A Prescale Value\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tapv](tapv) module"]
+#[doc = "GPTM Timer A Prescale Value\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tapv](tapv) module"]
 pub type TAPV = crate::Reg<u32, _TAPV>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -315,7 +315,7 @@ pub struct _TAPV;
 impl crate::Readable for TAPV {}
 #[doc = "GPTM Timer A Prescale Value"]
 pub mod tapv;
-#[doc = "GPTM Timer B Prescale Value\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbpv](tbpv) module"]
+#[doc = "GPTM Timer B Prescale Value\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbpv](tbpv) module"]
 pub type TBPV = crate::Reg<u32, _TBPV>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -324,7 +324,7 @@ pub struct _TBPV;
 impl crate::Readable for TBPV {}
 #[doc = "GPTM Timer B Prescale Value"]
 pub mod tbpv;
-#[doc = "GPTM Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "GPTM Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/timer0/cfg.rs
+++ b/crates/tm4c123x/src/timer0/cfg.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::CFG {
 }
 #[doc = "GPTM Configuration\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CFG_A {
     #[doc = "0: For a 16/32-bit timer, this value selects the 32-bit timer configuration"]
-    _32_BIT_TIMER,
+    _32_BIT_TIMER = 0,
     #[doc = "1: For a 16/32-bit timer, this value selects the 32-bit real-time clock (RTC) counter configuration"]
-    _32_BIT_RTC,
+    _32_BIT_RTC = 1,
     #[doc = "4: For a 16/32-bit timer, this value selects the 16-bit timer configuration"]
-    _16_BIT,
+    _16_BIT = 4,
 }
 impl From<CFG_A> for u8 {
     #[inline(always)]
     fn from(variant: CFG_A) -> Self {
-        match variant {
-            CFG_A::_32_BIT_TIMER => 0,
-            CFG_A::_32_BIT_RTC => 1,
-            CFG_A::_16_BIT => 4,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CFG`"]

--- a/crates/tm4c123x/src/timer0/ctl.rs
+++ b/crates/tm4c123x/src/timer0/ctl.rs
@@ -60,22 +60,19 @@ impl<'a> TASTALL_W<'a> {
 }
 #[doc = "GPTM Timer A Event Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TAEVENT_A {
     #[doc = "0: Positive edge"]
-    POS,
+    POS = 0,
     #[doc = "1: Negative edge"]
-    NEG,
+    NEG = 1,
     #[doc = "3: Both edges"]
-    BOTH,
+    BOTH = 3,
 }
 impl From<TAEVENT_A> for u8 {
     #[inline(always)]
     fn from(variant: TAEVENT_A) -> Self {
-        match variant {
-            TAEVENT_A::POS => 0,
-            TAEVENT_A::NEG => 1,
-            TAEVENT_A::BOTH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TAEVENT`"]
@@ -262,22 +259,19 @@ impl<'a> TBSTALL_W<'a> {
 }
 #[doc = "GPTM Timer B Event Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TBEVENT_A {
     #[doc = "0: Positive edge"]
-    POS,
+    POS = 0,
     #[doc = "1: Negative edge"]
-    NEG,
+    NEG = 1,
     #[doc = "3: Both edges"]
-    BOTH,
+    BOTH = 3,
 }
 impl From<TBEVENT_A> for u8 {
     #[inline(always)]
     fn from(variant: TBEVENT_A) -> Self {
-        match variant {
-            TBEVENT_A::POS => 0,
-            TBEVENT_A::NEG => 1,
-            TBEVENT_A::BOTH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TBEVENT`"]

--- a/crates/tm4c123x/src/timer0/pp.rs
+++ b/crates/tm4c123x/src/timer0/pp.rs
@@ -2,19 +2,17 @@
 pub type R = crate::R<u32, super::PP>;
 #[doc = "Count Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SIZE_A {
     #[doc = "0: Timer A and Timer B counters are 16 bits each with an 8-bit prescale counter"]
-    _16,
+    _16 = 0,
     #[doc = "1: Timer A and Timer B counters are 32 bits each with a 16-bit prescale counter"]
-    _32,
+    _32 = 1,
 }
 impl From<SIZE_A> for u8 {
     #[inline(always)]
     fn from(variant: SIZE_A) -> Self {
-        match variant {
-            SIZE_A::_16 => 0,
-            SIZE_A::_32 => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SIZE`"]

--- a/crates/tm4c123x/src/timer0/sync.rs
+++ b/crates/tm4c123x/src/timer0/sync.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::SYNC {
 }
 #[doc = "Synchronize GPTM Timer 0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT0_A {
     #[doc = "0: GPTM0 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM0 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM0 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM0 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT0_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT0_A) -> Self {
-        match variant {
-            SYNCT0_A::NONE => 0,
-            SYNCT0_A::TA => 1,
-            SYNCT0_A::TB => 2,
-            SYNCT0_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT0`"]
@@ -109,25 +105,21 @@ impl<'a> SYNCT0_W<'a> {
 }
 #[doc = "Synchronize GPTM Timer 1\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT1_A {
     #[doc = "0: GPTM1 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM1 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM1 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM1 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT1_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT1_A) -> Self {
-        match variant {
-            SYNCT1_A::NONE => 0,
-            SYNCT1_A::TA => 1,
-            SYNCT1_A::TB => 2,
-            SYNCT1_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT1`"]
@@ -206,25 +198,21 @@ impl<'a> SYNCT1_W<'a> {
 }
 #[doc = "Synchronize GPTM Timer 2\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT2_A {
     #[doc = "0: GPTM2 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM2 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM2 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM2 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT2_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT2_A) -> Self {
-        match variant {
-            SYNCT2_A::NONE => 0,
-            SYNCT2_A::TA => 1,
-            SYNCT2_A::TB => 2,
-            SYNCT2_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT2`"]
@@ -303,25 +291,21 @@ impl<'a> SYNCT2_W<'a> {
 }
 #[doc = "Synchronize GPTM Timer 3\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT3_A {
     #[doc = "0: GPTM3 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM3 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM3 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM3 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT3_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT3_A) -> Self {
-        match variant {
-            SYNCT3_A::NONE => 0,
-            SYNCT3_A::TA => 1,
-            SYNCT3_A::TB => 2,
-            SYNCT3_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT3`"]
@@ -400,25 +384,21 @@ impl<'a> SYNCT3_W<'a> {
 }
 #[doc = "Synchronize GPTM Timer 4\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT4_A {
     #[doc = "0: GPTM4 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM4 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM4 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM4 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT4_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT4_A) -> Self {
-        match variant {
-            SYNCT4_A::NONE => 0,
-            SYNCT4_A::TA => 1,
-            SYNCT4_A::TB => 2,
-            SYNCT4_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT4`"]
@@ -497,25 +477,21 @@ impl<'a> SYNCT4_W<'a> {
 }
 #[doc = "Synchronize GPTM Timer 5\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT5_A {
     #[doc = "0: GPTM5 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM5 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM5 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM5 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT5_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT5_A) -> Self {
-        match variant {
-            SYNCT5_A::NONE => 0,
-            SYNCT5_A::TA => 1,
-            SYNCT5_A::TB => 2,
-            SYNCT5_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT5`"]
@@ -594,25 +570,21 @@ impl<'a> SYNCT5_W<'a> {
 }
 #[doc = "Synchronize GPTM 32/64-Bit Timer 0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCWT0_A {
     #[doc = "0: GPTM 32/64-Bit Timer 0 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM 32/64-Bit Timer 0 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM 32/64-Bit Timer 0 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 0 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCWT0_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCWT0_A) -> Self {
-        match variant {
-            SYNCWT0_A::NONE => 0,
-            SYNCWT0_A::TA => 1,
-            SYNCWT0_A::TB => 2,
-            SYNCWT0_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCWT0`"]
@@ -691,25 +663,21 @@ impl<'a> SYNCWT0_W<'a> {
 }
 #[doc = "Synchronize GPTM 32/64-Bit Timer 1\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCWT1_A {
     #[doc = "0: GPTM 32/64-Bit Timer 1 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM 32/64-Bit Timer 1 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM 32/64-Bit Timer 1 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 1 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCWT1_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCWT1_A) -> Self {
-        match variant {
-            SYNCWT1_A::NONE => 0,
-            SYNCWT1_A::TA => 1,
-            SYNCWT1_A::TB => 2,
-            SYNCWT1_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCWT1`"]
@@ -788,25 +756,21 @@ impl<'a> SYNCWT1_W<'a> {
 }
 #[doc = "Synchronize GPTM 32/64-Bit Timer 2\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCWT2_A {
     #[doc = "0: GPTM 32/64-Bit Timer 2 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM 32/64-Bit Timer 2 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM 32/64-Bit Timer 2 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 2 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCWT2_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCWT2_A) -> Self {
-        match variant {
-            SYNCWT2_A::NONE => 0,
-            SYNCWT2_A::TA => 1,
-            SYNCWT2_A::TB => 2,
-            SYNCWT2_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCWT2`"]
@@ -885,25 +849,21 @@ impl<'a> SYNCWT2_W<'a> {
 }
 #[doc = "Synchronize GPTM 32/64-Bit Timer 3\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCWT3_A {
     #[doc = "0: GPTM 32/64-Bit Timer 3 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM 32/64-Bit Timer 3 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM 32/64-Bit Timer 3 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 3 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCWT3_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCWT3_A) -> Self {
-        match variant {
-            SYNCWT3_A::NONE => 0,
-            SYNCWT3_A::TA => 1,
-            SYNCWT3_A::TB => 2,
-            SYNCWT3_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCWT3`"]
@@ -982,25 +942,21 @@ impl<'a> SYNCWT3_W<'a> {
 }
 #[doc = "Synchronize GPTM 32/64-Bit Timer 4\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCWT4_A {
     #[doc = "0: GPTM 32/64-Bit Timer 4 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM 32/64-Bit Timer 4 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM 32/64-Bit Timer 4 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 4 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCWT4_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCWT4_A) -> Self {
-        match variant {
-            SYNCWT4_A::NONE => 0,
-            SYNCWT4_A::TA => 1,
-            SYNCWT4_A::TB => 2,
-            SYNCWT4_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCWT4`"]
@@ -1079,25 +1035,21 @@ impl<'a> SYNCWT4_W<'a> {
 }
 #[doc = "Synchronize GPTM 32/64-Bit Timer 5\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCWT5_A {
     #[doc = "0: GPTM 32/64-Bit Timer 5 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM 32/64-Bit Timer 5 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM 32/64-Bit Timer 5 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 5 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCWT5_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCWT5_A) -> Self {
-        match variant {
-            SYNCWT5_A::NONE => 0,
-            SYNCWT5_A::TA => 1,
-            SYNCWT5_A::TB => 2,
-            SYNCWT5_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCWT5`"]

--- a/crates/tm4c123x/src/timer0/tamr.rs
+++ b/crates/tm4c123x/src/timer0/tamr.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::TAMR {
 }
 #[doc = "GPTM Timer A Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TAMR_A {
     #[doc = "1: One-Shot Timer mode"]
-    _1_SHOT,
+    _1_SHOT = 1,
     #[doc = "2: Periodic Timer mode"]
-    PERIOD,
+    PERIOD = 2,
     #[doc = "3: Capture mode"]
-    CAP,
+    CAP = 3,
 }
 impl From<TAMR_A> for u8 {
     #[inline(always)]
     fn from(variant: TAMR_A) -> Self {
-        match variant {
-            TAMR_A::_1_SHOT => 1,
-            TAMR_A::PERIOD => 2,
-            TAMR_A::CAP => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TAMR`"]

--- a/crates/tm4c123x/src/timer0/tbmr.rs
+++ b/crates/tm4c123x/src/timer0/tbmr.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::TBMR {
 }
 #[doc = "GPTM Timer B Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TBMR_A {
     #[doc = "1: One-Shot Timer mode"]
-    _1_SHOT,
+    _1_SHOT = 1,
     #[doc = "2: Periodic Timer mode"]
-    PERIOD,
+    PERIOD = 2,
     #[doc = "3: Capture mode"]
-    CAP,
+    CAP = 3,
 }
 impl From<TBMR_A> for u8 {
     #[inline(always)]
     fn from(variant: TBMR_A) -> Self {
-        match variant {
-            TBMR_A::_1_SHOT => 1,
-            TBMR_A::PERIOD => 2,
-            TBMR_A::CAP => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TBMR`"]

--- a/crates/tm4c123x/src/uart0.rs
+++ b/crates/tm4c123x/src/uart0.rs
@@ -64,7 +64,7 @@ impl RegisterBlock {
         unsafe { &mut *(((self as *const Self) as *mut u8).add(4usize) as *mut RSR) }
     }
 }
-#[doc = "UART Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dr](dr) module"]
+#[doc = "UART Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dr](dr) module"]
 pub type DR = crate::Reg<u32, _DR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -75,7 +75,7 @@ impl crate::Readable for DR {}
 impl crate::Writable for DR {}
 #[doc = "UART Data"]
 pub mod dr;
-#[doc = "UART Receive Status/Error Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rsr](rsr) module"]
+#[doc = "UART Receive Status/Error Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rsr](rsr) module"]
 pub type RSR = crate::Reg<u32, _RSR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -86,7 +86,7 @@ impl crate::Readable for RSR {}
 impl crate::Writable for RSR {}
 #[doc = "UART Receive Status/Error Clear"]
 pub mod rsr;
-#[doc = "UART Receive Status/Error Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ecr](ecr) module"]
+#[doc = "UART Receive Status/Error Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ecr](ecr) module"]
 pub type ECR = crate::Reg<u32, _ECR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -97,7 +97,7 @@ impl crate::Readable for ECR {}
 impl crate::Writable for ECR {}
 #[doc = "UART Receive Status/Error Clear"]
 pub mod ecr;
-#[doc = "UART Flag\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fr](fr) module"]
+#[doc = "UART Flag\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fr](fr) module"]
 pub type FR = crate::Reg<u32, _FR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -106,7 +106,7 @@ pub struct _FR;
 impl crate::Readable for FR {}
 #[doc = "UART Flag"]
 pub mod fr;
-#[doc = "UART IrDA Low-Power Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ilpr](ilpr) module"]
+#[doc = "UART IrDA Low-Power Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ilpr](ilpr) module"]
 pub type ILPR = crate::Reg<u32, _ILPR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -117,7 +117,7 @@ impl crate::Readable for ILPR {}
 impl crate::Writable for ILPR {}
 #[doc = "UART IrDA Low-Power Register"]
 pub mod ilpr;
-#[doc = "UART Integer Baud-Rate Divisor\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ibrd](ibrd) module"]
+#[doc = "UART Integer Baud-Rate Divisor\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ibrd](ibrd) module"]
 pub type IBRD = crate::Reg<u32, _IBRD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -128,7 +128,7 @@ impl crate::Readable for IBRD {}
 impl crate::Writable for IBRD {}
 #[doc = "UART Integer Baud-Rate Divisor"]
 pub mod ibrd;
-#[doc = "UART Fractional Baud-Rate Divisor\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fbrd](fbrd) module"]
+#[doc = "UART Fractional Baud-Rate Divisor\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fbrd](fbrd) module"]
 pub type FBRD = crate::Reg<u32, _FBRD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -139,7 +139,7 @@ impl crate::Readable for FBRD {}
 impl crate::Writable for FBRD {}
 #[doc = "UART Fractional Baud-Rate Divisor"]
 pub mod fbrd;
-#[doc = "UART Line Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [lcrh](lcrh) module"]
+#[doc = "UART Line Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [lcrh](lcrh) module"]
 pub type LCRH = crate::Reg<u32, _LCRH>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -150,7 +150,7 @@ impl crate::Readable for LCRH {}
 impl crate::Writable for LCRH {}
 #[doc = "UART Line Control"]
 pub mod lcrh;
-#[doc = "UART Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctl](ctl) module"]
+#[doc = "UART Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctl](ctl) module"]
 pub type CTL = crate::Reg<u32, _CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -161,7 +161,7 @@ impl crate::Readable for CTL {}
 impl crate::Writable for CTL {}
 #[doc = "UART Control"]
 pub mod ctl;
-#[doc = "UART Interrupt FIFO Level Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ifls](ifls) module"]
+#[doc = "UART Interrupt FIFO Level Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ifls](ifls) module"]
 pub type IFLS = crate::Reg<u32, _IFLS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -172,7 +172,7 @@ impl crate::Readable for IFLS {}
 impl crate::Writable for IFLS {}
 #[doc = "UART Interrupt FIFO Level Select"]
 pub mod ifls;
-#[doc = "UART Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [im](im) module"]
+#[doc = "UART Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [im](im) module"]
 pub type IM = crate::Reg<u32, _IM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -183,7 +183,7 @@ impl crate::Readable for IM {}
 impl crate::Writable for IM {}
 #[doc = "UART Interrupt Mask"]
 pub mod im;
-#[doc = "UART Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "UART Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -192,7 +192,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "UART Raw Interrupt Status"]
 pub mod ris;
-#[doc = "UART Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mis](mis) module"]
+#[doc = "UART Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mis](mis) module"]
 pub type MIS = crate::Reg<u32, _MIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -201,7 +201,7 @@ pub struct _MIS;
 impl crate::Readable for MIS {}
 #[doc = "UART Masked Interrupt Status"]
 pub mod mis;
-#[doc = "UART Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [icr](icr) module"]
+#[doc = "UART Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [icr](icr) module"]
 pub type ICR = crate::Reg<u32, _ICR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -210,7 +210,7 @@ pub struct _ICR;
 impl crate::Writable for ICR {}
 #[doc = "UART Interrupt Clear"]
 pub mod icr;
-#[doc = "UART DMA Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmactl](dmactl) module"]
+#[doc = "UART DMA Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmactl](dmactl) module"]
 pub type DMACTL = crate::Reg<u32, _DMACTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -221,7 +221,7 @@ impl crate::Readable for DMACTL {}
 impl crate::Writable for DMACTL {}
 #[doc = "UART DMA Control"]
 pub mod dmactl;
-#[doc = "UART 9-Bit Self Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_9bitaddr](_9bitaddr) module"]
+#[doc = "UART 9-Bit Self Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_9bitaddr](_9bitaddr) module"]
 pub type _9BITADDR = crate::Reg<u32, __9BITADDR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -232,7 +232,7 @@ impl crate::Readable for _9BITADDR {}
 impl crate::Writable for _9BITADDR {}
 #[doc = "UART 9-Bit Self Address"]
 pub mod _9bitaddr;
-#[doc = "UART 9-Bit Self Address Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_9bitamask](_9bitamask) module"]
+#[doc = "UART 9-Bit Self Address Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_9bitamask](_9bitamask) module"]
 pub type _9BITAMASK = crate::Reg<u32, __9BITAMASK>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -243,7 +243,7 @@ impl crate::Readable for _9BITAMASK {}
 impl crate::Writable for _9BITAMASK {}
 #[doc = "UART 9-Bit Self Address Mask"]
 pub mod _9bitamask;
-#[doc = "UART Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "UART Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -252,7 +252,7 @@ pub struct _PP;
 impl crate::Readable for PP {}
 #[doc = "UART Peripheral Properties"]
 pub mod pp;
-#[doc = "UART Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc](cc) module"]
+#[doc = "UART Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cc](cc) module"]
 pub type CC = crate::Reg<u32, _CC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/uart0/cc.rs
+++ b/crates/tm4c123x/src/uart0/cc.rs
@@ -12,19 +12,17 @@ impl crate::ResetValue for super::CC {
 }
 #[doc = "UART Baud Clock Source\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CS_A {
     #[doc = "0: System clock (based on clock source and divisor factor)"]
-    SYSCLK,
+    SYSCLK = 0,
     #[doc = "5: PIOSC"]
-    PIOSC,
+    PIOSC = 5,
 }
 impl From<CS_A> for u8 {
     #[inline(always)]
     fn from(variant: CS_A) -> Self {
-        match variant {
-            CS_A::SYSCLK => 0,
-            CS_A::PIOSC => 5,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CS`"]

--- a/crates/tm4c123x/src/uart0/ifls.rs
+++ b/crates/tm4c123x/src/uart0/ifls.rs
@@ -12,28 +12,23 @@ impl crate::ResetValue for super::IFLS {
 }
 #[doc = "UART Transmit Interrupt FIFO Level Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TX_A {
     #[doc = "0: TX FIFO &lt;= 1/8 full"]
-    TX1_8,
+    TX1_8 = 0,
     #[doc = "1: TX FIFO &lt;= 1/4 full"]
-    TX2_8,
+    TX2_8 = 1,
     #[doc = "2: TX FIFO &lt;= 1/2 full (default)"]
-    TX4_8,
+    TX4_8 = 2,
     #[doc = "3: TX FIFO &lt;= 3/4 full"]
-    TX6_8,
+    TX6_8 = 3,
     #[doc = "4: TX FIFO &lt;= 7/8 full"]
-    TX7_8,
+    TX7_8 = 4,
 }
 impl From<TX_A> for u8 {
     #[inline(always)]
     fn from(variant: TX_A) -> Self {
-        match variant {
-            TX_A::TX1_8 => 0,
-            TX_A::TX2_8 => 1,
-            TX_A::TX4_8 => 2,
-            TX_A::TX6_8 => 3,
-            TX_A::TX7_8 => 4,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TX`"]
@@ -122,28 +117,23 @@ impl<'a> TX_W<'a> {
 }
 #[doc = "UART Receive Interrupt FIFO Level Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum RX_A {
     #[doc = "0: RX FIFO >= 1/8 full"]
-    RX1_8,
+    RX1_8 = 0,
     #[doc = "1: RX FIFO >= 1/4 full"]
-    RX2_8,
+    RX2_8 = 1,
     #[doc = "2: RX FIFO >= 1/2 full (default)"]
-    RX4_8,
+    RX4_8 = 2,
     #[doc = "3: RX FIFO >= 3/4 full"]
-    RX6_8,
+    RX6_8 = 3,
     #[doc = "4: RX FIFO >= 7/8 full"]
-    RX7_8,
+    RX7_8 = 4,
 }
 impl From<RX_A> for u8 {
     #[inline(always)]
     fn from(variant: RX_A) -> Self {
-        match variant {
-            RX_A::RX1_8 => 0,
-            RX_A::RX2_8 => 1,
-            RX_A::RX4_8 => 2,
-            RX_A::RX6_8 => 3,
-            RX_A::RX7_8 => 4,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `RX`"]

--- a/crates/tm4c123x/src/uart0/lcrh.rs
+++ b/crates/tm4c123x/src/uart0/lcrh.rs
@@ -132,25 +132,21 @@ impl<'a> FEN_W<'a> {
 }
 #[doc = "UART Word Length\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum WLEN_A {
     #[doc = "0: 5 bits (default)"]
-    _5,
+    _5 = 0,
     #[doc = "1: 6 bits"]
-    _6,
+    _6 = 1,
     #[doc = "2: 7 bits"]
-    _7,
+    _7 = 2,
     #[doc = "3: 8 bits"]
-    _8,
+    _8 = 3,
 }
 impl From<WLEN_A> for u8 {
     #[inline(always)]
     fn from(variant: WLEN_A) -> Self {
-        match variant {
-            WLEN_A::_5 => 0,
-            WLEN_A::_6 => 1,
-            WLEN_A::_7 => 2,
-            WLEN_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `WLEN`"]

--- a/crates/tm4c123x/src/udma.rs
+++ b/crates/tm4c123x/src/udma.rs
@@ -51,7 +51,7 @@ pub struct RegisterBlock {
     #[doc = "0x51c - DMA Channel Map Select 3"]
     pub chmap3: CHMAP3,
 }
-#[doc = "DMA Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [stat](stat) module"]
+#[doc = "DMA Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [stat](stat) module"]
 pub type STAT = crate::Reg<u32, _STAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -69,7 +69,7 @@ pub struct _CFG;
 impl crate::Writable for CFG {}
 #[doc = "DMA Configuration"]
 pub mod cfg;
-#[doc = "DMA Channel Control Base Pointer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctlbase](ctlbase) module"]
+#[doc = "DMA Channel Control Base Pointer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctlbase](ctlbase) module"]
 pub type CTLBASE = crate::Reg<u32, _CTLBASE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -80,7 +80,7 @@ impl crate::Readable for CTLBASE {}
 impl crate::Writable for CTLBASE {}
 #[doc = "DMA Channel Control Base Pointer"]
 pub mod ctlbase;
-#[doc = "DMA Alternate Channel Control Base Pointer\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [altbase](altbase) module"]
+#[doc = "DMA Alternate Channel Control Base Pointer\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [altbase](altbase) module"]
 pub type ALTBASE = crate::Reg<u32, _ALTBASE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -89,7 +89,7 @@ pub struct _ALTBASE;
 impl crate::Readable for ALTBASE {}
 #[doc = "DMA Alternate Channel Control Base Pointer"]
 pub mod altbase;
-#[doc = "DMA Channel Wait-on-Request Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [waitstat](waitstat) module"]
+#[doc = "DMA Channel Wait-on-Request Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [waitstat](waitstat) module"]
 pub type WAITSTAT = crate::Reg<u32, _WAITSTAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -98,7 +98,7 @@ pub struct _WAITSTAT;
 impl crate::Readable for WAITSTAT {}
 #[doc = "DMA Channel Wait-on-Request Status"]
 pub mod waitstat;
-#[doc = "DMA Channel Software Request\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [swreq](swreq) module"]
+#[doc = "DMA Channel Software Request\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [swreq](swreq) module"]
 pub type SWREQ = crate::Reg<u32, _SWREQ>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -107,7 +107,7 @@ pub struct _SWREQ;
 impl crate::Writable for SWREQ {}
 #[doc = "DMA Channel Software Request"]
 pub mod swreq;
-#[doc = "DMA Channel Useburst Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [useburstset](useburstset) module"]
+#[doc = "DMA Channel Useburst Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [useburstset](useburstset) module"]
 pub type USEBURSTSET = crate::Reg<u32, _USEBURSTSET>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -118,7 +118,7 @@ impl crate::Readable for USEBURSTSET {}
 impl crate::Writable for USEBURSTSET {}
 #[doc = "DMA Channel Useburst Set"]
 pub mod useburstset;
-#[doc = "DMA Channel Useburst Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [useburstclr](useburstclr) module"]
+#[doc = "DMA Channel Useburst Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [useburstclr](useburstclr) module"]
 pub type USEBURSTCLR = crate::Reg<u32, _USEBURSTCLR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -127,7 +127,7 @@ pub struct _USEBURSTCLR;
 impl crate::Writable for USEBURSTCLR {}
 #[doc = "DMA Channel Useburst Clear"]
 pub mod useburstclr;
-#[doc = "DMA Channel Request Mask Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [reqmaskset](reqmaskset) module"]
+#[doc = "DMA Channel Request Mask Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [reqmaskset](reqmaskset) module"]
 pub type REQMASKSET = crate::Reg<u32, _REQMASKSET>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -138,7 +138,7 @@ impl crate::Readable for REQMASKSET {}
 impl crate::Writable for REQMASKSET {}
 #[doc = "DMA Channel Request Mask Set"]
 pub mod reqmaskset;
-#[doc = "DMA Channel Request Mask Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [reqmaskclr](reqmaskclr) module"]
+#[doc = "DMA Channel Request Mask Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [reqmaskclr](reqmaskclr) module"]
 pub type REQMASKCLR = crate::Reg<u32, _REQMASKCLR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -147,7 +147,7 @@ pub struct _REQMASKCLR;
 impl crate::Writable for REQMASKCLR {}
 #[doc = "DMA Channel Request Mask Clear"]
 pub mod reqmaskclr;
-#[doc = "DMA Channel Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [enaset](enaset) module"]
+#[doc = "DMA Channel Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [enaset](enaset) module"]
 pub type ENASET = crate::Reg<u32, _ENASET>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -158,7 +158,7 @@ impl crate::Readable for ENASET {}
 impl crate::Writable for ENASET {}
 #[doc = "DMA Channel Enable Set"]
 pub mod enaset;
-#[doc = "DMA Channel Enable Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [enaclr](enaclr) module"]
+#[doc = "DMA Channel Enable Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [enaclr](enaclr) module"]
 pub type ENACLR = crate::Reg<u32, _ENACLR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -167,7 +167,7 @@ pub struct _ENACLR;
 impl crate::Writable for ENACLR {}
 #[doc = "DMA Channel Enable Clear"]
 pub mod enaclr;
-#[doc = "DMA Channel Primary Alternate Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [altset](altset) module"]
+#[doc = "DMA Channel Primary Alternate Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [altset](altset) module"]
 pub type ALTSET = crate::Reg<u32, _ALTSET>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -178,7 +178,7 @@ impl crate::Readable for ALTSET {}
 impl crate::Writable for ALTSET {}
 #[doc = "DMA Channel Primary Alternate Set"]
 pub mod altset;
-#[doc = "DMA Channel Primary Alternate Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [altclr](altclr) module"]
+#[doc = "DMA Channel Primary Alternate Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [altclr](altclr) module"]
 pub type ALTCLR = crate::Reg<u32, _ALTCLR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -187,7 +187,7 @@ pub struct _ALTCLR;
 impl crate::Writable for ALTCLR {}
 #[doc = "DMA Channel Primary Alternate Clear"]
 pub mod altclr;
-#[doc = "DMA Channel Priority Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prioset](prioset) module"]
+#[doc = "DMA Channel Priority Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prioset](prioset) module"]
 pub type PRIOSET = crate::Reg<u32, _PRIOSET>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -198,7 +198,7 @@ impl crate::Readable for PRIOSET {}
 impl crate::Writable for PRIOSET {}
 #[doc = "DMA Channel Priority Set"]
 pub mod prioset;
-#[doc = "DMA Channel Priority Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prioclr](prioclr) module"]
+#[doc = "DMA Channel Priority Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prioclr](prioclr) module"]
 pub type PRIOCLR = crate::Reg<u32, _PRIOCLR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -207,7 +207,7 @@ pub struct _PRIOCLR;
 impl crate::Writable for PRIOCLR {}
 #[doc = "DMA Channel Priority Clear"]
 pub mod prioclr;
-#[doc = "DMA Bus Error Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [errclr](errclr) module"]
+#[doc = "DMA Bus Error Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [errclr](errclr) module"]
 pub type ERRCLR = crate::Reg<u32, _ERRCLR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -218,7 +218,7 @@ impl crate::Readable for ERRCLR {}
 impl crate::Writable for ERRCLR {}
 #[doc = "DMA Bus Error Clear"]
 pub mod errclr;
-#[doc = "DMA Channel Assignment\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chasgn](chasgn) module"]
+#[doc = "DMA Channel Assignment\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [chasgn](chasgn) module"]
 pub type CHASGN = crate::Reg<u32, _CHASGN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -229,7 +229,7 @@ impl crate::Readable for CHASGN {}
 impl crate::Writable for CHASGN {}
 #[doc = "DMA Channel Assignment"]
 pub mod chasgn;
-#[doc = "DMA Channel Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chis](chis) module"]
+#[doc = "DMA Channel Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [chis](chis) module"]
 pub type CHIS = crate::Reg<u32, _CHIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -240,7 +240,7 @@ impl crate::Readable for CHIS {}
 impl crate::Writable for CHIS {}
 #[doc = "DMA Channel Interrupt Status"]
 pub mod chis;
-#[doc = "DMA Channel Map Select 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chmap0](chmap0) module"]
+#[doc = "DMA Channel Map Select 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [chmap0](chmap0) module"]
 pub type CHMAP0 = crate::Reg<u32, _CHMAP0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -251,7 +251,7 @@ impl crate::Readable for CHMAP0 {}
 impl crate::Writable for CHMAP0 {}
 #[doc = "DMA Channel Map Select 0"]
 pub mod chmap0;
-#[doc = "DMA Channel Map Select 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chmap1](chmap1) module"]
+#[doc = "DMA Channel Map Select 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [chmap1](chmap1) module"]
 pub type CHMAP1 = crate::Reg<u32, _CHMAP1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -262,7 +262,7 @@ impl crate::Readable for CHMAP1 {}
 impl crate::Writable for CHMAP1 {}
 #[doc = "DMA Channel Map Select 1"]
 pub mod chmap1;
-#[doc = "DMA Channel Map Select 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chmap2](chmap2) module"]
+#[doc = "DMA Channel Map Select 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [chmap2](chmap2) module"]
 pub type CHMAP2 = crate::Reg<u32, _CHMAP2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -273,7 +273,7 @@ impl crate::Readable for CHMAP2 {}
 impl crate::Writable for CHMAP2 {}
 #[doc = "DMA Channel Map Select 2"]
 pub mod chmap2;
-#[doc = "DMA Channel Map Select 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chmap3](chmap3) module"]
+#[doc = "DMA Channel Map Select 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [chmap3](chmap3) module"]
 pub type CHMAP3 = crate::Reg<u32, _CHMAP3>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/udma/altclr.rs
+++ b/crates/tm4c123x/src/udma/altclr.rs
@@ -21,7 +21,8 @@ impl<'a> CLR_W<'a> {
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Alternate Clear"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Alternate Clear"]
     #[inline(always)]
     pub fn clr(&mut self) -> CLR_W {
         CLR_W { w: self }

--- a/crates/tm4c123x/src/udma/altset.rs
+++ b/crates/tm4c123x/src/udma/altset.rs
@@ -25,14 +25,16 @@ impl<'a> SET_W<'a> {
     }
 }
 impl R {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Alternate Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Alternate Set"]
     #[inline(always)]
     pub fn set(&self) -> SET_R {
         SET_R::new((self.bits & 0xffff_ffff) as u32)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Alternate Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Alternate Set"]
     #[inline(always)]
     pub fn set(&mut self) -> SET_W {
         SET_W { w: self }

--- a/crates/tm4c123x/src/udma/chasgn.rs
+++ b/crates/tm4c123x/src/udma/chasgn.rs
@@ -10,21 +10,20 @@ impl crate::ResetValue for super::CHASGN {
         0
     }
 }
-#[doc = "Channel \\[n\\] Assignment Select\n\nValue on reset: 0"]
+#[doc = "Channel \\[n\\]
+Assignment Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u32)]
 pub enum CHASGN_A {
     #[doc = "0: Use the primary channel assignment"]
-    PRIMARY,
+    PRIMARY = 0,
     #[doc = "1: Use the secondary channel assignment"]
-    SECONDARY,
+    SECONDARY = 1,
 }
 impl From<CHASGN_A> for u32 {
     #[inline(always)]
     fn from(variant: CHASGN_A) -> Self {
-        match variant {
-            CHASGN_A::PRIMARY => 0,
-            CHASGN_A::SECONDARY => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CHASGN`"]
@@ -79,14 +78,16 @@ impl<'a> CHASGN_W<'a> {
     }
 }
 impl R {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Assignment Select"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Assignment Select"]
     #[inline(always)]
     pub fn chasgn(&self) -> CHASGN_R {
         CHASGN_R::new((self.bits & 0xffff_ffff) as u32)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Assignment Select"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Assignment Select"]
     #[inline(always)]
     pub fn chasgn(&mut self) -> CHASGN_W {
         CHASGN_W { w: self }

--- a/crates/tm4c123x/src/udma/enaclr.rs
+++ b/crates/tm4c123x/src/udma/enaclr.rs
@@ -21,7 +21,8 @@ impl<'a> CLR_W<'a> {
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Clear Channel \\[n\\] Enable Clear"]
+    #[doc = "Bits 0:31 - Clear Channel \\[n\\]
+Enable Clear"]
     #[inline(always)]
     pub fn clr(&mut self) -> CLR_W {
         CLR_W { w: self }

--- a/crates/tm4c123x/src/udma/enaset.rs
+++ b/crates/tm4c123x/src/udma/enaset.rs
@@ -25,14 +25,16 @@ impl<'a> SET_W<'a> {
     }
 }
 impl R {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Enable Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Enable Set"]
     #[inline(always)]
     pub fn set(&self) -> SET_R {
         SET_R::new((self.bits & 0xffff_ffff) as u32)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Enable Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Enable Set"]
     #[inline(always)]
     pub fn set(&mut self) -> SET_W {
         SET_W { w: self }

--- a/crates/tm4c123x/src/udma/prioclr.rs
+++ b/crates/tm4c123x/src/udma/prioclr.rs
@@ -21,7 +21,8 @@ impl<'a> CLR_W<'a> {
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Priority Clear"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Priority Clear"]
     #[inline(always)]
     pub fn clr(&mut self) -> CLR_W {
         CLR_W { w: self }

--- a/crates/tm4c123x/src/udma/prioset.rs
+++ b/crates/tm4c123x/src/udma/prioset.rs
@@ -25,14 +25,16 @@ impl<'a> SET_W<'a> {
     }
 }
 impl R {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Priority Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Priority Set"]
     #[inline(always)]
     pub fn set(&self) -> SET_R {
         SET_R::new((self.bits & 0xffff_ffff) as u32)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Priority Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Priority Set"]
     #[inline(always)]
     pub fn set(&mut self) -> SET_W {
         SET_W { w: self }

--- a/crates/tm4c123x/src/udma/reqmaskclr.rs
+++ b/crates/tm4c123x/src/udma/reqmaskclr.rs
@@ -21,7 +21,8 @@ impl<'a> CLR_W<'a> {
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Request Mask Clear"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Request Mask Clear"]
     #[inline(always)]
     pub fn clr(&mut self) -> CLR_W {
         CLR_W { w: self }

--- a/crates/tm4c123x/src/udma/reqmaskset.rs
+++ b/crates/tm4c123x/src/udma/reqmaskset.rs
@@ -25,14 +25,16 @@ impl<'a> SET_W<'a> {
     }
 }
 impl R {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Request Mask Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Request Mask Set"]
     #[inline(always)]
     pub fn set(&self) -> SET_R {
         SET_R::new((self.bits & 0xffff_ffff) as u32)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Request Mask Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Request Mask Set"]
     #[inline(always)]
     pub fn set(&mut self) -> SET_W {
         SET_W { w: self }

--- a/crates/tm4c123x/src/udma/stat.rs
+++ b/crates/tm4c123x/src/udma/stat.rs
@@ -4,46 +4,35 @@ pub type R = crate::R<u32, super::STAT>;
 pub type MASTEN_R = crate::R<bool, bool>;
 #[doc = "Control State Machine Status\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum STATE_A {
     #[doc = "0: Idle"]
-    IDLE,
+    IDLE = 0,
     #[doc = "1: Reading channel controller data"]
-    RD_CTRL,
+    RD_CTRL = 1,
     #[doc = "2: Reading source end pointer"]
-    RD_SRCENDP,
+    RD_SRCENDP = 2,
     #[doc = "3: Reading destination end pointer"]
-    RD_DSTENDP,
+    RD_DSTENDP = 3,
     #[doc = "4: Reading source data"]
-    RD_SRCDAT,
+    RD_SRCDAT = 4,
     #[doc = "5: Writing destination data"]
-    WR_DSTDAT,
+    WR_DSTDAT = 5,
     #[doc = "6: Waiting for uDMA request to clear"]
-    WAIT,
+    WAIT = 6,
     #[doc = "7: Writing channel controller data"]
-    WR_CTRL,
+    WR_CTRL = 7,
     #[doc = "8: Stalled"]
-    STALL,
+    STALL = 8,
     #[doc = "9: Done"]
-    DONE,
+    DONE = 9,
     #[doc = "10: Undefined"]
-    UNDEF,
+    UNDEF = 10,
 }
 impl From<STATE_A> for u8 {
     #[inline(always)]
     fn from(variant: STATE_A) -> Self {
-        match variant {
-            STATE_A::IDLE => 0,
-            STATE_A::RD_CTRL => 1,
-            STATE_A::RD_SRCENDP => 2,
-            STATE_A::RD_DSTENDP => 3,
-            STATE_A::RD_SRCDAT => 4,
-            STATE_A::WR_DSTDAT => 5,
-            STATE_A::WAIT => 6,
-            STATE_A::WR_CTRL => 7,
-            STATE_A::STALL => 8,
-            STATE_A::DONE => 9,
-            STATE_A::UNDEF => 10,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `STATE`"]

--- a/crates/tm4c123x/src/udma/useburstclr.rs
+++ b/crates/tm4c123x/src/udma/useburstclr.rs
@@ -21,7 +21,8 @@ impl<'a> CLR_W<'a> {
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Useburst Clear"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Useburst Clear"]
     #[inline(always)]
     pub fn clr(&mut self) -> CLR_W {
         CLR_W { w: self }

--- a/crates/tm4c123x/src/udma/useburstset.rs
+++ b/crates/tm4c123x/src/udma/useburstset.rs
@@ -25,14 +25,16 @@ impl<'a> SET_W<'a> {
     }
 }
 impl R {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Useburst Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Useburst Set"]
     #[inline(always)]
     pub fn set(&self) -> SET_R {
         SET_R::new((self.bits & 0xffff_ffff) as u32)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Useburst Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Useburst Set"]
     #[inline(always)]
     pub fn set(&mut self) -> SET_W {
         SET_W { w: self }

--- a/crates/tm4c123x/src/udma/waitstat.rs
+++ b/crates/tm4c123x/src/udma/waitstat.rs
@@ -3,7 +3,8 @@ pub type R = crate::R<u32, super::WAITSTAT>;
 #[doc = "Reader of field `WAITREQ`"]
 pub type WAITREQ_R = crate::R<u32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Wait Status"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Wait Status"]
     #[inline(always)]
     pub fn waitreq(&self) -> WAITREQ_R {
         WAITREQ_R::new((self.bits & 0xffff_ffff) as u32)

--- a/crates/tm4c123x/src/usb0.rs
+++ b/crates/tm4c123x/src/usb0.rs
@@ -408,7 +408,7 @@ pub struct RegisterBlock {
     #[doc = "0xfc0 - USB Peripheral Properties"]
     pub pp: PP,
 }
-#[doc = "USB Device Functional Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [faddr](faddr) module"]
+#[doc = "USB Device Functional Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [faddr](faddr) module"]
 pub type FADDR = crate::Reg<u8, _FADDR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -419,7 +419,7 @@ impl crate::Readable for FADDR {}
 impl crate::Writable for FADDR {}
 #[doc = "USB Device Functional Address"]
 pub mod faddr;
-#[doc = "USB Power\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [power](power) module"]
+#[doc = "USB Power\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [power](power) module"]
 pub type POWER = crate::Reg<u8, _POWER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -430,7 +430,7 @@ impl crate::Readable for POWER {}
 impl crate::Writable for POWER {}
 #[doc = "USB Power"]
 pub mod power;
-#[doc = "USB Transmit Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txis](txis) module"]
+#[doc = "USB Transmit Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txis](txis) module"]
 pub type TXIS = crate::Reg<u16, _TXIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -439,7 +439,7 @@ pub struct _TXIS;
 impl crate::Readable for TXIS {}
 #[doc = "USB Transmit Interrupt Status"]
 pub mod txis;
-#[doc = "USB Receive Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxis](rxis) module"]
+#[doc = "USB Receive Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxis](rxis) module"]
 pub type RXIS = crate::Reg<u16, _RXIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -448,7 +448,7 @@ pub struct _RXIS;
 impl crate::Readable for RXIS {}
 #[doc = "USB Receive Interrupt Status"]
 pub mod rxis;
-#[doc = "USB Transmit Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txie](txie) module"]
+#[doc = "USB Transmit Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txie](txie) module"]
 pub type TXIE = crate::Reg<u16, _TXIE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -459,7 +459,7 @@ impl crate::Readable for TXIE {}
 impl crate::Writable for TXIE {}
 #[doc = "USB Transmit Interrupt Enable"]
 pub mod txie;
-#[doc = "USB Receive Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxie](rxie) module"]
+#[doc = "USB Receive Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxie](rxie) module"]
 pub type RXIE = crate::Reg<u16, _RXIE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -470,7 +470,7 @@ impl crate::Readable for RXIE {}
 impl crate::Writable for RXIE {}
 #[doc = "USB Receive Interrupt Enable"]
 pub mod rxie;
-#[doc = "USB General Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [is](is) module"]
+#[doc = "USB General Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [is](is) module"]
 pub type IS = crate::Reg<u8, _IS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -479,7 +479,7 @@ pub struct _IS;
 impl crate::Readable for IS {}
 #[doc = "USB General Interrupt Status"]
 pub mod is;
-#[doc = "USB Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ie](ie) module"]
+#[doc = "USB Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ie](ie) module"]
 pub type IE = crate::Reg<u8, _IE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -490,7 +490,7 @@ impl crate::Readable for IE {}
 impl crate::Writable for IE {}
 #[doc = "USB Interrupt Enable"]
 pub mod ie;
-#[doc = "USB Frame Value\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [frame](frame) module"]
+#[doc = "USB Frame Value\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [frame](frame) module"]
 pub type FRAME = crate::Reg<u16, _FRAME>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -499,7 +499,7 @@ pub struct _FRAME;
 impl crate::Readable for FRAME {}
 #[doc = "USB Frame Value"]
 pub mod frame;
-#[doc = "USB Endpoint Index\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epidx](epidx) module"]
+#[doc = "USB Endpoint Index\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [epidx](epidx) module"]
 pub type EPIDX = crate::Reg<u8, _EPIDX>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -510,7 +510,7 @@ impl crate::Readable for EPIDX {}
 impl crate::Writable for EPIDX {}
 #[doc = "USB Endpoint Index"]
 pub mod epidx;
-#[doc = "USB Test Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [test](test) module"]
+#[doc = "USB Test Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [test](test) module"]
 pub type TEST = crate::Reg<u8, _TEST>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -521,7 +521,7 @@ impl crate::Readable for TEST {}
 impl crate::Writable for TEST {}
 #[doc = "USB Test Mode"]
 pub mod test;
-#[doc = "USB FIFO Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifo0](fifo0) module"]
+#[doc = "USB FIFO Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifo0](fifo0) module"]
 pub type FIFO0 = crate::Reg<u32, _FIFO0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -532,7 +532,7 @@ impl crate::Readable for FIFO0 {}
 impl crate::Writable for FIFO0 {}
 #[doc = "USB FIFO Endpoint 0"]
 pub mod fifo0;
-#[doc = "USB FIFO Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifo1](fifo1) module"]
+#[doc = "USB FIFO Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifo1](fifo1) module"]
 pub type FIFO1 = crate::Reg<u32, _FIFO1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -543,7 +543,7 @@ impl crate::Readable for FIFO1 {}
 impl crate::Writable for FIFO1 {}
 #[doc = "USB FIFO Endpoint 1"]
 pub mod fifo1;
-#[doc = "USB FIFO Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifo2](fifo2) module"]
+#[doc = "USB FIFO Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifo2](fifo2) module"]
 pub type FIFO2 = crate::Reg<u32, _FIFO2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -554,7 +554,7 @@ impl crate::Readable for FIFO2 {}
 impl crate::Writable for FIFO2 {}
 #[doc = "USB FIFO Endpoint 2"]
 pub mod fifo2;
-#[doc = "USB FIFO Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifo3](fifo3) module"]
+#[doc = "USB FIFO Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifo3](fifo3) module"]
 pub type FIFO3 = crate::Reg<u32, _FIFO3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -565,7 +565,7 @@ impl crate::Readable for FIFO3 {}
 impl crate::Writable for FIFO3 {}
 #[doc = "USB FIFO Endpoint 3"]
 pub mod fifo3;
-#[doc = "USB FIFO Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifo4](fifo4) module"]
+#[doc = "USB FIFO Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifo4](fifo4) module"]
 pub type FIFO4 = crate::Reg<u32, _FIFO4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -576,7 +576,7 @@ impl crate::Readable for FIFO4 {}
 impl crate::Writable for FIFO4 {}
 #[doc = "USB FIFO Endpoint 4"]
 pub mod fifo4;
-#[doc = "USB FIFO Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifo5](fifo5) module"]
+#[doc = "USB FIFO Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifo5](fifo5) module"]
 pub type FIFO5 = crate::Reg<u32, _FIFO5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -587,7 +587,7 @@ impl crate::Readable for FIFO5 {}
 impl crate::Writable for FIFO5 {}
 #[doc = "USB FIFO Endpoint 5"]
 pub mod fifo5;
-#[doc = "USB FIFO Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifo6](fifo6) module"]
+#[doc = "USB FIFO Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifo6](fifo6) module"]
 pub type FIFO6 = crate::Reg<u32, _FIFO6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -598,7 +598,7 @@ impl crate::Readable for FIFO6 {}
 impl crate::Writable for FIFO6 {}
 #[doc = "USB FIFO Endpoint 6"]
 pub mod fifo6;
-#[doc = "USB FIFO Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifo7](fifo7) module"]
+#[doc = "USB FIFO Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifo7](fifo7) module"]
 pub type FIFO7 = crate::Reg<u32, _FIFO7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -609,7 +609,7 @@ impl crate::Readable for FIFO7 {}
 impl crate::Writable for FIFO7 {}
 #[doc = "USB FIFO Endpoint 7"]
 pub mod fifo7;
-#[doc = "USB Device Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [devctl](devctl) module"]
+#[doc = "USB Device Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [devctl](devctl) module"]
 pub type DEVCTL = crate::Reg<u8, _DEVCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -620,7 +620,7 @@ impl crate::Readable for DEVCTL {}
 impl crate::Writable for DEVCTL {}
 #[doc = "USB Device Control"]
 pub mod devctl;
-#[doc = "USB Transmit Dynamic FIFO Sizing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfifosz](txfifosz) module"]
+#[doc = "USB Transmit Dynamic FIFO Sizing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfifosz](txfifosz) module"]
 pub type TXFIFOSZ = crate::Reg<u8, _TXFIFOSZ>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -631,7 +631,7 @@ impl crate::Readable for TXFIFOSZ {}
 impl crate::Writable for TXFIFOSZ {}
 #[doc = "USB Transmit Dynamic FIFO Sizing"]
 pub mod txfifosz;
-#[doc = "USB Receive Dynamic FIFO Sizing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfifosz](rxfifosz) module"]
+#[doc = "USB Receive Dynamic FIFO Sizing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfifosz](rxfifosz) module"]
 pub type RXFIFOSZ = crate::Reg<u8, _RXFIFOSZ>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -642,7 +642,7 @@ impl crate::Readable for RXFIFOSZ {}
 impl crate::Writable for RXFIFOSZ {}
 #[doc = "USB Receive Dynamic FIFO Sizing"]
 pub mod rxfifosz;
-#[doc = "USB Transmit FIFO Start Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfifoadd](txfifoadd) module"]
+#[doc = "USB Transmit FIFO Start Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfifoadd](txfifoadd) module"]
 pub type TXFIFOADD = crate::Reg<u16, _TXFIFOADD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -653,7 +653,7 @@ impl crate::Readable for TXFIFOADD {}
 impl crate::Writable for TXFIFOADD {}
 #[doc = "USB Transmit FIFO Start Address"]
 pub mod txfifoadd;
-#[doc = "USB Receive FIFO Start Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfifoadd](rxfifoadd) module"]
+#[doc = "USB Receive FIFO Start Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfifoadd](rxfifoadd) module"]
 pub type RXFIFOADD = crate::Reg<u16, _RXFIFOADD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -664,7 +664,7 @@ impl crate::Readable for RXFIFOADD {}
 impl crate::Writable for RXFIFOADD {}
 #[doc = "USB Receive FIFO Start Address"]
 pub mod rxfifoadd;
-#[doc = "USB Connect Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [contim](contim) module"]
+#[doc = "USB Connect Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [contim](contim) module"]
 pub type CONTIM = crate::Reg<u8, _CONTIM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -675,7 +675,7 @@ impl crate::Readable for CONTIM {}
 impl crate::Writable for CONTIM {}
 #[doc = "USB Connect Timing"]
 pub mod contim;
-#[doc = "USB OTG VBUS Pulse Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [vplen](vplen) module"]
+#[doc = "USB OTG VBUS Pulse Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [vplen](vplen) module"]
 pub type VPLEN = crate::Reg<u8, _VPLEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -686,7 +686,7 @@ impl crate::Readable for VPLEN {}
 impl crate::Writable for VPLEN {}
 #[doc = "USB OTG VBUS Pulse Timing"]
 pub mod vplen;
-#[doc = "USB Full-Speed Last Transaction to End of Frame Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fseof](fseof) module"]
+#[doc = "USB Full-Speed Last Transaction to End of Frame Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fseof](fseof) module"]
 pub type FSEOF = crate::Reg<u8, _FSEOF>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -697,7 +697,7 @@ impl crate::Readable for FSEOF {}
 impl crate::Writable for FSEOF {}
 #[doc = "USB Full-Speed Last Transaction to End of Frame Timing"]
 pub mod fseof;
-#[doc = "USB Low-Speed Last Transaction to End of Frame Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [lseof](lseof) module"]
+#[doc = "USB Low-Speed Last Transaction to End of Frame Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [lseof](lseof) module"]
 pub type LSEOF = crate::Reg<u8, _LSEOF>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -708,7 +708,7 @@ impl crate::Readable for LSEOF {}
 impl crate::Writable for LSEOF {}
 #[doc = "USB Low-Speed Last Transaction to End of Frame Timing"]
 pub mod lseof;
-#[doc = "USB Transmit Functional Address Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfuncaddr0](txfuncaddr0) module"]
+#[doc = "USB Transmit Functional Address Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfuncaddr0](txfuncaddr0) module"]
 pub type TXFUNCADDR0 = crate::Reg<u8, _TXFUNCADDR0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -719,7 +719,7 @@ impl crate::Readable for TXFUNCADDR0 {}
 impl crate::Writable for TXFUNCADDR0 {}
 #[doc = "USB Transmit Functional Address Endpoint 0"]
 pub mod txfuncaddr0;
-#[doc = "USB Transmit Hub Address Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubaddr0](txhubaddr0) module"]
+#[doc = "USB Transmit Hub Address Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubaddr0](txhubaddr0) module"]
 pub type TXHUBADDR0 = crate::Reg<u8, _TXHUBADDR0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -730,7 +730,7 @@ impl crate::Readable for TXHUBADDR0 {}
 impl crate::Writable for TXHUBADDR0 {}
 #[doc = "USB Transmit Hub Address Endpoint 0"]
 pub mod txhubaddr0;
-#[doc = "USB Transmit Hub Port Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubport0](txhubport0) module"]
+#[doc = "USB Transmit Hub Port Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubport0](txhubport0) module"]
 pub type TXHUBPORT0 = crate::Reg<u8, _TXHUBPORT0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -741,7 +741,7 @@ impl crate::Readable for TXHUBPORT0 {}
 impl crate::Writable for TXHUBPORT0 {}
 #[doc = "USB Transmit Hub Port Endpoint 0"]
 pub mod txhubport0;
-#[doc = "USB Transmit Functional Address Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfuncaddr1](txfuncaddr1) module"]
+#[doc = "USB Transmit Functional Address Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfuncaddr1](txfuncaddr1) module"]
 pub type TXFUNCADDR1 = crate::Reg<u8, _TXFUNCADDR1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -752,7 +752,7 @@ impl crate::Readable for TXFUNCADDR1 {}
 impl crate::Writable for TXFUNCADDR1 {}
 #[doc = "USB Transmit Functional Address Endpoint 1"]
 pub mod txfuncaddr1;
-#[doc = "USB Transmit Hub Address Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubaddr1](txhubaddr1) module"]
+#[doc = "USB Transmit Hub Address Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubaddr1](txhubaddr1) module"]
 pub type TXHUBADDR1 = crate::Reg<u8, _TXHUBADDR1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -763,7 +763,7 @@ impl crate::Readable for TXHUBADDR1 {}
 impl crate::Writable for TXHUBADDR1 {}
 #[doc = "USB Transmit Hub Address Endpoint 1"]
 pub mod txhubaddr1;
-#[doc = "USB Transmit Hub Port Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubport1](txhubport1) module"]
+#[doc = "USB Transmit Hub Port Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubport1](txhubport1) module"]
 pub type TXHUBPORT1 = crate::Reg<u8, _TXHUBPORT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -774,7 +774,7 @@ impl crate::Readable for TXHUBPORT1 {}
 impl crate::Writable for TXHUBPORT1 {}
 #[doc = "USB Transmit Hub Port Endpoint 1"]
 pub mod txhubport1;
-#[doc = "USB Receive Functional Address Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfuncaddr1](rxfuncaddr1) module"]
+#[doc = "USB Receive Functional Address Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfuncaddr1](rxfuncaddr1) module"]
 pub type RXFUNCADDR1 = crate::Reg<u8, _RXFUNCADDR1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -785,7 +785,7 @@ impl crate::Readable for RXFUNCADDR1 {}
 impl crate::Writable for RXFUNCADDR1 {}
 #[doc = "USB Receive Functional Address Endpoint 1"]
 pub mod rxfuncaddr1;
-#[doc = "USB Receive Hub Address Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubaddr1](rxhubaddr1) module"]
+#[doc = "USB Receive Hub Address Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubaddr1](rxhubaddr1) module"]
 pub type RXHUBADDR1 = crate::Reg<u8, _RXHUBADDR1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -796,7 +796,7 @@ impl crate::Readable for RXHUBADDR1 {}
 impl crate::Writable for RXHUBADDR1 {}
 #[doc = "USB Receive Hub Address Endpoint 1"]
 pub mod rxhubaddr1;
-#[doc = "USB Receive Hub Port Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubport1](rxhubport1) module"]
+#[doc = "USB Receive Hub Port Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubport1](rxhubport1) module"]
 pub type RXHUBPORT1 = crate::Reg<u8, _RXHUBPORT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -807,7 +807,7 @@ impl crate::Readable for RXHUBPORT1 {}
 impl crate::Writable for RXHUBPORT1 {}
 #[doc = "USB Receive Hub Port Endpoint 1"]
 pub mod rxhubport1;
-#[doc = "USB Transmit Functional Address Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfuncaddr2](txfuncaddr2) module"]
+#[doc = "USB Transmit Functional Address Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfuncaddr2](txfuncaddr2) module"]
 pub type TXFUNCADDR2 = crate::Reg<u8, _TXFUNCADDR2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -818,7 +818,7 @@ impl crate::Readable for TXFUNCADDR2 {}
 impl crate::Writable for TXFUNCADDR2 {}
 #[doc = "USB Transmit Functional Address Endpoint 2"]
 pub mod txfuncaddr2;
-#[doc = "USB Transmit Hub Address Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubaddr2](txhubaddr2) module"]
+#[doc = "USB Transmit Hub Address Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubaddr2](txhubaddr2) module"]
 pub type TXHUBADDR2 = crate::Reg<u8, _TXHUBADDR2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -829,7 +829,7 @@ impl crate::Readable for TXHUBADDR2 {}
 impl crate::Writable for TXHUBADDR2 {}
 #[doc = "USB Transmit Hub Address Endpoint 2"]
 pub mod txhubaddr2;
-#[doc = "USB Transmit Hub Port Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubport2](txhubport2) module"]
+#[doc = "USB Transmit Hub Port Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubport2](txhubport2) module"]
 pub type TXHUBPORT2 = crate::Reg<u8, _TXHUBPORT2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -840,7 +840,7 @@ impl crate::Readable for TXHUBPORT2 {}
 impl crate::Writable for TXHUBPORT2 {}
 #[doc = "USB Transmit Hub Port Endpoint 2"]
 pub mod txhubport2;
-#[doc = "USB Receive Functional Address Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfuncaddr2](rxfuncaddr2) module"]
+#[doc = "USB Receive Functional Address Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfuncaddr2](rxfuncaddr2) module"]
 pub type RXFUNCADDR2 = crate::Reg<u8, _RXFUNCADDR2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -851,7 +851,7 @@ impl crate::Readable for RXFUNCADDR2 {}
 impl crate::Writable for RXFUNCADDR2 {}
 #[doc = "USB Receive Functional Address Endpoint 2"]
 pub mod rxfuncaddr2;
-#[doc = "USB Receive Hub Address Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubaddr2](rxhubaddr2) module"]
+#[doc = "USB Receive Hub Address Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubaddr2](rxhubaddr2) module"]
 pub type RXHUBADDR2 = crate::Reg<u8, _RXHUBADDR2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -862,7 +862,7 @@ impl crate::Readable for RXHUBADDR2 {}
 impl crate::Writable for RXHUBADDR2 {}
 #[doc = "USB Receive Hub Address Endpoint 2"]
 pub mod rxhubaddr2;
-#[doc = "USB Receive Hub Port Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubport2](rxhubport2) module"]
+#[doc = "USB Receive Hub Port Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubport2](rxhubport2) module"]
 pub type RXHUBPORT2 = crate::Reg<u8, _RXHUBPORT2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -873,7 +873,7 @@ impl crate::Readable for RXHUBPORT2 {}
 impl crate::Writable for RXHUBPORT2 {}
 #[doc = "USB Receive Hub Port Endpoint 2"]
 pub mod rxhubport2;
-#[doc = "USB Transmit Functional Address Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfuncaddr3](txfuncaddr3) module"]
+#[doc = "USB Transmit Functional Address Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfuncaddr3](txfuncaddr3) module"]
 pub type TXFUNCADDR3 = crate::Reg<u8, _TXFUNCADDR3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -884,7 +884,7 @@ impl crate::Readable for TXFUNCADDR3 {}
 impl crate::Writable for TXFUNCADDR3 {}
 #[doc = "USB Transmit Functional Address Endpoint 3"]
 pub mod txfuncaddr3;
-#[doc = "USB Transmit Hub Address Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubaddr3](txhubaddr3) module"]
+#[doc = "USB Transmit Hub Address Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubaddr3](txhubaddr3) module"]
 pub type TXHUBADDR3 = crate::Reg<u8, _TXHUBADDR3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -895,7 +895,7 @@ impl crate::Readable for TXHUBADDR3 {}
 impl crate::Writable for TXHUBADDR3 {}
 #[doc = "USB Transmit Hub Address Endpoint 3"]
 pub mod txhubaddr3;
-#[doc = "USB Transmit Hub Port Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubport3](txhubport3) module"]
+#[doc = "USB Transmit Hub Port Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubport3](txhubport3) module"]
 pub type TXHUBPORT3 = crate::Reg<u8, _TXHUBPORT3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -906,7 +906,7 @@ impl crate::Readable for TXHUBPORT3 {}
 impl crate::Writable for TXHUBPORT3 {}
 #[doc = "USB Transmit Hub Port Endpoint 3"]
 pub mod txhubport3;
-#[doc = "USB Receive Functional Address Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfuncaddr3](rxfuncaddr3) module"]
+#[doc = "USB Receive Functional Address Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfuncaddr3](rxfuncaddr3) module"]
 pub type RXFUNCADDR3 = crate::Reg<u8, _RXFUNCADDR3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -917,7 +917,7 @@ impl crate::Readable for RXFUNCADDR3 {}
 impl crate::Writable for RXFUNCADDR3 {}
 #[doc = "USB Receive Functional Address Endpoint 3"]
 pub mod rxfuncaddr3;
-#[doc = "USB Receive Hub Address Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubaddr3](rxhubaddr3) module"]
+#[doc = "USB Receive Hub Address Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubaddr3](rxhubaddr3) module"]
 pub type RXHUBADDR3 = crate::Reg<u8, _RXHUBADDR3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -928,7 +928,7 @@ impl crate::Readable for RXHUBADDR3 {}
 impl crate::Writable for RXHUBADDR3 {}
 #[doc = "USB Receive Hub Address Endpoint 3"]
 pub mod rxhubaddr3;
-#[doc = "USB Receive Hub Port Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubport3](rxhubport3) module"]
+#[doc = "USB Receive Hub Port Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubport3](rxhubport3) module"]
 pub type RXHUBPORT3 = crate::Reg<u8, _RXHUBPORT3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -939,7 +939,7 @@ impl crate::Readable for RXHUBPORT3 {}
 impl crate::Writable for RXHUBPORT3 {}
 #[doc = "USB Receive Hub Port Endpoint 3"]
 pub mod rxhubport3;
-#[doc = "USB Transmit Functional Address Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfuncaddr4](txfuncaddr4) module"]
+#[doc = "USB Transmit Functional Address Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfuncaddr4](txfuncaddr4) module"]
 pub type TXFUNCADDR4 = crate::Reg<u8, _TXFUNCADDR4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -950,7 +950,7 @@ impl crate::Readable for TXFUNCADDR4 {}
 impl crate::Writable for TXFUNCADDR4 {}
 #[doc = "USB Transmit Functional Address Endpoint 4"]
 pub mod txfuncaddr4;
-#[doc = "USB Transmit Hub Address Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubaddr4](txhubaddr4) module"]
+#[doc = "USB Transmit Hub Address Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubaddr4](txhubaddr4) module"]
 pub type TXHUBADDR4 = crate::Reg<u8, _TXHUBADDR4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -961,7 +961,7 @@ impl crate::Readable for TXHUBADDR4 {}
 impl crate::Writable for TXHUBADDR4 {}
 #[doc = "USB Transmit Hub Address Endpoint 4"]
 pub mod txhubaddr4;
-#[doc = "USB Transmit Hub Port Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubport4](txhubport4) module"]
+#[doc = "USB Transmit Hub Port Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubport4](txhubport4) module"]
 pub type TXHUBPORT4 = crate::Reg<u8, _TXHUBPORT4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -972,7 +972,7 @@ impl crate::Readable for TXHUBPORT4 {}
 impl crate::Writable for TXHUBPORT4 {}
 #[doc = "USB Transmit Hub Port Endpoint 4"]
 pub mod txhubport4;
-#[doc = "USB Receive Functional Address Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfuncaddr4](rxfuncaddr4) module"]
+#[doc = "USB Receive Functional Address Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfuncaddr4](rxfuncaddr4) module"]
 pub type RXFUNCADDR4 = crate::Reg<u8, _RXFUNCADDR4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -983,7 +983,7 @@ impl crate::Readable for RXFUNCADDR4 {}
 impl crate::Writable for RXFUNCADDR4 {}
 #[doc = "USB Receive Functional Address Endpoint 4"]
 pub mod rxfuncaddr4;
-#[doc = "USB Receive Hub Address Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubaddr4](rxhubaddr4) module"]
+#[doc = "USB Receive Hub Address Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubaddr4](rxhubaddr4) module"]
 pub type RXHUBADDR4 = crate::Reg<u8, _RXHUBADDR4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -994,7 +994,7 @@ impl crate::Readable for RXHUBADDR4 {}
 impl crate::Writable for RXHUBADDR4 {}
 #[doc = "USB Receive Hub Address Endpoint 4"]
 pub mod rxhubaddr4;
-#[doc = "USB Receive Hub Port Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubport4](rxhubport4) module"]
+#[doc = "USB Receive Hub Port Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubport4](rxhubport4) module"]
 pub type RXHUBPORT4 = crate::Reg<u8, _RXHUBPORT4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1005,7 +1005,7 @@ impl crate::Readable for RXHUBPORT4 {}
 impl crate::Writable for RXHUBPORT4 {}
 #[doc = "USB Receive Hub Port Endpoint 4"]
 pub mod rxhubport4;
-#[doc = "USB Transmit Functional Address Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfuncaddr5](txfuncaddr5) module"]
+#[doc = "USB Transmit Functional Address Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfuncaddr5](txfuncaddr5) module"]
 pub type TXFUNCADDR5 = crate::Reg<u8, _TXFUNCADDR5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1016,7 +1016,7 @@ impl crate::Readable for TXFUNCADDR5 {}
 impl crate::Writable for TXFUNCADDR5 {}
 #[doc = "USB Transmit Functional Address Endpoint 5"]
 pub mod txfuncaddr5;
-#[doc = "USB Transmit Hub Address Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubaddr5](txhubaddr5) module"]
+#[doc = "USB Transmit Hub Address Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubaddr5](txhubaddr5) module"]
 pub type TXHUBADDR5 = crate::Reg<u8, _TXHUBADDR5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1027,7 +1027,7 @@ impl crate::Readable for TXHUBADDR5 {}
 impl crate::Writable for TXHUBADDR5 {}
 #[doc = "USB Transmit Hub Address Endpoint 5"]
 pub mod txhubaddr5;
-#[doc = "USB Transmit Hub Port Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubport5](txhubport5) module"]
+#[doc = "USB Transmit Hub Port Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubport5](txhubport5) module"]
 pub type TXHUBPORT5 = crate::Reg<u8, _TXHUBPORT5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1038,7 +1038,7 @@ impl crate::Readable for TXHUBPORT5 {}
 impl crate::Writable for TXHUBPORT5 {}
 #[doc = "USB Transmit Hub Port Endpoint 5"]
 pub mod txhubport5;
-#[doc = "USB Receive Functional Address Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfuncaddr5](rxfuncaddr5) module"]
+#[doc = "USB Receive Functional Address Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfuncaddr5](rxfuncaddr5) module"]
 pub type RXFUNCADDR5 = crate::Reg<u8, _RXFUNCADDR5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1049,7 +1049,7 @@ impl crate::Readable for RXFUNCADDR5 {}
 impl crate::Writable for RXFUNCADDR5 {}
 #[doc = "USB Receive Functional Address Endpoint 5"]
 pub mod rxfuncaddr5;
-#[doc = "USB Receive Hub Address Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubaddr5](rxhubaddr5) module"]
+#[doc = "USB Receive Hub Address Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubaddr5](rxhubaddr5) module"]
 pub type RXHUBADDR5 = crate::Reg<u8, _RXHUBADDR5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1060,7 +1060,7 @@ impl crate::Readable for RXHUBADDR5 {}
 impl crate::Writable for RXHUBADDR5 {}
 #[doc = "USB Receive Hub Address Endpoint 5"]
 pub mod rxhubaddr5;
-#[doc = "USB Receive Hub Port Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubport5](rxhubport5) module"]
+#[doc = "USB Receive Hub Port Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubport5](rxhubport5) module"]
 pub type RXHUBPORT5 = crate::Reg<u8, _RXHUBPORT5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1071,7 +1071,7 @@ impl crate::Readable for RXHUBPORT5 {}
 impl crate::Writable for RXHUBPORT5 {}
 #[doc = "USB Receive Hub Port Endpoint 5"]
 pub mod rxhubport5;
-#[doc = "USB Transmit Functional Address Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfuncaddr6](txfuncaddr6) module"]
+#[doc = "USB Transmit Functional Address Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfuncaddr6](txfuncaddr6) module"]
 pub type TXFUNCADDR6 = crate::Reg<u8, _TXFUNCADDR6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1082,7 +1082,7 @@ impl crate::Readable for TXFUNCADDR6 {}
 impl crate::Writable for TXFUNCADDR6 {}
 #[doc = "USB Transmit Functional Address Endpoint 6"]
 pub mod txfuncaddr6;
-#[doc = "USB Transmit Hub Address Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubaddr6](txhubaddr6) module"]
+#[doc = "USB Transmit Hub Address Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubaddr6](txhubaddr6) module"]
 pub type TXHUBADDR6 = crate::Reg<u8, _TXHUBADDR6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1093,7 +1093,7 @@ impl crate::Readable for TXHUBADDR6 {}
 impl crate::Writable for TXHUBADDR6 {}
 #[doc = "USB Transmit Hub Address Endpoint 6"]
 pub mod txhubaddr6;
-#[doc = "USB Transmit Hub Port Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubport6](txhubport6) module"]
+#[doc = "USB Transmit Hub Port Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubport6](txhubport6) module"]
 pub type TXHUBPORT6 = crate::Reg<u8, _TXHUBPORT6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1104,7 +1104,7 @@ impl crate::Readable for TXHUBPORT6 {}
 impl crate::Writable for TXHUBPORT6 {}
 #[doc = "USB Transmit Hub Port Endpoint 6"]
 pub mod txhubport6;
-#[doc = "USB Receive Functional Address Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfuncaddr6](rxfuncaddr6) module"]
+#[doc = "USB Receive Functional Address Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfuncaddr6](rxfuncaddr6) module"]
 pub type RXFUNCADDR6 = crate::Reg<u8, _RXFUNCADDR6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1115,7 +1115,7 @@ impl crate::Readable for RXFUNCADDR6 {}
 impl crate::Writable for RXFUNCADDR6 {}
 #[doc = "USB Receive Functional Address Endpoint 6"]
 pub mod rxfuncaddr6;
-#[doc = "USB Receive Hub Address Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubaddr6](rxhubaddr6) module"]
+#[doc = "USB Receive Hub Address Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubaddr6](rxhubaddr6) module"]
 pub type RXHUBADDR6 = crate::Reg<u8, _RXHUBADDR6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1126,7 +1126,7 @@ impl crate::Readable for RXHUBADDR6 {}
 impl crate::Writable for RXHUBADDR6 {}
 #[doc = "USB Receive Hub Address Endpoint 6"]
 pub mod rxhubaddr6;
-#[doc = "USB Receive Hub Port Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubport6](rxhubport6) module"]
+#[doc = "USB Receive Hub Port Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubport6](rxhubport6) module"]
 pub type RXHUBPORT6 = crate::Reg<u8, _RXHUBPORT6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1137,7 +1137,7 @@ impl crate::Readable for RXHUBPORT6 {}
 impl crate::Writable for RXHUBPORT6 {}
 #[doc = "USB Receive Hub Port Endpoint 6"]
 pub mod rxhubport6;
-#[doc = "USB Transmit Functional Address Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfuncaddr7](txfuncaddr7) module"]
+#[doc = "USB Transmit Functional Address Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfuncaddr7](txfuncaddr7) module"]
 pub type TXFUNCADDR7 = crate::Reg<u8, _TXFUNCADDR7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1148,7 +1148,7 @@ impl crate::Readable for TXFUNCADDR7 {}
 impl crate::Writable for TXFUNCADDR7 {}
 #[doc = "USB Transmit Functional Address Endpoint 7"]
 pub mod txfuncaddr7;
-#[doc = "USB Transmit Hub Address Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubaddr7](txhubaddr7) module"]
+#[doc = "USB Transmit Hub Address Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubaddr7](txhubaddr7) module"]
 pub type TXHUBADDR7 = crate::Reg<u8, _TXHUBADDR7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1159,7 +1159,7 @@ impl crate::Readable for TXHUBADDR7 {}
 impl crate::Writable for TXHUBADDR7 {}
 #[doc = "USB Transmit Hub Address Endpoint 7"]
 pub mod txhubaddr7;
-#[doc = "USB Transmit Hub Port Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubport7](txhubport7) module"]
+#[doc = "USB Transmit Hub Port Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubport7](txhubport7) module"]
 pub type TXHUBPORT7 = crate::Reg<u8, _TXHUBPORT7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1170,7 +1170,7 @@ impl crate::Readable for TXHUBPORT7 {}
 impl crate::Writable for TXHUBPORT7 {}
 #[doc = "USB Transmit Hub Port Endpoint 7"]
 pub mod txhubport7;
-#[doc = "USB Receive Functional Address Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfuncaddr7](rxfuncaddr7) module"]
+#[doc = "USB Receive Functional Address Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfuncaddr7](rxfuncaddr7) module"]
 pub type RXFUNCADDR7 = crate::Reg<u8, _RXFUNCADDR7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1181,7 +1181,7 @@ impl crate::Readable for RXFUNCADDR7 {}
 impl crate::Writable for RXFUNCADDR7 {}
 #[doc = "USB Receive Functional Address Endpoint 7"]
 pub mod rxfuncaddr7;
-#[doc = "USB Receive Hub Address Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubaddr7](rxhubaddr7) module"]
+#[doc = "USB Receive Hub Address Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubaddr7](rxhubaddr7) module"]
 pub type RXHUBADDR7 = crate::Reg<u8, _RXHUBADDR7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1192,7 +1192,7 @@ impl crate::Readable for RXHUBADDR7 {}
 impl crate::Writable for RXHUBADDR7 {}
 #[doc = "USB Receive Hub Address Endpoint 7"]
 pub mod rxhubaddr7;
-#[doc = "USB Receive Hub Port Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubport7](rxhubport7) module"]
+#[doc = "USB Receive Hub Port Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubport7](rxhubport7) module"]
 pub type RXHUBPORT7 = crate::Reg<u8, _RXHUBPORT7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1203,7 +1203,7 @@ impl crate::Readable for RXHUBPORT7 {}
 impl crate::Writable for RXHUBPORT7 {}
 #[doc = "USB Receive Hub Port Endpoint 7"]
 pub mod rxhubport7;
-#[doc = "USB Control and Status Endpoint 0 Low\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [csrl0](csrl0) module"]
+#[doc = "USB Control and Status Endpoint 0 Low\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [csrl0](csrl0) module"]
 pub type CSRL0 = crate::Reg<u8, _CSRL0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1212,7 +1212,7 @@ pub struct _CSRL0;
 impl crate::Writable for CSRL0 {}
 #[doc = "USB Control and Status Endpoint 0 Low"]
 pub mod csrl0;
-#[doc = "USB Control and Status Endpoint 0 High\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [csrh0](csrh0) module"]
+#[doc = "USB Control and Status Endpoint 0 High\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [csrh0](csrh0) module"]
 pub type CSRH0 = crate::Reg<u8, _CSRH0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1221,7 +1221,7 @@ pub struct _CSRH0;
 impl crate::Writable for CSRH0 {}
 #[doc = "USB Control and Status Endpoint 0 High"]
 pub mod csrh0;
-#[doc = "USB Receive Byte Count Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [count0](count0) module"]
+#[doc = "USB Receive Byte Count Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [count0](count0) module"]
 pub type COUNT0 = crate::Reg<u8, _COUNT0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1230,7 +1230,7 @@ pub struct _COUNT0;
 impl crate::Readable for COUNT0 {}
 #[doc = "USB Receive Byte Count Endpoint 0"]
 pub mod count0;
-#[doc = "USB Type Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [type0](type0) module"]
+#[doc = "USB Type Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [type0](type0) module"]
 pub type TYPE0 = crate::Reg<u8, _TYPE0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1241,7 +1241,7 @@ impl crate::Readable for TYPE0 {}
 impl crate::Writable for TYPE0 {}
 #[doc = "USB Type Endpoint 0"]
 pub mod type0;
-#[doc = "USB NAK Limit\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [naklmt](naklmt) module"]
+#[doc = "USB NAK Limit\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [naklmt](naklmt) module"]
 pub type NAKLMT = crate::Reg<u8, _NAKLMT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1252,7 +1252,7 @@ impl crate::Readable for NAKLMT {}
 impl crate::Writable for NAKLMT {}
 #[doc = "USB NAK Limit"]
 pub mod naklmt;
-#[doc = "USB Maximum Transmit Data Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txmaxp1](txmaxp1) module"]
+#[doc = "USB Maximum Transmit Data Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txmaxp1](txmaxp1) module"]
 pub type TXMAXP1 = crate::Reg<u16, _TXMAXP1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1263,7 +1263,7 @@ impl crate::Readable for TXMAXP1 {}
 impl crate::Writable for TXMAXP1 {}
 #[doc = "USB Maximum Transmit Data Endpoint 1"]
 pub mod txmaxp1;
-#[doc = "USB Transmit Control and Status Endpoint 1 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrl1](txcsrl1) module"]
+#[doc = "USB Transmit Control and Status Endpoint 1 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrl1](txcsrl1) module"]
 pub type TXCSRL1 = crate::Reg<u8, _TXCSRL1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1274,7 +1274,7 @@ impl crate::Readable for TXCSRL1 {}
 impl crate::Writable for TXCSRL1 {}
 #[doc = "USB Transmit Control and Status Endpoint 1 Low"]
 pub mod txcsrl1;
-#[doc = "USB Transmit Control and Status Endpoint 1 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrh1](txcsrh1) module"]
+#[doc = "USB Transmit Control and Status Endpoint 1 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrh1](txcsrh1) module"]
 pub type TXCSRH1 = crate::Reg<u8, _TXCSRH1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1285,7 +1285,7 @@ impl crate::Readable for TXCSRH1 {}
 impl crate::Writable for TXCSRH1 {}
 #[doc = "USB Transmit Control and Status Endpoint 1 High"]
 pub mod txcsrh1;
-#[doc = "USB Maximum Receive Data Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxmaxp1](rxmaxp1) module"]
+#[doc = "USB Maximum Receive Data Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxmaxp1](rxmaxp1) module"]
 pub type RXMAXP1 = crate::Reg<u16, _RXMAXP1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1296,7 +1296,7 @@ impl crate::Readable for RXMAXP1 {}
 impl crate::Writable for RXMAXP1 {}
 #[doc = "USB Maximum Receive Data Endpoint 1"]
 pub mod rxmaxp1;
-#[doc = "USB Receive Control and Status Endpoint 1 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrl1](rxcsrl1) module"]
+#[doc = "USB Receive Control and Status Endpoint 1 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrl1](rxcsrl1) module"]
 pub type RXCSRL1 = crate::Reg<u8, _RXCSRL1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1307,7 +1307,7 @@ impl crate::Readable for RXCSRL1 {}
 impl crate::Writable for RXCSRL1 {}
 #[doc = "USB Receive Control and Status Endpoint 1 Low"]
 pub mod rxcsrl1;
-#[doc = "USB Receive Control and Status Endpoint 1 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrh1](rxcsrh1) module"]
+#[doc = "USB Receive Control and Status Endpoint 1 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrh1](rxcsrh1) module"]
 pub type RXCSRH1 = crate::Reg<u8, _RXCSRH1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1318,7 +1318,7 @@ impl crate::Readable for RXCSRH1 {}
 impl crate::Writable for RXCSRH1 {}
 #[doc = "USB Receive Control and Status Endpoint 1 High"]
 pub mod rxcsrh1;
-#[doc = "USB Receive Byte Count Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcount1](rxcount1) module"]
+#[doc = "USB Receive Byte Count Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcount1](rxcount1) module"]
 pub type RXCOUNT1 = crate::Reg<u16, _RXCOUNT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1327,7 +1327,7 @@ pub struct _RXCOUNT1;
 impl crate::Readable for RXCOUNT1 {}
 #[doc = "USB Receive Byte Count Endpoint 1"]
 pub mod rxcount1;
-#[doc = "USB Host Transmit Configure Type Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txtype1](txtype1) module"]
+#[doc = "USB Host Transmit Configure Type Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txtype1](txtype1) module"]
 pub type TXTYPE1 = crate::Reg<u8, _TXTYPE1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1338,7 +1338,7 @@ impl crate::Readable for TXTYPE1 {}
 impl crate::Writable for TXTYPE1 {}
 #[doc = "USB Host Transmit Configure Type Endpoint 1"]
 pub mod txtype1;
-#[doc = "USB Host Transmit Interval Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txinterval1](txinterval1) module"]
+#[doc = "USB Host Transmit Interval Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txinterval1](txinterval1) module"]
 pub type TXINTERVAL1 = crate::Reg<u8, _TXINTERVAL1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1349,7 +1349,7 @@ impl crate::Readable for TXINTERVAL1 {}
 impl crate::Writable for TXINTERVAL1 {}
 #[doc = "USB Host Transmit Interval Endpoint 1"]
 pub mod txinterval1;
-#[doc = "USB Host Configure Receive Type Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxtype1](rxtype1) module"]
+#[doc = "USB Host Configure Receive Type Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxtype1](rxtype1) module"]
 pub type RXTYPE1 = crate::Reg<u8, _RXTYPE1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1360,7 +1360,7 @@ impl crate::Readable for RXTYPE1 {}
 impl crate::Writable for RXTYPE1 {}
 #[doc = "USB Host Configure Receive Type Endpoint 1"]
 pub mod rxtype1;
-#[doc = "USB Host Receive Polling Interval Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxinterval1](rxinterval1) module"]
+#[doc = "USB Host Receive Polling Interval Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxinterval1](rxinterval1) module"]
 pub type RXINTERVAL1 = crate::Reg<u8, _RXINTERVAL1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1371,7 +1371,7 @@ impl crate::Readable for RXINTERVAL1 {}
 impl crate::Writable for RXINTERVAL1 {}
 #[doc = "USB Host Receive Polling Interval Endpoint 1"]
 pub mod rxinterval1;
-#[doc = "USB Maximum Transmit Data Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txmaxp2](txmaxp2) module"]
+#[doc = "USB Maximum Transmit Data Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txmaxp2](txmaxp2) module"]
 pub type TXMAXP2 = crate::Reg<u16, _TXMAXP2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1382,7 +1382,7 @@ impl crate::Readable for TXMAXP2 {}
 impl crate::Writable for TXMAXP2 {}
 #[doc = "USB Maximum Transmit Data Endpoint 2"]
 pub mod txmaxp2;
-#[doc = "USB Transmit Control and Status Endpoint 2 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrl2](txcsrl2) module"]
+#[doc = "USB Transmit Control and Status Endpoint 2 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrl2](txcsrl2) module"]
 pub type TXCSRL2 = crate::Reg<u8, _TXCSRL2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1393,7 +1393,7 @@ impl crate::Readable for TXCSRL2 {}
 impl crate::Writable for TXCSRL2 {}
 #[doc = "USB Transmit Control and Status Endpoint 2 Low"]
 pub mod txcsrl2;
-#[doc = "USB Transmit Control and Status Endpoint 2 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrh2](txcsrh2) module"]
+#[doc = "USB Transmit Control and Status Endpoint 2 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrh2](txcsrh2) module"]
 pub type TXCSRH2 = crate::Reg<u8, _TXCSRH2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1404,7 +1404,7 @@ impl crate::Readable for TXCSRH2 {}
 impl crate::Writable for TXCSRH2 {}
 #[doc = "USB Transmit Control and Status Endpoint 2 High"]
 pub mod txcsrh2;
-#[doc = "USB Maximum Receive Data Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxmaxp2](rxmaxp2) module"]
+#[doc = "USB Maximum Receive Data Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxmaxp2](rxmaxp2) module"]
 pub type RXMAXP2 = crate::Reg<u16, _RXMAXP2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1415,7 +1415,7 @@ impl crate::Readable for RXMAXP2 {}
 impl crate::Writable for RXMAXP2 {}
 #[doc = "USB Maximum Receive Data Endpoint 2"]
 pub mod rxmaxp2;
-#[doc = "USB Receive Control and Status Endpoint 2 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrl2](rxcsrl2) module"]
+#[doc = "USB Receive Control and Status Endpoint 2 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrl2](rxcsrl2) module"]
 pub type RXCSRL2 = crate::Reg<u8, _RXCSRL2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1426,7 +1426,7 @@ impl crate::Readable for RXCSRL2 {}
 impl crate::Writable for RXCSRL2 {}
 #[doc = "USB Receive Control and Status Endpoint 2 Low"]
 pub mod rxcsrl2;
-#[doc = "USB Receive Control and Status Endpoint 2 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrh2](rxcsrh2) module"]
+#[doc = "USB Receive Control and Status Endpoint 2 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrh2](rxcsrh2) module"]
 pub type RXCSRH2 = crate::Reg<u8, _RXCSRH2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1437,7 +1437,7 @@ impl crate::Readable for RXCSRH2 {}
 impl crate::Writable for RXCSRH2 {}
 #[doc = "USB Receive Control and Status Endpoint 2 High"]
 pub mod rxcsrh2;
-#[doc = "USB Receive Byte Count Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcount2](rxcount2) module"]
+#[doc = "USB Receive Byte Count Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcount2](rxcount2) module"]
 pub type RXCOUNT2 = crate::Reg<u16, _RXCOUNT2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1446,7 +1446,7 @@ pub struct _RXCOUNT2;
 impl crate::Readable for RXCOUNT2 {}
 #[doc = "USB Receive Byte Count Endpoint 2"]
 pub mod rxcount2;
-#[doc = "USB Host Transmit Configure Type Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txtype2](txtype2) module"]
+#[doc = "USB Host Transmit Configure Type Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txtype2](txtype2) module"]
 pub type TXTYPE2 = crate::Reg<u8, _TXTYPE2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1457,7 +1457,7 @@ impl crate::Readable for TXTYPE2 {}
 impl crate::Writable for TXTYPE2 {}
 #[doc = "USB Host Transmit Configure Type Endpoint 2"]
 pub mod txtype2;
-#[doc = "USB Host Transmit Interval Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txinterval2](txinterval2) module"]
+#[doc = "USB Host Transmit Interval Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txinterval2](txinterval2) module"]
 pub type TXINTERVAL2 = crate::Reg<u8, _TXINTERVAL2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1468,7 +1468,7 @@ impl crate::Readable for TXINTERVAL2 {}
 impl crate::Writable for TXINTERVAL2 {}
 #[doc = "USB Host Transmit Interval Endpoint 2"]
 pub mod txinterval2;
-#[doc = "USB Host Configure Receive Type Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxtype2](rxtype2) module"]
+#[doc = "USB Host Configure Receive Type Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxtype2](rxtype2) module"]
 pub type RXTYPE2 = crate::Reg<u8, _RXTYPE2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1479,7 +1479,7 @@ impl crate::Readable for RXTYPE2 {}
 impl crate::Writable for RXTYPE2 {}
 #[doc = "USB Host Configure Receive Type Endpoint 2"]
 pub mod rxtype2;
-#[doc = "USB Host Receive Polling Interval Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxinterval2](rxinterval2) module"]
+#[doc = "USB Host Receive Polling Interval Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxinterval2](rxinterval2) module"]
 pub type RXINTERVAL2 = crate::Reg<u8, _RXINTERVAL2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1490,7 +1490,7 @@ impl crate::Readable for RXINTERVAL2 {}
 impl crate::Writable for RXINTERVAL2 {}
 #[doc = "USB Host Receive Polling Interval Endpoint 2"]
 pub mod rxinterval2;
-#[doc = "USB Maximum Transmit Data Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txmaxp3](txmaxp3) module"]
+#[doc = "USB Maximum Transmit Data Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txmaxp3](txmaxp3) module"]
 pub type TXMAXP3 = crate::Reg<u16, _TXMAXP3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1501,7 +1501,7 @@ impl crate::Readable for TXMAXP3 {}
 impl crate::Writable for TXMAXP3 {}
 #[doc = "USB Maximum Transmit Data Endpoint 3"]
 pub mod txmaxp3;
-#[doc = "USB Transmit Control and Status Endpoint 3 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrl3](txcsrl3) module"]
+#[doc = "USB Transmit Control and Status Endpoint 3 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrl3](txcsrl3) module"]
 pub type TXCSRL3 = crate::Reg<u8, _TXCSRL3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1512,7 +1512,7 @@ impl crate::Readable for TXCSRL3 {}
 impl crate::Writable for TXCSRL3 {}
 #[doc = "USB Transmit Control and Status Endpoint 3 Low"]
 pub mod txcsrl3;
-#[doc = "USB Transmit Control and Status Endpoint 3 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrh3](txcsrh3) module"]
+#[doc = "USB Transmit Control and Status Endpoint 3 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrh3](txcsrh3) module"]
 pub type TXCSRH3 = crate::Reg<u8, _TXCSRH3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1523,7 +1523,7 @@ impl crate::Readable for TXCSRH3 {}
 impl crate::Writable for TXCSRH3 {}
 #[doc = "USB Transmit Control and Status Endpoint 3 High"]
 pub mod txcsrh3;
-#[doc = "USB Maximum Receive Data Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxmaxp3](rxmaxp3) module"]
+#[doc = "USB Maximum Receive Data Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxmaxp3](rxmaxp3) module"]
 pub type RXMAXP3 = crate::Reg<u16, _RXMAXP3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1534,7 +1534,7 @@ impl crate::Readable for RXMAXP3 {}
 impl crate::Writable for RXMAXP3 {}
 #[doc = "USB Maximum Receive Data Endpoint 3"]
 pub mod rxmaxp3;
-#[doc = "USB Receive Control and Status Endpoint 3 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrl3](rxcsrl3) module"]
+#[doc = "USB Receive Control and Status Endpoint 3 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrl3](rxcsrl3) module"]
 pub type RXCSRL3 = crate::Reg<u8, _RXCSRL3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1545,7 +1545,7 @@ impl crate::Readable for RXCSRL3 {}
 impl crate::Writable for RXCSRL3 {}
 #[doc = "USB Receive Control and Status Endpoint 3 Low"]
 pub mod rxcsrl3;
-#[doc = "USB Receive Control and Status Endpoint 3 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrh3](rxcsrh3) module"]
+#[doc = "USB Receive Control and Status Endpoint 3 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrh3](rxcsrh3) module"]
 pub type RXCSRH3 = crate::Reg<u8, _RXCSRH3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1556,7 +1556,7 @@ impl crate::Readable for RXCSRH3 {}
 impl crate::Writable for RXCSRH3 {}
 #[doc = "USB Receive Control and Status Endpoint 3 High"]
 pub mod rxcsrh3;
-#[doc = "USB Receive Byte Count Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcount3](rxcount3) module"]
+#[doc = "USB Receive Byte Count Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcount3](rxcount3) module"]
 pub type RXCOUNT3 = crate::Reg<u16, _RXCOUNT3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1565,7 +1565,7 @@ pub struct _RXCOUNT3;
 impl crate::Readable for RXCOUNT3 {}
 #[doc = "USB Receive Byte Count Endpoint 3"]
 pub mod rxcount3;
-#[doc = "USB Host Transmit Configure Type Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txtype3](txtype3) module"]
+#[doc = "USB Host Transmit Configure Type Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txtype3](txtype3) module"]
 pub type TXTYPE3 = crate::Reg<u8, _TXTYPE3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1576,7 +1576,7 @@ impl crate::Readable for TXTYPE3 {}
 impl crate::Writable for TXTYPE3 {}
 #[doc = "USB Host Transmit Configure Type Endpoint 3"]
 pub mod txtype3;
-#[doc = "USB Host Transmit Interval Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txinterval3](txinterval3) module"]
+#[doc = "USB Host Transmit Interval Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txinterval3](txinterval3) module"]
 pub type TXINTERVAL3 = crate::Reg<u8, _TXINTERVAL3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1587,7 +1587,7 @@ impl crate::Readable for TXINTERVAL3 {}
 impl crate::Writable for TXINTERVAL3 {}
 #[doc = "USB Host Transmit Interval Endpoint 3"]
 pub mod txinterval3;
-#[doc = "USB Host Configure Receive Type Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxtype3](rxtype3) module"]
+#[doc = "USB Host Configure Receive Type Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxtype3](rxtype3) module"]
 pub type RXTYPE3 = crate::Reg<u8, _RXTYPE3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1598,7 +1598,7 @@ impl crate::Readable for RXTYPE3 {}
 impl crate::Writable for RXTYPE3 {}
 #[doc = "USB Host Configure Receive Type Endpoint 3"]
 pub mod rxtype3;
-#[doc = "USB Host Receive Polling Interval Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxinterval3](rxinterval3) module"]
+#[doc = "USB Host Receive Polling Interval Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxinterval3](rxinterval3) module"]
 pub type RXINTERVAL3 = crate::Reg<u8, _RXINTERVAL3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1609,7 +1609,7 @@ impl crate::Readable for RXINTERVAL3 {}
 impl crate::Writable for RXINTERVAL3 {}
 #[doc = "USB Host Receive Polling Interval Endpoint 3"]
 pub mod rxinterval3;
-#[doc = "USB Maximum Transmit Data Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txmaxp4](txmaxp4) module"]
+#[doc = "USB Maximum Transmit Data Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txmaxp4](txmaxp4) module"]
 pub type TXMAXP4 = crate::Reg<u16, _TXMAXP4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1620,7 +1620,7 @@ impl crate::Readable for TXMAXP4 {}
 impl crate::Writable for TXMAXP4 {}
 #[doc = "USB Maximum Transmit Data Endpoint 4"]
 pub mod txmaxp4;
-#[doc = "USB Transmit Control and Status Endpoint 4 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrl4](txcsrl4) module"]
+#[doc = "USB Transmit Control and Status Endpoint 4 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrl4](txcsrl4) module"]
 pub type TXCSRL4 = crate::Reg<u8, _TXCSRL4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1631,7 +1631,7 @@ impl crate::Readable for TXCSRL4 {}
 impl crate::Writable for TXCSRL4 {}
 #[doc = "USB Transmit Control and Status Endpoint 4 Low"]
 pub mod txcsrl4;
-#[doc = "USB Transmit Control and Status Endpoint 4 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrh4](txcsrh4) module"]
+#[doc = "USB Transmit Control and Status Endpoint 4 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrh4](txcsrh4) module"]
 pub type TXCSRH4 = crate::Reg<u8, _TXCSRH4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1642,7 +1642,7 @@ impl crate::Readable for TXCSRH4 {}
 impl crate::Writable for TXCSRH4 {}
 #[doc = "USB Transmit Control and Status Endpoint 4 High"]
 pub mod txcsrh4;
-#[doc = "USB Maximum Receive Data Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxmaxp4](rxmaxp4) module"]
+#[doc = "USB Maximum Receive Data Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxmaxp4](rxmaxp4) module"]
 pub type RXMAXP4 = crate::Reg<u16, _RXMAXP4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1653,7 +1653,7 @@ impl crate::Readable for RXMAXP4 {}
 impl crate::Writable for RXMAXP4 {}
 #[doc = "USB Maximum Receive Data Endpoint 4"]
 pub mod rxmaxp4;
-#[doc = "USB Receive Control and Status Endpoint 4 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrl4](rxcsrl4) module"]
+#[doc = "USB Receive Control and Status Endpoint 4 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrl4](rxcsrl4) module"]
 pub type RXCSRL4 = crate::Reg<u8, _RXCSRL4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1664,7 +1664,7 @@ impl crate::Readable for RXCSRL4 {}
 impl crate::Writable for RXCSRL4 {}
 #[doc = "USB Receive Control and Status Endpoint 4 Low"]
 pub mod rxcsrl4;
-#[doc = "USB Receive Control and Status Endpoint 4 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrh4](rxcsrh4) module"]
+#[doc = "USB Receive Control and Status Endpoint 4 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrh4](rxcsrh4) module"]
 pub type RXCSRH4 = crate::Reg<u8, _RXCSRH4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1675,7 +1675,7 @@ impl crate::Readable for RXCSRH4 {}
 impl crate::Writable for RXCSRH4 {}
 #[doc = "USB Receive Control and Status Endpoint 4 High"]
 pub mod rxcsrh4;
-#[doc = "USB Receive Byte Count Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcount4](rxcount4) module"]
+#[doc = "USB Receive Byte Count Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcount4](rxcount4) module"]
 pub type RXCOUNT4 = crate::Reg<u16, _RXCOUNT4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1684,7 +1684,7 @@ pub struct _RXCOUNT4;
 impl crate::Readable for RXCOUNT4 {}
 #[doc = "USB Receive Byte Count Endpoint 4"]
 pub mod rxcount4;
-#[doc = "USB Host Transmit Configure Type Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txtype4](txtype4) module"]
+#[doc = "USB Host Transmit Configure Type Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txtype4](txtype4) module"]
 pub type TXTYPE4 = crate::Reg<u8, _TXTYPE4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1695,7 +1695,7 @@ impl crate::Readable for TXTYPE4 {}
 impl crate::Writable for TXTYPE4 {}
 #[doc = "USB Host Transmit Configure Type Endpoint 4"]
 pub mod txtype4;
-#[doc = "USB Host Transmit Interval Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txinterval4](txinterval4) module"]
+#[doc = "USB Host Transmit Interval Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txinterval4](txinterval4) module"]
 pub type TXINTERVAL4 = crate::Reg<u8, _TXINTERVAL4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1706,7 +1706,7 @@ impl crate::Readable for TXINTERVAL4 {}
 impl crate::Writable for TXINTERVAL4 {}
 #[doc = "USB Host Transmit Interval Endpoint 4"]
 pub mod txinterval4;
-#[doc = "USB Host Configure Receive Type Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxtype4](rxtype4) module"]
+#[doc = "USB Host Configure Receive Type Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxtype4](rxtype4) module"]
 pub type RXTYPE4 = crate::Reg<u8, _RXTYPE4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1717,7 +1717,7 @@ impl crate::Readable for RXTYPE4 {}
 impl crate::Writable for RXTYPE4 {}
 #[doc = "USB Host Configure Receive Type Endpoint 4"]
 pub mod rxtype4;
-#[doc = "USB Host Receive Polling Interval Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxinterval4](rxinterval4) module"]
+#[doc = "USB Host Receive Polling Interval Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxinterval4](rxinterval4) module"]
 pub type RXINTERVAL4 = crate::Reg<u8, _RXINTERVAL4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1728,7 +1728,7 @@ impl crate::Readable for RXINTERVAL4 {}
 impl crate::Writable for RXINTERVAL4 {}
 #[doc = "USB Host Receive Polling Interval Endpoint 4"]
 pub mod rxinterval4;
-#[doc = "USB Maximum Transmit Data Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txmaxp5](txmaxp5) module"]
+#[doc = "USB Maximum Transmit Data Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txmaxp5](txmaxp5) module"]
 pub type TXMAXP5 = crate::Reg<u16, _TXMAXP5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1739,7 +1739,7 @@ impl crate::Readable for TXMAXP5 {}
 impl crate::Writable for TXMAXP5 {}
 #[doc = "USB Maximum Transmit Data Endpoint 5"]
 pub mod txmaxp5;
-#[doc = "USB Transmit Control and Status Endpoint 5 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrl5](txcsrl5) module"]
+#[doc = "USB Transmit Control and Status Endpoint 5 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrl5](txcsrl5) module"]
 pub type TXCSRL5 = crate::Reg<u8, _TXCSRL5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1750,7 +1750,7 @@ impl crate::Readable for TXCSRL5 {}
 impl crate::Writable for TXCSRL5 {}
 #[doc = "USB Transmit Control and Status Endpoint 5 Low"]
 pub mod txcsrl5;
-#[doc = "USB Transmit Control and Status Endpoint 5 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrh5](txcsrh5) module"]
+#[doc = "USB Transmit Control and Status Endpoint 5 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrh5](txcsrh5) module"]
 pub type TXCSRH5 = crate::Reg<u8, _TXCSRH5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1761,7 +1761,7 @@ impl crate::Readable for TXCSRH5 {}
 impl crate::Writable for TXCSRH5 {}
 #[doc = "USB Transmit Control and Status Endpoint 5 High"]
 pub mod txcsrh5;
-#[doc = "USB Maximum Receive Data Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxmaxp5](rxmaxp5) module"]
+#[doc = "USB Maximum Receive Data Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxmaxp5](rxmaxp5) module"]
 pub type RXMAXP5 = crate::Reg<u16, _RXMAXP5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1772,7 +1772,7 @@ impl crate::Readable for RXMAXP5 {}
 impl crate::Writable for RXMAXP5 {}
 #[doc = "USB Maximum Receive Data Endpoint 5"]
 pub mod rxmaxp5;
-#[doc = "USB Receive Control and Status Endpoint 5 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrl5](rxcsrl5) module"]
+#[doc = "USB Receive Control and Status Endpoint 5 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrl5](rxcsrl5) module"]
 pub type RXCSRL5 = crate::Reg<u8, _RXCSRL5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1783,7 +1783,7 @@ impl crate::Readable for RXCSRL5 {}
 impl crate::Writable for RXCSRL5 {}
 #[doc = "USB Receive Control and Status Endpoint 5 Low"]
 pub mod rxcsrl5;
-#[doc = "USB Receive Control and Status Endpoint 5 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrh5](rxcsrh5) module"]
+#[doc = "USB Receive Control and Status Endpoint 5 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrh5](rxcsrh5) module"]
 pub type RXCSRH5 = crate::Reg<u8, _RXCSRH5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1794,7 +1794,7 @@ impl crate::Readable for RXCSRH5 {}
 impl crate::Writable for RXCSRH5 {}
 #[doc = "USB Receive Control and Status Endpoint 5 High"]
 pub mod rxcsrh5;
-#[doc = "USB Receive Byte Count Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcount5](rxcount5) module"]
+#[doc = "USB Receive Byte Count Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcount5](rxcount5) module"]
 pub type RXCOUNT5 = crate::Reg<u16, _RXCOUNT5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1803,7 +1803,7 @@ pub struct _RXCOUNT5;
 impl crate::Readable for RXCOUNT5 {}
 #[doc = "USB Receive Byte Count Endpoint 5"]
 pub mod rxcount5;
-#[doc = "USB Host Transmit Configure Type Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txtype5](txtype5) module"]
+#[doc = "USB Host Transmit Configure Type Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txtype5](txtype5) module"]
 pub type TXTYPE5 = crate::Reg<u8, _TXTYPE5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1814,7 +1814,7 @@ impl crate::Readable for TXTYPE5 {}
 impl crate::Writable for TXTYPE5 {}
 #[doc = "USB Host Transmit Configure Type Endpoint 5"]
 pub mod txtype5;
-#[doc = "USB Host Transmit Interval Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txinterval5](txinterval5) module"]
+#[doc = "USB Host Transmit Interval Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txinterval5](txinterval5) module"]
 pub type TXINTERVAL5 = crate::Reg<u8, _TXINTERVAL5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1825,7 +1825,7 @@ impl crate::Readable for TXINTERVAL5 {}
 impl crate::Writable for TXINTERVAL5 {}
 #[doc = "USB Host Transmit Interval Endpoint 5"]
 pub mod txinterval5;
-#[doc = "USB Host Configure Receive Type Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxtype5](rxtype5) module"]
+#[doc = "USB Host Configure Receive Type Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxtype5](rxtype5) module"]
 pub type RXTYPE5 = crate::Reg<u8, _RXTYPE5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1836,7 +1836,7 @@ impl crate::Readable for RXTYPE5 {}
 impl crate::Writable for RXTYPE5 {}
 #[doc = "USB Host Configure Receive Type Endpoint 5"]
 pub mod rxtype5;
-#[doc = "USB Host Receive Polling Interval Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxinterval5](rxinterval5) module"]
+#[doc = "USB Host Receive Polling Interval Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxinterval5](rxinterval5) module"]
 pub type RXINTERVAL5 = crate::Reg<u8, _RXINTERVAL5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1847,7 +1847,7 @@ impl crate::Readable for RXINTERVAL5 {}
 impl crate::Writable for RXINTERVAL5 {}
 #[doc = "USB Host Receive Polling Interval Endpoint 5"]
 pub mod rxinterval5;
-#[doc = "USB Maximum Transmit Data Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txmaxp6](txmaxp6) module"]
+#[doc = "USB Maximum Transmit Data Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txmaxp6](txmaxp6) module"]
 pub type TXMAXP6 = crate::Reg<u16, _TXMAXP6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1858,7 +1858,7 @@ impl crate::Readable for TXMAXP6 {}
 impl crate::Writable for TXMAXP6 {}
 #[doc = "USB Maximum Transmit Data Endpoint 6"]
 pub mod txmaxp6;
-#[doc = "USB Transmit Control and Status Endpoint 6 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrl6](txcsrl6) module"]
+#[doc = "USB Transmit Control and Status Endpoint 6 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrl6](txcsrl6) module"]
 pub type TXCSRL6 = crate::Reg<u8, _TXCSRL6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1869,7 +1869,7 @@ impl crate::Readable for TXCSRL6 {}
 impl crate::Writable for TXCSRL6 {}
 #[doc = "USB Transmit Control and Status Endpoint 6 Low"]
 pub mod txcsrl6;
-#[doc = "USB Transmit Control and Status Endpoint 6 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrh6](txcsrh6) module"]
+#[doc = "USB Transmit Control and Status Endpoint 6 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrh6](txcsrh6) module"]
 pub type TXCSRH6 = crate::Reg<u8, _TXCSRH6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1880,7 +1880,7 @@ impl crate::Readable for TXCSRH6 {}
 impl crate::Writable for TXCSRH6 {}
 #[doc = "USB Transmit Control and Status Endpoint 6 High"]
 pub mod txcsrh6;
-#[doc = "USB Maximum Receive Data Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxmaxp6](rxmaxp6) module"]
+#[doc = "USB Maximum Receive Data Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxmaxp6](rxmaxp6) module"]
 pub type RXMAXP6 = crate::Reg<u16, _RXMAXP6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1891,7 +1891,7 @@ impl crate::Readable for RXMAXP6 {}
 impl crate::Writable for RXMAXP6 {}
 #[doc = "USB Maximum Receive Data Endpoint 6"]
 pub mod rxmaxp6;
-#[doc = "USB Receive Control and Status Endpoint 6 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrl6](rxcsrl6) module"]
+#[doc = "USB Receive Control and Status Endpoint 6 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrl6](rxcsrl6) module"]
 pub type RXCSRL6 = crate::Reg<u8, _RXCSRL6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1902,7 +1902,7 @@ impl crate::Readable for RXCSRL6 {}
 impl crate::Writable for RXCSRL6 {}
 #[doc = "USB Receive Control and Status Endpoint 6 Low"]
 pub mod rxcsrl6;
-#[doc = "USB Receive Control and Status Endpoint 6 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrh6](rxcsrh6) module"]
+#[doc = "USB Receive Control and Status Endpoint 6 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrh6](rxcsrh6) module"]
 pub type RXCSRH6 = crate::Reg<u8, _RXCSRH6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1913,7 +1913,7 @@ impl crate::Readable for RXCSRH6 {}
 impl crate::Writable for RXCSRH6 {}
 #[doc = "USB Receive Control and Status Endpoint 6 High"]
 pub mod rxcsrh6;
-#[doc = "USB Receive Byte Count Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcount6](rxcount6) module"]
+#[doc = "USB Receive Byte Count Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcount6](rxcount6) module"]
 pub type RXCOUNT6 = crate::Reg<u16, _RXCOUNT6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1922,7 +1922,7 @@ pub struct _RXCOUNT6;
 impl crate::Readable for RXCOUNT6 {}
 #[doc = "USB Receive Byte Count Endpoint 6"]
 pub mod rxcount6;
-#[doc = "USB Host Transmit Configure Type Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txtype6](txtype6) module"]
+#[doc = "USB Host Transmit Configure Type Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txtype6](txtype6) module"]
 pub type TXTYPE6 = crate::Reg<u8, _TXTYPE6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1933,7 +1933,7 @@ impl crate::Readable for TXTYPE6 {}
 impl crate::Writable for TXTYPE6 {}
 #[doc = "USB Host Transmit Configure Type Endpoint 6"]
 pub mod txtype6;
-#[doc = "USB Host Transmit Interval Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txinterval6](txinterval6) module"]
+#[doc = "USB Host Transmit Interval Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txinterval6](txinterval6) module"]
 pub type TXINTERVAL6 = crate::Reg<u8, _TXINTERVAL6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1944,7 +1944,7 @@ impl crate::Readable for TXINTERVAL6 {}
 impl crate::Writable for TXINTERVAL6 {}
 #[doc = "USB Host Transmit Interval Endpoint 6"]
 pub mod txinterval6;
-#[doc = "USB Host Configure Receive Type Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxtype6](rxtype6) module"]
+#[doc = "USB Host Configure Receive Type Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxtype6](rxtype6) module"]
 pub type RXTYPE6 = crate::Reg<u8, _RXTYPE6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1955,7 +1955,7 @@ impl crate::Readable for RXTYPE6 {}
 impl crate::Writable for RXTYPE6 {}
 #[doc = "USB Host Configure Receive Type Endpoint 6"]
 pub mod rxtype6;
-#[doc = "USB Host Receive Polling Interval Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxinterval6](rxinterval6) module"]
+#[doc = "USB Host Receive Polling Interval Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxinterval6](rxinterval6) module"]
 pub type RXINTERVAL6 = crate::Reg<u8, _RXINTERVAL6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1966,7 +1966,7 @@ impl crate::Readable for RXINTERVAL6 {}
 impl crate::Writable for RXINTERVAL6 {}
 #[doc = "USB Host Receive Polling Interval Endpoint 6"]
 pub mod rxinterval6;
-#[doc = "USB Maximum Transmit Data Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txmaxp7](txmaxp7) module"]
+#[doc = "USB Maximum Transmit Data Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txmaxp7](txmaxp7) module"]
 pub type TXMAXP7 = crate::Reg<u16, _TXMAXP7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1977,7 +1977,7 @@ impl crate::Readable for TXMAXP7 {}
 impl crate::Writable for TXMAXP7 {}
 #[doc = "USB Maximum Transmit Data Endpoint 7"]
 pub mod txmaxp7;
-#[doc = "USB Transmit Control and Status Endpoint 7 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrl7](txcsrl7) module"]
+#[doc = "USB Transmit Control and Status Endpoint 7 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrl7](txcsrl7) module"]
 pub type TXCSRL7 = crate::Reg<u8, _TXCSRL7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1988,7 +1988,7 @@ impl crate::Readable for TXCSRL7 {}
 impl crate::Writable for TXCSRL7 {}
 #[doc = "USB Transmit Control and Status Endpoint 7 Low"]
 pub mod txcsrl7;
-#[doc = "USB Transmit Control and Status Endpoint 7 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrh7](txcsrh7) module"]
+#[doc = "USB Transmit Control and Status Endpoint 7 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrh7](txcsrh7) module"]
 pub type TXCSRH7 = crate::Reg<u8, _TXCSRH7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1999,7 +1999,7 @@ impl crate::Readable for TXCSRH7 {}
 impl crate::Writable for TXCSRH7 {}
 #[doc = "USB Transmit Control and Status Endpoint 7 High"]
 pub mod txcsrh7;
-#[doc = "USB Maximum Receive Data Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxmaxp7](rxmaxp7) module"]
+#[doc = "USB Maximum Receive Data Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxmaxp7](rxmaxp7) module"]
 pub type RXMAXP7 = crate::Reg<u16, _RXMAXP7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2010,7 +2010,7 @@ impl crate::Readable for RXMAXP7 {}
 impl crate::Writable for RXMAXP7 {}
 #[doc = "USB Maximum Receive Data Endpoint 7"]
 pub mod rxmaxp7;
-#[doc = "USB Receive Control and Status Endpoint 7 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrl7](rxcsrl7) module"]
+#[doc = "USB Receive Control and Status Endpoint 7 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrl7](rxcsrl7) module"]
 pub type RXCSRL7 = crate::Reg<u8, _RXCSRL7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2021,7 +2021,7 @@ impl crate::Readable for RXCSRL7 {}
 impl crate::Writable for RXCSRL7 {}
 #[doc = "USB Receive Control and Status Endpoint 7 Low"]
 pub mod rxcsrl7;
-#[doc = "USB Receive Control and Status Endpoint 7 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrh7](rxcsrh7) module"]
+#[doc = "USB Receive Control and Status Endpoint 7 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrh7](rxcsrh7) module"]
 pub type RXCSRH7 = crate::Reg<u8, _RXCSRH7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2032,7 +2032,7 @@ impl crate::Readable for RXCSRH7 {}
 impl crate::Writable for RXCSRH7 {}
 #[doc = "USB Receive Control and Status Endpoint 7 High"]
 pub mod rxcsrh7;
-#[doc = "USB Receive Byte Count Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcount7](rxcount7) module"]
+#[doc = "USB Receive Byte Count Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcount7](rxcount7) module"]
 pub type RXCOUNT7 = crate::Reg<u16, _RXCOUNT7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2041,7 +2041,7 @@ pub struct _RXCOUNT7;
 impl crate::Readable for RXCOUNT7 {}
 #[doc = "USB Receive Byte Count Endpoint 7"]
 pub mod rxcount7;
-#[doc = "USB Host Transmit Configure Type Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txtype7](txtype7) module"]
+#[doc = "USB Host Transmit Configure Type Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txtype7](txtype7) module"]
 pub type TXTYPE7 = crate::Reg<u8, _TXTYPE7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2052,7 +2052,7 @@ impl crate::Readable for TXTYPE7 {}
 impl crate::Writable for TXTYPE7 {}
 #[doc = "USB Host Transmit Configure Type Endpoint 7"]
 pub mod txtype7;
-#[doc = "USB Host Transmit Interval Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txinterval7](txinterval7) module"]
+#[doc = "USB Host Transmit Interval Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txinterval7](txinterval7) module"]
 pub type TXINTERVAL7 = crate::Reg<u8, _TXINTERVAL7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2063,7 +2063,7 @@ impl crate::Readable for TXINTERVAL7 {}
 impl crate::Writable for TXINTERVAL7 {}
 #[doc = "USB Host Transmit Interval Endpoint 7"]
 pub mod txinterval7;
-#[doc = "USB Host Configure Receive Type Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxtype7](rxtype7) module"]
+#[doc = "USB Host Configure Receive Type Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxtype7](rxtype7) module"]
 pub type RXTYPE7 = crate::Reg<u8, _RXTYPE7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2074,7 +2074,7 @@ impl crate::Readable for RXTYPE7 {}
 impl crate::Writable for RXTYPE7 {}
 #[doc = "USB Host Configure Receive Type Endpoint 7"]
 pub mod rxtype7;
-#[doc = "USB Host Receive Polling Interval Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxinterval7](rxinterval7) module"]
+#[doc = "USB Host Receive Polling Interval Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxinterval7](rxinterval7) module"]
 pub type RXINTERVAL7 = crate::Reg<u8, _RXINTERVAL7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2085,7 +2085,7 @@ impl crate::Readable for RXINTERVAL7 {}
 impl crate::Writable for RXINTERVAL7 {}
 #[doc = "USB Host Receive Polling Interval Endpoint 7"]
 pub mod rxinterval7;
-#[doc = "USB Request Packet Count in Block Transfer Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rqpktcount1](rqpktcount1) module"]
+#[doc = "USB Request Packet Count in Block Transfer Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rqpktcount1](rqpktcount1) module"]
 pub type RQPKTCOUNT1 = crate::Reg<u16, _RQPKTCOUNT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2096,7 +2096,7 @@ impl crate::Readable for RQPKTCOUNT1 {}
 impl crate::Writable for RQPKTCOUNT1 {}
 #[doc = "USB Request Packet Count in Block Transfer Endpoint 1"]
 pub mod rqpktcount1;
-#[doc = "USB Request Packet Count in Block Transfer Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rqpktcount2](rqpktcount2) module"]
+#[doc = "USB Request Packet Count in Block Transfer Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rqpktcount2](rqpktcount2) module"]
 pub type RQPKTCOUNT2 = crate::Reg<u16, _RQPKTCOUNT2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2107,7 +2107,7 @@ impl crate::Readable for RQPKTCOUNT2 {}
 impl crate::Writable for RQPKTCOUNT2 {}
 #[doc = "USB Request Packet Count in Block Transfer Endpoint 2"]
 pub mod rqpktcount2;
-#[doc = "USB Request Packet Count in Block Transfer Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rqpktcount3](rqpktcount3) module"]
+#[doc = "USB Request Packet Count in Block Transfer Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rqpktcount3](rqpktcount3) module"]
 pub type RQPKTCOUNT3 = crate::Reg<u16, _RQPKTCOUNT3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2118,7 +2118,7 @@ impl crate::Readable for RQPKTCOUNT3 {}
 impl crate::Writable for RQPKTCOUNT3 {}
 #[doc = "USB Request Packet Count in Block Transfer Endpoint 3"]
 pub mod rqpktcount3;
-#[doc = "USB Request Packet Count in Block Transfer Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rqpktcount4](rqpktcount4) module"]
+#[doc = "USB Request Packet Count in Block Transfer Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rqpktcount4](rqpktcount4) module"]
 pub type RQPKTCOUNT4 = crate::Reg<u16, _RQPKTCOUNT4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2129,7 +2129,7 @@ impl crate::Readable for RQPKTCOUNT4 {}
 impl crate::Writable for RQPKTCOUNT4 {}
 #[doc = "USB Request Packet Count in Block Transfer Endpoint 4"]
 pub mod rqpktcount4;
-#[doc = "USB Request Packet Count in Block Transfer Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rqpktcount5](rqpktcount5) module"]
+#[doc = "USB Request Packet Count in Block Transfer Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rqpktcount5](rqpktcount5) module"]
 pub type RQPKTCOUNT5 = crate::Reg<u16, _RQPKTCOUNT5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2140,7 +2140,7 @@ impl crate::Readable for RQPKTCOUNT5 {}
 impl crate::Writable for RQPKTCOUNT5 {}
 #[doc = "USB Request Packet Count in Block Transfer Endpoint 5"]
 pub mod rqpktcount5;
-#[doc = "USB Request Packet Count in Block Transfer Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rqpktcount6](rqpktcount6) module"]
+#[doc = "USB Request Packet Count in Block Transfer Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rqpktcount6](rqpktcount6) module"]
 pub type RQPKTCOUNT6 = crate::Reg<u16, _RQPKTCOUNT6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2151,7 +2151,7 @@ impl crate::Readable for RQPKTCOUNT6 {}
 impl crate::Writable for RQPKTCOUNT6 {}
 #[doc = "USB Request Packet Count in Block Transfer Endpoint 6"]
 pub mod rqpktcount6;
-#[doc = "USB Request Packet Count in Block Transfer Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rqpktcount7](rqpktcount7) module"]
+#[doc = "USB Request Packet Count in Block Transfer Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rqpktcount7](rqpktcount7) module"]
 pub type RQPKTCOUNT7 = crate::Reg<u16, _RQPKTCOUNT7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2162,7 +2162,7 @@ impl crate::Readable for RQPKTCOUNT7 {}
 impl crate::Writable for RQPKTCOUNT7 {}
 #[doc = "USB Request Packet Count in Block Transfer Endpoint 7"]
 pub mod rqpktcount7;
-#[doc = "USB Receive Double Packet Buffer Disable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxdpktbufdis](rxdpktbufdis) module"]
+#[doc = "USB Receive Double Packet Buffer Disable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxdpktbufdis](rxdpktbufdis) module"]
 pub type RXDPKTBUFDIS = crate::Reg<u16, _RXDPKTBUFDIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2173,7 +2173,7 @@ impl crate::Readable for RXDPKTBUFDIS {}
 impl crate::Writable for RXDPKTBUFDIS {}
 #[doc = "USB Receive Double Packet Buffer Disable"]
 pub mod rxdpktbufdis;
-#[doc = "USB Transmit Double Packet Buffer Disable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txdpktbufdis](txdpktbufdis) module"]
+#[doc = "USB Transmit Double Packet Buffer Disable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txdpktbufdis](txdpktbufdis) module"]
 pub type TXDPKTBUFDIS = crate::Reg<u16, _TXDPKTBUFDIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2184,7 +2184,7 @@ impl crate::Readable for TXDPKTBUFDIS {}
 impl crate::Writable for TXDPKTBUFDIS {}
 #[doc = "USB Transmit Double Packet Buffer Disable"]
 pub mod txdpktbufdis;
-#[doc = "USB External Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epc](epc) module"]
+#[doc = "USB External Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [epc](epc) module"]
 pub type EPC = crate::Reg<u32, _EPC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2195,7 +2195,7 @@ impl crate::Readable for EPC {}
 impl crate::Writable for EPC {}
 #[doc = "USB External Power Control"]
 pub mod epc;
-#[doc = "USB External Power Control Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epcris](epcris) module"]
+#[doc = "USB External Power Control Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [epcris](epcris) module"]
 pub type EPCRIS = crate::Reg<u32, _EPCRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2204,7 +2204,7 @@ pub struct _EPCRIS;
 impl crate::Readable for EPCRIS {}
 #[doc = "USB External Power Control Raw Interrupt Status"]
 pub mod epcris;
-#[doc = "USB External Power Control Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epcim](epcim) module"]
+#[doc = "USB External Power Control Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [epcim](epcim) module"]
 pub type EPCIM = crate::Reg<u32, _EPCIM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2215,7 +2215,7 @@ impl crate::Readable for EPCIM {}
 impl crate::Writable for EPCIM {}
 #[doc = "USB External Power Control Interrupt Mask"]
 pub mod epcim;
-#[doc = "USB External Power Control Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epcisc](epcisc) module"]
+#[doc = "USB External Power Control Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [epcisc](epcisc) module"]
 pub type EPCISC = crate::Reg<u32, _EPCISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2226,7 +2226,7 @@ impl crate::Readable for EPCISC {}
 impl crate::Writable for EPCISC {}
 #[doc = "USB External Power Control Interrupt Status and Clear"]
 pub mod epcisc;
-#[doc = "USB Device RESUME Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [drris](drris) module"]
+#[doc = "USB Device RESUME Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [drris](drris) module"]
 pub type DRRIS = crate::Reg<u32, _DRRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2235,7 +2235,7 @@ pub struct _DRRIS;
 impl crate::Readable for DRRIS {}
 #[doc = "USB Device RESUME Raw Interrupt Status"]
 pub mod drris;
-#[doc = "USB Device RESUME Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [drim](drim) module"]
+#[doc = "USB Device RESUME Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [drim](drim) module"]
 pub type DRIM = crate::Reg<u32, _DRIM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2246,7 +2246,7 @@ impl crate::Readable for DRIM {}
 impl crate::Writable for DRIM {}
 #[doc = "USB Device RESUME Interrupt Mask"]
 pub mod drim;
-#[doc = "USB Device RESUME Interrupt Status and Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [drisc](drisc) module"]
+#[doc = "USB Device RESUME Interrupt Status and Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [drisc](drisc) module"]
 pub type DRISC = crate::Reg<u32, _DRISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2255,7 +2255,7 @@ pub struct _DRISC;
 impl crate::Writable for DRISC {}
 #[doc = "USB Device RESUME Interrupt Status and Clear"]
 pub mod drisc;
-#[doc = "USB General-Purpose Control and Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [gpcs](gpcs) module"]
+#[doc = "USB General-Purpose Control and Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [gpcs](gpcs) module"]
 pub type GPCS = crate::Reg<u32, _GPCS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2266,7 +2266,7 @@ impl crate::Readable for GPCS {}
 impl crate::Writable for GPCS {}
 #[doc = "USB General-Purpose Control and Status"]
 pub mod gpcs;
-#[doc = "USB VBUS Droop Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [vdc](vdc) module"]
+#[doc = "USB VBUS Droop Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [vdc](vdc) module"]
 pub type VDC = crate::Reg<u32, _VDC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2277,7 +2277,7 @@ impl crate::Readable for VDC {}
 impl crate::Writable for VDC {}
 #[doc = "USB VBUS Droop Control"]
 pub mod vdc;
-#[doc = "USB VBUS Droop Control Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [vdcris](vdcris) module"]
+#[doc = "USB VBUS Droop Control Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [vdcris](vdcris) module"]
 pub type VDCRIS = crate::Reg<u32, _VDCRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2286,7 +2286,7 @@ pub struct _VDCRIS;
 impl crate::Readable for VDCRIS {}
 #[doc = "USB VBUS Droop Control Raw Interrupt Status"]
 pub mod vdcris;
-#[doc = "USB VBUS Droop Control Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [vdcim](vdcim) module"]
+#[doc = "USB VBUS Droop Control Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [vdcim](vdcim) module"]
 pub type VDCIM = crate::Reg<u32, _VDCIM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2297,7 +2297,7 @@ impl crate::Readable for VDCIM {}
 impl crate::Writable for VDCIM {}
 #[doc = "USB VBUS Droop Control Interrupt Mask"]
 pub mod vdcim;
-#[doc = "USB VBUS Droop Control Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [vdcisc](vdcisc) module"]
+#[doc = "USB VBUS Droop Control Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [vdcisc](vdcisc) module"]
 pub type VDCISC = crate::Reg<u32, _VDCISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2308,7 +2308,7 @@ impl crate::Readable for VDCISC {}
 impl crate::Writable for VDCISC {}
 #[doc = "USB VBUS Droop Control Interrupt Status and Clear"]
 pub mod vdcisc;
-#[doc = "USB ID Valid Detect Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [idvris](idvris) module"]
+#[doc = "USB ID Valid Detect Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [idvris](idvris) module"]
 pub type IDVRIS = crate::Reg<u32, _IDVRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2317,7 +2317,7 @@ pub struct _IDVRIS;
 impl crate::Readable for IDVRIS {}
 #[doc = "USB ID Valid Detect Raw Interrupt Status"]
 pub mod idvris;
-#[doc = "USB ID Valid Detect Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [idvim](idvim) module"]
+#[doc = "USB ID Valid Detect Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [idvim](idvim) module"]
 pub type IDVIM = crate::Reg<u32, _IDVIM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2328,7 +2328,7 @@ impl crate::Readable for IDVIM {}
 impl crate::Writable for IDVIM {}
 #[doc = "USB ID Valid Detect Interrupt Mask"]
 pub mod idvim;
-#[doc = "USB ID Valid Detect Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [idvisc](idvisc) module"]
+#[doc = "USB ID Valid Detect Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [idvisc](idvisc) module"]
 pub type IDVISC = crate::Reg<u32, _IDVISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2339,7 +2339,7 @@ impl crate::Readable for IDVISC {}
 impl crate::Writable for IDVISC {}
 #[doc = "USB ID Valid Detect Interrupt Status and Clear"]
 pub mod idvisc;
-#[doc = "USB DMA Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmasel](dmasel) module"]
+#[doc = "USB DMA Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmasel](dmasel) module"]
 pub type DMASEL = crate::Reg<u32, _DMASEL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2350,7 +2350,7 @@ impl crate::Readable for DMASEL {}
 impl crate::Writable for DMASEL {}
 #[doc = "USB DMA Select"]
 pub mod dmasel;
-#[doc = "USB Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "USB Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/usb0/devctl.rs
+++ b/crates/tm4c123x/src/usb0/devctl.rs
@@ -84,25 +84,21 @@ impl<'a> HOST_W<'a> {
 }
 #[doc = "VBUS Level (OTG only)\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum VBUS_A {
     #[doc = "0: Below SessionEnd"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Above SessionEnd, below AValid"]
-    SEND,
+    SEND = 1,
     #[doc = "2: Above AValid, below VBUSValid"]
-    AVALID,
+    AVALID = 2,
     #[doc = "3: Above VBUSValid"]
-    VALID,
+    VALID = 3,
 }
 impl From<VBUS_A> for u8 {
     #[inline(always)]
     fn from(variant: VBUS_A) -> Self {
-        match variant {
-            VBUS_A::NONE => 0,
-            VBUS_A::SEND => 1,
-            VBUS_A::AVALID => 2,
-            VBUS_A::VALID => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `VBUS`"]

--- a/crates/tm4c123x/src/usb0/epc.rs
+++ b/crates/tm4c123x/src/usb0/epc.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::EPC {
 }
 #[doc = "External Power Supply Enable Configuration\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum EPEN_A {
     #[doc = "0: Power Enable Active Low"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Power Enable Active High"]
-    HIGH,
+    HIGH = 1,
     #[doc = "2: Power Enable High if VBUS Low (OTG only)"]
-    VBLOW,
+    VBLOW = 2,
     #[doc = "3: Power Enable High if VBUS High (OTG only)"]
-    VBHIGH,
+    VBHIGH = 3,
 }
 impl From<EPEN_A> for u8 {
     #[inline(always)]
     fn from(variant: EPEN_A) -> Self {
-        match variant {
-            EPEN_A::LOW => 0,
-            EPEN_A::HIGH => 1,
-            EPEN_A::VBLOW => 2,
-            EPEN_A::VBHIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `EPEN`"]
@@ -205,25 +201,21 @@ impl<'a> PFLTAEN_W<'a> {
 }
 #[doc = "Power Fault Action\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PFLTACT_A {
     #[doc = "0: Unchanged"]
-    UNCHG,
+    UNCHG = 0,
     #[doc = "1: Tristate"]
-    TRIS,
+    TRIS = 1,
     #[doc = "2: Low"]
-    LOW,
+    LOW = 2,
     #[doc = "3: High"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<PFLTACT_A> for u8 {
     #[inline(always)]
     fn from(variant: PFLTACT_A) -> Self {
-        match variant {
-            PFLTACT_A::UNCHG => 0,
-            PFLTACT_A::TRIS => 1,
-            PFLTACT_A::LOW => 2,
-            PFLTACT_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PFLTACT`"]

--- a/crates/tm4c123x/src/usb0/pp.rs
+++ b/crates/tm4c123x/src/usb0/pp.rs
@@ -2,16 +2,15 @@
 pub type R = crate::R<u32, super::PP>;
 #[doc = "Controller Type\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TYPE_A {
     #[doc = "0: The first-generation USB controller"]
-    _0,
+    _0 = 0,
 }
 impl From<TYPE_A> for u8 {
     #[inline(always)]
     fn from(variant: TYPE_A) -> Self {
-        match variant {
-            TYPE_A::_0 => 0,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TYPE`"]
@@ -36,22 +35,19 @@ impl TYPE_R {
 pub type PHY_R = crate::R<bool, bool>;
 #[doc = "USB Capability\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum USB_A {
     #[doc = "1: DEVICE"]
-    DEVICE,
+    DEVICE = 1,
     #[doc = "2: HOST"]
-    HOSTDEVICE,
+    HOSTDEVICE = 2,
     #[doc = "3: OTG"]
-    OTG,
+    OTG = 3,
 }
 impl From<USB_A> for u8 {
     #[inline(always)]
     fn from(variant: USB_A) -> Self {
-        match variant {
-            USB_A::DEVICE => 1,
-            USB_A::HOSTDEVICE => 2,
-            USB_A::OTG => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `USB`"]

--- a/crates/tm4c123x/src/usb0/rxfifosz.rs
+++ b/crates/tm4c123x/src/usb0/rxfifosz.rs
@@ -12,40 +12,31 @@ impl crate::ResetValue for super::RXFIFOSZ {
 }
 #[doc = "Max Packet Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SIZE_A {
     #[doc = "0: 8"]
-    _8,
+    _8 = 0,
     #[doc = "1: 16"]
-    _16,
+    _16 = 1,
     #[doc = "2: 32"]
-    _32,
+    _32 = 2,
     #[doc = "3: 64"]
-    _64,
+    _64 = 3,
     #[doc = "4: 128"]
-    _128,
+    _128 = 4,
     #[doc = "5: 256"]
-    _256,
+    _256 = 5,
     #[doc = "6: 512"]
-    _512,
+    _512 = 6,
     #[doc = "7: 1024"]
-    _1024,
+    _1024 = 7,
     #[doc = "8: 2048"]
-    _2048,
+    _2048 = 8,
 }
 impl From<SIZE_A> for u8 {
     #[inline(always)]
     fn from(variant: SIZE_A) -> Self {
-        match variant {
-            SIZE_A::_8 => 0,
-            SIZE_A::_16 => 1,
-            SIZE_A::_32 => 2,
-            SIZE_A::_64 => 3,
-            SIZE_A::_128 => 4,
-            SIZE_A::_256 => 5,
-            SIZE_A::_512 => 6,
-            SIZE_A::_1024 => 7,
-            SIZE_A::_2048 => 8,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SIZE`"]

--- a/crates/tm4c123x/src/usb0/rxtype1.rs
+++ b/crates/tm4c123x/src/usb0/rxtype1.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,22 +119,19 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c123x/src/usb0/rxtype2.rs
+++ b/crates/tm4c123x/src/usb0/rxtype2.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,22 +119,19 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c123x/src/usb0/rxtype3.rs
+++ b/crates/tm4c123x/src/usb0/rxtype3.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,22 +119,19 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c123x/src/usb0/rxtype4.rs
+++ b/crates/tm4c123x/src/usb0/rxtype4.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,22 +119,19 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c123x/src/usb0/rxtype5.rs
+++ b/crates/tm4c123x/src/usb0/rxtype5.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,22 +119,19 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c123x/src/usb0/rxtype6.rs
+++ b/crates/tm4c123x/src/usb0/rxtype6.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,22 +119,19 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c123x/src/usb0/rxtype7.rs
+++ b/crates/tm4c123x/src/usb0/rxtype7.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,22 +119,19 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c123x/src/usb0/txfifosz.rs
+++ b/crates/tm4c123x/src/usb0/txfifosz.rs
@@ -12,40 +12,31 @@ impl crate::ResetValue for super::TXFIFOSZ {
 }
 #[doc = "Max Packet Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SIZE_A {
     #[doc = "0: 8"]
-    _8,
+    _8 = 0,
     #[doc = "1: 16"]
-    _16,
+    _16 = 1,
     #[doc = "2: 32"]
-    _32,
+    _32 = 2,
     #[doc = "3: 64"]
-    _64,
+    _64 = 3,
     #[doc = "4: 128"]
-    _128,
+    _128 = 4,
     #[doc = "5: 256"]
-    _256,
+    _256 = 5,
     #[doc = "6: 512"]
-    _512,
+    _512 = 6,
     #[doc = "7: 1024"]
-    _1024,
+    _1024 = 7,
     #[doc = "8: 2048"]
-    _2048,
+    _2048 = 8,
 }
 impl From<SIZE_A> for u8 {
     #[inline(always)]
     fn from(variant: SIZE_A) -> Self {
-        match variant {
-            SIZE_A::_8 => 0,
-            SIZE_A::_16 => 1,
-            SIZE_A::_32 => 2,
-            SIZE_A::_64 => 3,
-            SIZE_A::_128 => 4,
-            SIZE_A::_256 => 5,
-            SIZE_A::_512 => 6,
-            SIZE_A::_1024 => 7,
-            SIZE_A::_2048 => 8,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SIZE`"]

--- a/crates/tm4c123x/src/usb0/txtype1.rs
+++ b/crates/tm4c123x/src/usb0/txtype1.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,22 +119,19 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c123x/src/usb0/txtype2.rs
+++ b/crates/tm4c123x/src/usb0/txtype2.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,22 +119,19 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c123x/src/usb0/txtype3.rs
+++ b/crates/tm4c123x/src/usb0/txtype3.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,22 +119,19 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c123x/src/usb0/txtype4.rs
+++ b/crates/tm4c123x/src/usb0/txtype4.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,22 +119,19 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c123x/src/usb0/txtype5.rs
+++ b/crates/tm4c123x/src/usb0/txtype5.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,22 +119,19 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c123x/src/usb0/txtype6.rs
+++ b/crates/tm4c123x/src/usb0/txtype6.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,22 +119,19 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c123x/src/usb0/txtype7.rs
+++ b/crates/tm4c123x/src/usb0/txtype7.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,22 +119,19 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c123x/src/usb0/type0.rs
+++ b/crates/tm4c123x/src/usb0/type0.rs
@@ -12,19 +12,17 @@ impl crate::ResetValue for super::TYPE0 {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c123x/src/watchdog0.rs
+++ b/crates/tm4c123x/src/watchdog0.rs
@@ -20,7 +20,7 @@ pub struct RegisterBlock {
     #[doc = "0xc00 - Watchdog Lock"]
     pub lock: LOCK,
 }
-#[doc = "Watchdog Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [load](load) module"]
+#[doc = "Watchdog Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [load](load) module"]
 pub type LOAD = crate::Reg<u32, _LOAD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -31,7 +31,7 @@ impl crate::Readable for LOAD {}
 impl crate::Writable for LOAD {}
 #[doc = "Watchdog Load"]
 pub mod load;
-#[doc = "Watchdog Value\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [value](value) module"]
+#[doc = "Watchdog Value\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [value](value) module"]
 pub type VALUE = crate::Reg<u32, _VALUE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -40,7 +40,7 @@ pub struct _VALUE;
 impl crate::Readable for VALUE {}
 #[doc = "Watchdog Value"]
 pub mod value;
-#[doc = "Watchdog Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctl](ctl) module"]
+#[doc = "Watchdog Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctl](ctl) module"]
 pub type CTL = crate::Reg<u32, _CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -51,7 +51,7 @@ impl crate::Readable for CTL {}
 impl crate::Writable for CTL {}
 #[doc = "Watchdog Control"]
 pub mod ctl;
-#[doc = "Watchdog Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [icr](icr) module"]
+#[doc = "Watchdog Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [icr](icr) module"]
 pub type ICR = crate::Reg<u32, _ICR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -60,7 +60,7 @@ pub struct _ICR;
 impl crate::Writable for ICR {}
 #[doc = "Watchdog Interrupt Clear"]
 pub mod icr;
-#[doc = "Watchdog Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "Watchdog Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -69,7 +69,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "Watchdog Raw Interrupt Status"]
 pub mod ris;
-#[doc = "Watchdog Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mis](mis) module"]
+#[doc = "Watchdog Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mis](mis) module"]
 pub type MIS = crate::Reg<u32, _MIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -78,7 +78,7 @@ pub struct _MIS;
 impl crate::Readable for MIS {}
 #[doc = "Watchdog Masked Interrupt Status"]
 pub mod mis;
-#[doc = "Watchdog Test\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [test](test) module"]
+#[doc = "Watchdog Test\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [test](test) module"]
 pub type TEST = crate::Reg<u32, _TEST>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -89,7 +89,7 @@ impl crate::Readable for TEST {}
 impl crate::Writable for TEST {}
 #[doc = "Watchdog Test"]
 pub mod test;
-#[doc = "Watchdog Lock\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [lock](lock) module"]
+#[doc = "Watchdog Lock\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [lock](lock) module"]
 pub type LOCK = crate::Reg<u32, _LOCK>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/watchdog0/lock.rs
+++ b/crates/tm4c123x/src/watchdog0/lock.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::LOCK {
 }
 #[doc = "Watchdog Lock\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u32)]
 pub enum LOCK_A {
     #[doc = "0: Unlocked"]
-    UNLOCKED,
+    UNLOCKED = 0,
     #[doc = "1: Locked"]
-    LOCKED,
+    LOCKED = 1,
     #[doc = "449635665: Unlocks the watchdog timer"]
-    UNLOCK,
+    UNLOCK = 449635665,
 }
 impl From<LOCK_A> for u32 {
     #[inline(always)]
     fn from(variant: LOCK_A) -> Self {
-        match variant {
-            LOCK_A::UNLOCKED => 0,
-            LOCK_A::LOCKED => 1,
-            LOCK_A::UNLOCK => 449635665,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `LOCK`"]

--- a/crates/tm4c123x/src/wtimer0.rs
+++ b/crates/tm4c123x/src/wtimer0.rs
@@ -69,7 +69,7 @@ impl crate::Readable for CFG {}
 impl crate::Writable for CFG {}
 #[doc = "GPTM Configuration"]
 pub mod cfg;
-#[doc = "GPTM Timer A Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tamr](tamr) module"]
+#[doc = "GPTM Timer A Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tamr](tamr) module"]
 pub type TAMR = crate::Reg<u32, _TAMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -80,7 +80,7 @@ impl crate::Readable for TAMR {}
 impl crate::Writable for TAMR {}
 #[doc = "GPTM Timer A Mode"]
 pub mod tamr;
-#[doc = "GPTM Timer B Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbmr](tbmr) module"]
+#[doc = "GPTM Timer B Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbmr](tbmr) module"]
 pub type TBMR = crate::Reg<u32, _TBMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -91,7 +91,7 @@ impl crate::Readable for TBMR {}
 impl crate::Writable for TBMR {}
 #[doc = "GPTM Timer B Mode"]
 pub mod tbmr;
-#[doc = "GPTM Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctl](ctl) module"]
+#[doc = "GPTM Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctl](ctl) module"]
 pub type CTL = crate::Reg<u32, _CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -102,7 +102,7 @@ impl crate::Readable for CTL {}
 impl crate::Writable for CTL {}
 #[doc = "GPTM Control"]
 pub mod ctl;
-#[doc = "GPTM Synchronize\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sync](sync) module"]
+#[doc = "GPTM Synchronize\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sync](sync) module"]
 pub type SYNC = crate::Reg<u32, _SYNC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -113,7 +113,7 @@ impl crate::Readable for SYNC {}
 impl crate::Writable for SYNC {}
 #[doc = "GPTM Synchronize"]
 pub mod sync;
-#[doc = "GPTM Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [imr](imr) module"]
+#[doc = "GPTM Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [imr](imr) module"]
 pub type IMR = crate::Reg<u32, _IMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -124,7 +124,7 @@ impl crate::Readable for IMR {}
 impl crate::Writable for IMR {}
 #[doc = "GPTM Interrupt Mask"]
 pub mod imr;
-#[doc = "GPTM Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "GPTM Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -133,7 +133,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "GPTM Raw Interrupt Status"]
 pub mod ris;
-#[doc = "GPTM Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mis](mis) module"]
+#[doc = "GPTM Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mis](mis) module"]
 pub type MIS = crate::Reg<u32, _MIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -142,7 +142,7 @@ pub struct _MIS;
 impl crate::Readable for MIS {}
 #[doc = "GPTM Masked Interrupt Status"]
 pub mod mis;
-#[doc = "GPTM Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [icr](icr) module"]
+#[doc = "GPTM Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [icr](icr) module"]
 pub type ICR = crate::Reg<u32, _ICR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -151,7 +151,7 @@ pub struct _ICR;
 impl crate::Writable for ICR {}
 #[doc = "GPTM Interrupt Clear"]
 pub mod icr;
-#[doc = "GPTM Timer A Interval Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tailr](tailr) module"]
+#[doc = "GPTM Timer A Interval Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tailr](tailr) module"]
 pub type TAILR = crate::Reg<u32, _TAILR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -162,7 +162,7 @@ impl crate::Readable for TAILR {}
 impl crate::Writable for TAILR {}
 #[doc = "GPTM Timer A Interval Load"]
 pub mod tailr;
-#[doc = "GPTM Timer B Interval Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbilr](tbilr) module"]
+#[doc = "GPTM Timer B Interval Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbilr](tbilr) module"]
 pub type TBILR = crate::Reg<u32, _TBILR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -173,7 +173,7 @@ impl crate::Readable for TBILR {}
 impl crate::Writable for TBILR {}
 #[doc = "GPTM Timer B Interval Load"]
 pub mod tbilr;
-#[doc = "GPTM Timer A Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tamatchr](tamatchr) module"]
+#[doc = "GPTM Timer A Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tamatchr](tamatchr) module"]
 pub type TAMATCHR = crate::Reg<u32, _TAMATCHR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -184,7 +184,7 @@ impl crate::Readable for TAMATCHR {}
 impl crate::Writable for TAMATCHR {}
 #[doc = "GPTM Timer A Match"]
 pub mod tamatchr;
-#[doc = "GPTM Timer B Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbmatchr](tbmatchr) module"]
+#[doc = "GPTM Timer B Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbmatchr](tbmatchr) module"]
 pub type TBMATCHR = crate::Reg<u32, _TBMATCHR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -195,7 +195,7 @@ impl crate::Readable for TBMATCHR {}
 impl crate::Writable for TBMATCHR {}
 #[doc = "GPTM Timer B Match"]
 pub mod tbmatchr;
-#[doc = "GPTM Timer A Prescale\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tapr](tapr) module"]
+#[doc = "GPTM Timer A Prescale\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tapr](tapr) module"]
 pub type TAPR = crate::Reg<u32, _TAPR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -206,7 +206,7 @@ impl crate::Readable for TAPR {}
 impl crate::Writable for TAPR {}
 #[doc = "GPTM Timer A Prescale"]
 pub mod tapr;
-#[doc = "GPTM Timer B Prescale\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbpr](tbpr) module"]
+#[doc = "GPTM Timer B Prescale\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbpr](tbpr) module"]
 pub type TBPR = crate::Reg<u32, _TBPR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -217,7 +217,7 @@ impl crate::Readable for TBPR {}
 impl crate::Writable for TBPR {}
 #[doc = "GPTM Timer B Prescale"]
 pub mod tbpr;
-#[doc = "GPTM TimerA Prescale Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tapmr](tapmr) module"]
+#[doc = "GPTM TimerA Prescale Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tapmr](tapmr) module"]
 pub type TAPMR = crate::Reg<u32, _TAPMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -228,7 +228,7 @@ impl crate::Readable for TAPMR {}
 impl crate::Writable for TAPMR {}
 #[doc = "GPTM TimerA Prescale Match"]
 pub mod tapmr;
-#[doc = "GPTM TimerB Prescale Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbpmr](tbpmr) module"]
+#[doc = "GPTM TimerB Prescale Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbpmr](tbpmr) module"]
 pub type TBPMR = crate::Reg<u32, _TBPMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -239,7 +239,7 @@ impl crate::Readable for TBPMR {}
 impl crate::Writable for TBPMR {}
 #[doc = "GPTM TimerB Prescale Match"]
 pub mod tbpmr;
-#[doc = "GPTM Timer A\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tar](tar) module"]
+#[doc = "GPTM Timer A\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tar](tar) module"]
 pub type TAR = crate::Reg<u32, _TAR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -248,7 +248,7 @@ pub struct _TAR;
 impl crate::Readable for TAR {}
 #[doc = "GPTM Timer A"]
 pub mod tar;
-#[doc = "GPTM Timer B\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbr](tbr) module"]
+#[doc = "GPTM Timer B\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbr](tbr) module"]
 pub type TBR = crate::Reg<u32, _TBR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -257,7 +257,7 @@ pub struct _TBR;
 impl crate::Readable for TBR {}
 #[doc = "GPTM Timer B"]
 pub mod tbr;
-#[doc = "GPTM Timer A Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tav](tav) module"]
+#[doc = "GPTM Timer A Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tav](tav) module"]
 pub type TAV = crate::Reg<u32, _TAV>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -268,7 +268,7 @@ impl crate::Readable for TAV {}
 impl crate::Writable for TAV {}
 #[doc = "GPTM Timer A Value"]
 pub mod tav;
-#[doc = "GPTM Timer B Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbv](tbv) module"]
+#[doc = "GPTM Timer B Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbv](tbv) module"]
 pub type TBV = crate::Reg<u32, _TBV>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -279,7 +279,7 @@ impl crate::Readable for TBV {}
 impl crate::Writable for TBV {}
 #[doc = "GPTM Timer B Value"]
 pub mod tbv;
-#[doc = "GPTM RTC Predivide\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rtcpd](rtcpd) module"]
+#[doc = "GPTM RTC Predivide\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rtcpd](rtcpd) module"]
 pub type RTCPD = crate::Reg<u32, _RTCPD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -288,7 +288,7 @@ pub struct _RTCPD;
 impl crate::Readable for RTCPD {}
 #[doc = "GPTM RTC Predivide"]
 pub mod rtcpd;
-#[doc = "GPTM Timer A Prescale Snapshot\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [taps](taps) module"]
+#[doc = "GPTM Timer A Prescale Snapshot\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [taps](taps) module"]
 pub type TAPS = crate::Reg<u32, _TAPS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -297,7 +297,7 @@ pub struct _TAPS;
 impl crate::Readable for TAPS {}
 #[doc = "GPTM Timer A Prescale Snapshot"]
 pub mod taps;
-#[doc = "GPTM Timer B Prescale Snapshot\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbps](tbps) module"]
+#[doc = "GPTM Timer B Prescale Snapshot\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbps](tbps) module"]
 pub type TBPS = crate::Reg<u32, _TBPS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -306,7 +306,7 @@ pub struct _TBPS;
 impl crate::Readable for TBPS {}
 #[doc = "GPTM Timer B Prescale Snapshot"]
 pub mod tbps;
-#[doc = "GPTM Timer A Prescale Value\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tapv](tapv) module"]
+#[doc = "GPTM Timer A Prescale Value\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tapv](tapv) module"]
 pub type TAPV = crate::Reg<u32, _TAPV>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -315,7 +315,7 @@ pub struct _TAPV;
 impl crate::Readable for TAPV {}
 #[doc = "GPTM Timer A Prescale Value"]
 pub mod tapv;
-#[doc = "GPTM Timer B Prescale Value\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbpv](tbpv) module"]
+#[doc = "GPTM Timer B Prescale Value\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbpv](tbpv) module"]
 pub type TBPV = crate::Reg<u32, _TBPV>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -324,7 +324,7 @@ pub struct _TBPV;
 impl crate::Readable for TBPV {}
 #[doc = "GPTM Timer B Prescale Value"]
 pub mod tbpv;
-#[doc = "GPTM Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "GPTM Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c123x/src/wtimer0/cfg.rs
+++ b/crates/tm4c123x/src/wtimer0/cfg.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::CFG {
 }
 #[doc = "GPTM Configuration\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CFG_A {
     #[doc = "0: For a 16/32-bit timer, this value selects the 32-bit timer configuration"]
-    _32_BIT_TIMER,
+    _32_BIT_TIMER = 0,
     #[doc = "1: For a 16/32-bit timer, this value selects the 32-bit real-time clock (RTC) counter configuration"]
-    _32_BIT_RTC,
+    _32_BIT_RTC = 1,
     #[doc = "4: For a 16/32-bit timer, this value selects the 16-bit timer configuration"]
-    _16_BIT,
+    _16_BIT = 4,
 }
 impl From<CFG_A> for u8 {
     #[inline(always)]
     fn from(variant: CFG_A) -> Self {
-        match variant {
-            CFG_A::_32_BIT_TIMER => 0,
-            CFG_A::_32_BIT_RTC => 1,
-            CFG_A::_16_BIT => 4,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CFG`"]

--- a/crates/tm4c123x/src/wtimer0/ctl.rs
+++ b/crates/tm4c123x/src/wtimer0/ctl.rs
@@ -60,22 +60,19 @@ impl<'a> TASTALL_W<'a> {
 }
 #[doc = "GPTM Timer A Event Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TAEVENT_A {
     #[doc = "0: Positive edge"]
-    POS,
+    POS = 0,
     #[doc = "1: Negative edge"]
-    NEG,
+    NEG = 1,
     #[doc = "3: Both edges"]
-    BOTH,
+    BOTH = 3,
 }
 impl From<TAEVENT_A> for u8 {
     #[inline(always)]
     fn from(variant: TAEVENT_A) -> Self {
-        match variant {
-            TAEVENT_A::POS => 0,
-            TAEVENT_A::NEG => 1,
-            TAEVENT_A::BOTH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TAEVENT`"]
@@ -262,22 +259,19 @@ impl<'a> TBSTALL_W<'a> {
 }
 #[doc = "GPTM Timer B Event Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TBEVENT_A {
     #[doc = "0: Positive edge"]
-    POS,
+    POS = 0,
     #[doc = "1: Negative edge"]
-    NEG,
+    NEG = 1,
     #[doc = "3: Both edges"]
-    BOTH,
+    BOTH = 3,
 }
 impl From<TBEVENT_A> for u8 {
     #[inline(always)]
     fn from(variant: TBEVENT_A) -> Self {
-        match variant {
-            TBEVENT_A::POS => 0,
-            TBEVENT_A::NEG => 1,
-            TBEVENT_A::BOTH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TBEVENT`"]

--- a/crates/tm4c123x/src/wtimer0/pp.rs
+++ b/crates/tm4c123x/src/wtimer0/pp.rs
@@ -2,19 +2,17 @@
 pub type R = crate::R<u32, super::PP>;
 #[doc = "Count Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SIZE_A {
     #[doc = "0: Timer A and Timer B counters are 16 bits each with an 8-bit prescale counter"]
-    _16,
+    _16 = 0,
     #[doc = "1: Timer A and Timer B counters are 32 bits each with a 16-bit prescale counter"]
-    _32,
+    _32 = 1,
 }
 impl From<SIZE_A> for u8 {
     #[inline(always)]
     fn from(variant: SIZE_A) -> Self {
-        match variant {
-            SIZE_A::_16 => 0,
-            SIZE_A::_32 => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SIZE`"]

--- a/crates/tm4c123x/src/wtimer0/sync.rs
+++ b/crates/tm4c123x/src/wtimer0/sync.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::SYNC {
 }
 #[doc = "Synchronize GPTM Timer 0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT0_A {
     #[doc = "0: GPTM0 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM0 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM0 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM0 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT0_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT0_A) -> Self {
-        match variant {
-            SYNCT0_A::NONE => 0,
-            SYNCT0_A::TA => 1,
-            SYNCT0_A::TB => 2,
-            SYNCT0_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT0`"]
@@ -109,25 +105,21 @@ impl<'a> SYNCT0_W<'a> {
 }
 #[doc = "Synchronize GPTM Timer 1\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT1_A {
     #[doc = "0: GPTM1 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM1 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM1 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM1 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT1_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT1_A) -> Self {
-        match variant {
-            SYNCT1_A::NONE => 0,
-            SYNCT1_A::TA => 1,
-            SYNCT1_A::TB => 2,
-            SYNCT1_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT1`"]
@@ -206,25 +198,21 @@ impl<'a> SYNCT1_W<'a> {
 }
 #[doc = "Synchronize GPTM Timer 2\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT2_A {
     #[doc = "0: GPTM2 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM2 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM2 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM2 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT2_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT2_A) -> Self {
-        match variant {
-            SYNCT2_A::NONE => 0,
-            SYNCT2_A::TA => 1,
-            SYNCT2_A::TB => 2,
-            SYNCT2_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT2`"]
@@ -303,25 +291,21 @@ impl<'a> SYNCT2_W<'a> {
 }
 #[doc = "Synchronize GPTM Timer 3\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT3_A {
     #[doc = "0: GPTM3 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM3 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM3 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM3 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT3_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT3_A) -> Self {
-        match variant {
-            SYNCT3_A::NONE => 0,
-            SYNCT3_A::TA => 1,
-            SYNCT3_A::TB => 2,
-            SYNCT3_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT3`"]
@@ -400,25 +384,21 @@ impl<'a> SYNCT3_W<'a> {
 }
 #[doc = "Synchronize GPTM Timer 4\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT4_A {
     #[doc = "0: GPTM4 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM4 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM4 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM4 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT4_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT4_A) -> Self {
-        match variant {
-            SYNCT4_A::NONE => 0,
-            SYNCT4_A::TA => 1,
-            SYNCT4_A::TB => 2,
-            SYNCT4_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT4`"]
@@ -497,25 +477,21 @@ impl<'a> SYNCT4_W<'a> {
 }
 #[doc = "Synchronize GPTM Timer 5\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT5_A {
     #[doc = "0: GPTM5 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM5 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM5 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM5 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT5_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT5_A) -> Self {
-        match variant {
-            SYNCT5_A::NONE => 0,
-            SYNCT5_A::TA => 1,
-            SYNCT5_A::TB => 2,
-            SYNCT5_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT5`"]
@@ -594,25 +570,21 @@ impl<'a> SYNCT5_W<'a> {
 }
 #[doc = "Synchronize GPTM 32/64-Bit Timer 0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCWT0_A {
     #[doc = "0: GPTM 32/64-Bit Timer 0 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM 32/64-Bit Timer 0 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM 32/64-Bit Timer 0 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 0 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCWT0_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCWT0_A) -> Self {
-        match variant {
-            SYNCWT0_A::NONE => 0,
-            SYNCWT0_A::TA => 1,
-            SYNCWT0_A::TB => 2,
-            SYNCWT0_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCWT0`"]
@@ -691,25 +663,21 @@ impl<'a> SYNCWT0_W<'a> {
 }
 #[doc = "Synchronize GPTM 32/64-Bit Timer 1\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCWT1_A {
     #[doc = "0: GPTM 32/64-Bit Timer 1 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM 32/64-Bit Timer 1 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM 32/64-Bit Timer 1 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 1 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCWT1_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCWT1_A) -> Self {
-        match variant {
-            SYNCWT1_A::NONE => 0,
-            SYNCWT1_A::TA => 1,
-            SYNCWT1_A::TB => 2,
-            SYNCWT1_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCWT1`"]
@@ -788,25 +756,21 @@ impl<'a> SYNCWT1_W<'a> {
 }
 #[doc = "Synchronize GPTM 32/64-Bit Timer 2\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCWT2_A {
     #[doc = "0: GPTM 32/64-Bit Timer 2 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM 32/64-Bit Timer 2 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM 32/64-Bit Timer 2 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 2 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCWT2_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCWT2_A) -> Self {
-        match variant {
-            SYNCWT2_A::NONE => 0,
-            SYNCWT2_A::TA => 1,
-            SYNCWT2_A::TB => 2,
-            SYNCWT2_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCWT2`"]
@@ -885,25 +849,21 @@ impl<'a> SYNCWT2_W<'a> {
 }
 #[doc = "Synchronize GPTM 32/64-Bit Timer 3\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCWT3_A {
     #[doc = "0: GPTM 32/64-Bit Timer 3 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM 32/64-Bit Timer 3 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM 32/64-Bit Timer 3 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 3 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCWT3_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCWT3_A) -> Self {
-        match variant {
-            SYNCWT3_A::NONE => 0,
-            SYNCWT3_A::TA => 1,
-            SYNCWT3_A::TB => 2,
-            SYNCWT3_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCWT3`"]
@@ -982,25 +942,21 @@ impl<'a> SYNCWT3_W<'a> {
 }
 #[doc = "Synchronize GPTM 32/64-Bit Timer 4\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCWT4_A {
     #[doc = "0: GPTM 32/64-Bit Timer 4 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM 32/64-Bit Timer 4 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM 32/64-Bit Timer 4 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 4 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCWT4_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCWT4_A) -> Self {
-        match variant {
-            SYNCWT4_A::NONE => 0,
-            SYNCWT4_A::TA => 1,
-            SYNCWT4_A::TB => 2,
-            SYNCWT4_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCWT4`"]
@@ -1079,25 +1035,21 @@ impl<'a> SYNCWT4_W<'a> {
 }
 #[doc = "Synchronize GPTM 32/64-Bit Timer 5\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCWT5_A {
     #[doc = "0: GPTM 32/64-Bit Timer 5 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM 32/64-Bit Timer 5 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM 32/64-Bit Timer 5 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 5 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCWT5_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCWT5_A) -> Self {
-        match variant {
-            SYNCWT5_A::NONE => 0,
-            SYNCWT5_A::TA => 1,
-            SYNCWT5_A::TB => 2,
-            SYNCWT5_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCWT5`"]

--- a/crates/tm4c123x/src/wtimer0/tamr.rs
+++ b/crates/tm4c123x/src/wtimer0/tamr.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::TAMR {
 }
 #[doc = "GPTM Timer A Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TAMR_A {
     #[doc = "1: One-Shot Timer mode"]
-    _1_SHOT,
+    _1_SHOT = 1,
     #[doc = "2: Periodic Timer mode"]
-    PERIOD,
+    PERIOD = 2,
     #[doc = "3: Capture mode"]
-    CAP,
+    CAP = 3,
 }
 impl From<TAMR_A> for u8 {
     #[inline(always)]
     fn from(variant: TAMR_A) -> Self {
-        match variant {
-            TAMR_A::_1_SHOT => 1,
-            TAMR_A::PERIOD => 2,
-            TAMR_A::CAP => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TAMR`"]

--- a/crates/tm4c123x/src/wtimer0/tbmr.rs
+++ b/crates/tm4c123x/src/wtimer0/tbmr.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::TBMR {
 }
 #[doc = "GPTM Timer B Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TBMR_A {
     #[doc = "1: One-Shot Timer mode"]
-    _1_SHOT,
+    _1_SHOT = 1,
     #[doc = "2: Periodic Timer mode"]
-    PERIOD,
+    PERIOD = 2,
     #[doc = "3: Capture mode"]
-    CAP,
+    CAP = 3,
 }
 impl From<TBMR_A> for u8 {
     #[inline(always)]
     fn from(variant: TBMR_A) -> Self {
-        match variant {
-            TBMR_A::_1_SHOT => 1,
-            TBMR_A::PERIOD => 2,
-            TBMR_A::CAP => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TBMR`"]

--- a/crates/tm4c129x/src/adc0.rs
+++ b/crates/tm4c129x/src/adc0.rs
@@ -140,7 +140,7 @@ pub struct RegisterBlock {
     #[doc = "0xfc8 - ADC Clock Configuration"]
     pub cc: CC,
 }
-#[doc = "ADC Active Sample Sequencer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [actss](actss) module"]
+#[doc = "ADC Active Sample Sequencer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [actss](actss) module"]
 pub type ACTSS = crate::Reg<u32, _ACTSS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -151,7 +151,7 @@ impl crate::Readable for ACTSS {}
 impl crate::Writable for ACTSS {}
 #[doc = "ADC Active Sample Sequencer"]
 pub mod actss;
-#[doc = "ADC Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "ADC Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -160,7 +160,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "ADC Raw Interrupt Status"]
 pub mod ris;
-#[doc = "ADC Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [im](im) module"]
+#[doc = "ADC Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [im](im) module"]
 pub type IM = crate::Reg<u32, _IM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -171,7 +171,7 @@ impl crate::Readable for IM {}
 impl crate::Writable for IM {}
 #[doc = "ADC Interrupt Mask"]
 pub mod im;
-#[doc = "ADC Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [isc](isc) module"]
+#[doc = "ADC Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [isc](isc) module"]
 pub type ISC = crate::Reg<u32, _ISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -182,7 +182,7 @@ impl crate::Readable for ISC {}
 impl crate::Writable for ISC {}
 #[doc = "ADC Interrupt Status and Clear"]
 pub mod isc;
-#[doc = "ADC Overflow Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ostat](ostat) module"]
+#[doc = "ADC Overflow Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ostat](ostat) module"]
 pub type OSTAT = crate::Reg<u32, _OSTAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -193,7 +193,7 @@ impl crate::Readable for OSTAT {}
 impl crate::Writable for OSTAT {}
 #[doc = "ADC Overflow Status"]
 pub mod ostat;
-#[doc = "ADC Event Multiplexer Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [emux](emux) module"]
+#[doc = "ADC Event Multiplexer Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [emux](emux) module"]
 pub type EMUX = crate::Reg<u32, _EMUX>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -204,7 +204,7 @@ impl crate::Readable for EMUX {}
 impl crate::Writable for EMUX {}
 #[doc = "ADC Event Multiplexer Select"]
 pub mod emux;
-#[doc = "ADC Underflow Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ustat](ustat) module"]
+#[doc = "ADC Underflow Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ustat](ustat) module"]
 pub type USTAT = crate::Reg<u32, _USTAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -215,7 +215,7 @@ impl crate::Readable for USTAT {}
 impl crate::Writable for USTAT {}
 #[doc = "ADC Underflow Status"]
 pub mod ustat;
-#[doc = "ADC Trigger Source Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tssel](tssel) module"]
+#[doc = "ADC Trigger Source Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tssel](tssel) module"]
 pub type TSSEL = crate::Reg<u32, _TSSEL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -226,7 +226,7 @@ impl crate::Readable for TSSEL {}
 impl crate::Writable for TSSEL {}
 #[doc = "ADC Trigger Source Select"]
 pub mod tssel;
-#[doc = "ADC Sample Sequencer Priority\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sspri](sspri) module"]
+#[doc = "ADC Sample Sequencer Priority\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sspri](sspri) module"]
 pub type SSPRI = crate::Reg<u32, _SSPRI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -237,7 +237,7 @@ impl crate::Readable for SSPRI {}
 impl crate::Writable for SSPRI {}
 #[doc = "ADC Sample Sequencer Priority"]
 pub mod sspri;
-#[doc = "ADC Sample Phase Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [spc](spc) module"]
+#[doc = "ADC Sample Phase Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [spc](spc) module"]
 pub type SPC = crate::Reg<u32, _SPC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -248,7 +248,7 @@ impl crate::Readable for SPC {}
 impl crate::Writable for SPC {}
 #[doc = "ADC Sample Phase Control"]
 pub mod spc;
-#[doc = "ADC Processor Sample Sequence Initiate\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pssi](pssi) module"]
+#[doc = "ADC Processor Sample Sequence Initiate\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pssi](pssi) module"]
 pub type PSSI = crate::Reg<u32, _PSSI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -259,7 +259,7 @@ impl crate::Readable for PSSI {}
 impl crate::Writable for PSSI {}
 #[doc = "ADC Processor Sample Sequence Initiate"]
 pub mod pssi;
-#[doc = "ADC Sample Averaging Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sac](sac) module"]
+#[doc = "ADC Sample Averaging Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sac](sac) module"]
 pub type SAC = crate::Reg<u32, _SAC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -270,7 +270,7 @@ impl crate::Readable for SAC {}
 impl crate::Writable for SAC {}
 #[doc = "ADC Sample Averaging Control"]
 pub mod sac;
-#[doc = "ADC Digital Comparator Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcisc](dcisc) module"]
+#[doc = "ADC Digital Comparator Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcisc](dcisc) module"]
 pub type DCISC = crate::Reg<u32, _DCISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -281,7 +281,7 @@ impl crate::Readable for DCISC {}
 impl crate::Writable for DCISC {}
 #[doc = "ADC Digital Comparator Interrupt Status and Clear"]
 pub mod dcisc;
-#[doc = "ADC Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctl](ctl) module"]
+#[doc = "ADC Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctl](ctl) module"]
 pub type CTL = crate::Reg<u32, _CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -292,7 +292,7 @@ impl crate::Readable for CTL {}
 impl crate::Writable for CTL {}
 #[doc = "ADC Control"]
 pub mod ctl;
-#[doc = "ADC Sample Sequence Input Multiplexer Select 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssmux0](ssmux0) module"]
+#[doc = "ADC Sample Sequence Input Multiplexer Select 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssmux0](ssmux0) module"]
 pub type SSMUX0 = crate::Reg<u32, _SSMUX0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -303,7 +303,7 @@ impl crate::Readable for SSMUX0 {}
 impl crate::Writable for SSMUX0 {}
 #[doc = "ADC Sample Sequence Input Multiplexer Select 0"]
 pub mod ssmux0;
-#[doc = "ADC Sample Sequence Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssctl0](ssctl0) module"]
+#[doc = "ADC Sample Sequence Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssctl0](ssctl0) module"]
 pub type SSCTL0 = crate::Reg<u32, _SSCTL0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -314,7 +314,7 @@ impl crate::Readable for SSCTL0 {}
 impl crate::Writable for SSCTL0 {}
 #[doc = "ADC Sample Sequence Control 0"]
 pub mod ssctl0;
-#[doc = "ADC Sample Sequence Result FIFO 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssfifo0](ssfifo0) module"]
+#[doc = "ADC Sample Sequence Result FIFO 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssfifo0](ssfifo0) module"]
 pub type SSFIFO0 = crate::Reg<u32, _SSFIFO0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -323,7 +323,7 @@ pub struct _SSFIFO0;
 impl crate::Readable for SSFIFO0 {}
 #[doc = "ADC Sample Sequence Result FIFO 0"]
 pub mod ssfifo0;
-#[doc = "ADC Sample Sequence FIFO 0 Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssfstat0](ssfstat0) module"]
+#[doc = "ADC Sample Sequence FIFO 0 Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssfstat0](ssfstat0) module"]
 pub type SSFSTAT0 = crate::Reg<u32, _SSFSTAT0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -332,7 +332,7 @@ pub struct _SSFSTAT0;
 impl crate::Readable for SSFSTAT0 {}
 #[doc = "ADC Sample Sequence FIFO 0 Status"]
 pub mod ssfstat0;
-#[doc = "ADC Sample Sequence 0 Operation\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssop0](ssop0) module"]
+#[doc = "ADC Sample Sequence 0 Operation\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssop0](ssop0) module"]
 pub type SSOP0 = crate::Reg<u32, _SSOP0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -343,7 +343,7 @@ impl crate::Readable for SSOP0 {}
 impl crate::Writable for SSOP0 {}
 #[doc = "ADC Sample Sequence 0 Operation"]
 pub mod ssop0;
-#[doc = "ADC Sample Sequence 0 Digital Comparator Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssdc0](ssdc0) module"]
+#[doc = "ADC Sample Sequence 0 Digital Comparator Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssdc0](ssdc0) module"]
 pub type SSDC0 = crate::Reg<u32, _SSDC0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -354,7 +354,7 @@ impl crate::Readable for SSDC0 {}
 impl crate::Writable for SSDC0 {}
 #[doc = "ADC Sample Sequence 0 Digital Comparator Select"]
 pub mod ssdc0;
-#[doc = "ADC Sample Sequence Extended Input Multiplexer Select 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssemux0](ssemux0) module"]
+#[doc = "ADC Sample Sequence Extended Input Multiplexer Select 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssemux0](ssemux0) module"]
 pub type SSEMUX0 = crate::Reg<u32, _SSEMUX0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -365,7 +365,7 @@ impl crate::Readable for SSEMUX0 {}
 impl crate::Writable for SSEMUX0 {}
 #[doc = "ADC Sample Sequence Extended Input Multiplexer Select 0"]
 pub mod ssemux0;
-#[doc = "ADC Sample Sequence 0 Sample and Hold Time\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sstsh0](sstsh0) module"]
+#[doc = "ADC Sample Sequence 0 Sample and Hold Time\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sstsh0](sstsh0) module"]
 pub type SSTSH0 = crate::Reg<u32, _SSTSH0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -376,7 +376,7 @@ impl crate::Readable for SSTSH0 {}
 impl crate::Writable for SSTSH0 {}
 #[doc = "ADC Sample Sequence 0 Sample and Hold Time"]
 pub mod sstsh0;
-#[doc = "ADC Sample Sequence Input Multiplexer Select 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssmux1](ssmux1) module"]
+#[doc = "ADC Sample Sequence Input Multiplexer Select 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssmux1](ssmux1) module"]
 pub type SSMUX1 = crate::Reg<u32, _SSMUX1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -387,7 +387,7 @@ impl crate::Readable for SSMUX1 {}
 impl crate::Writable for SSMUX1 {}
 #[doc = "ADC Sample Sequence Input Multiplexer Select 1"]
 pub mod ssmux1;
-#[doc = "ADC Sample Sequence Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssctl1](ssctl1) module"]
+#[doc = "ADC Sample Sequence Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssctl1](ssctl1) module"]
 pub type SSCTL1 = crate::Reg<u32, _SSCTL1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -398,7 +398,7 @@ impl crate::Readable for SSCTL1 {}
 impl crate::Writable for SSCTL1 {}
 #[doc = "ADC Sample Sequence Control 1"]
 pub mod ssctl1;
-#[doc = "ADC Sample Sequence Result FIFO 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssfifo1](ssfifo1) module"]
+#[doc = "ADC Sample Sequence Result FIFO 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssfifo1](ssfifo1) module"]
 pub type SSFIFO1 = crate::Reg<u32, _SSFIFO1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -407,7 +407,7 @@ pub struct _SSFIFO1;
 impl crate::Readable for SSFIFO1 {}
 #[doc = "ADC Sample Sequence Result FIFO 1"]
 pub mod ssfifo1;
-#[doc = "ADC Sample Sequence FIFO 1 Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssfstat1](ssfstat1) module"]
+#[doc = "ADC Sample Sequence FIFO 1 Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssfstat1](ssfstat1) module"]
 pub type SSFSTAT1 = crate::Reg<u32, _SSFSTAT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -416,7 +416,7 @@ pub struct _SSFSTAT1;
 impl crate::Readable for SSFSTAT1 {}
 #[doc = "ADC Sample Sequence FIFO 1 Status"]
 pub mod ssfstat1;
-#[doc = "ADC Sample Sequence 1 Operation\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssop1](ssop1) module"]
+#[doc = "ADC Sample Sequence 1 Operation\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssop1](ssop1) module"]
 pub type SSOP1 = crate::Reg<u32, _SSOP1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -427,7 +427,7 @@ impl crate::Readable for SSOP1 {}
 impl crate::Writable for SSOP1 {}
 #[doc = "ADC Sample Sequence 1 Operation"]
 pub mod ssop1;
-#[doc = "ADC Sample Sequence 1 Digital Comparator Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssdc1](ssdc1) module"]
+#[doc = "ADC Sample Sequence 1 Digital Comparator Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssdc1](ssdc1) module"]
 pub type SSDC1 = crate::Reg<u32, _SSDC1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -438,7 +438,7 @@ impl crate::Readable for SSDC1 {}
 impl crate::Writable for SSDC1 {}
 #[doc = "ADC Sample Sequence 1 Digital Comparator Select"]
 pub mod ssdc1;
-#[doc = "ADC Sample Sequence Extended Input Multiplexer Select 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssemux1](ssemux1) module"]
+#[doc = "ADC Sample Sequence Extended Input Multiplexer Select 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssemux1](ssemux1) module"]
 pub type SSEMUX1 = crate::Reg<u32, _SSEMUX1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -449,7 +449,7 @@ impl crate::Readable for SSEMUX1 {}
 impl crate::Writable for SSEMUX1 {}
 #[doc = "ADC Sample Sequence Extended Input Multiplexer Select 1"]
 pub mod ssemux1;
-#[doc = "ADC Sample Sequence 1 Sample and Hold Time\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sstsh1](sstsh1) module"]
+#[doc = "ADC Sample Sequence 1 Sample and Hold Time\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sstsh1](sstsh1) module"]
 pub type SSTSH1 = crate::Reg<u32, _SSTSH1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -460,7 +460,7 @@ impl crate::Readable for SSTSH1 {}
 impl crate::Writable for SSTSH1 {}
 #[doc = "ADC Sample Sequence 1 Sample and Hold Time"]
 pub mod sstsh1;
-#[doc = "ADC Sample Sequence Input Multiplexer Select 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssmux2](ssmux2) module"]
+#[doc = "ADC Sample Sequence Input Multiplexer Select 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssmux2](ssmux2) module"]
 pub type SSMUX2 = crate::Reg<u32, _SSMUX2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -471,7 +471,7 @@ impl crate::Readable for SSMUX2 {}
 impl crate::Writable for SSMUX2 {}
 #[doc = "ADC Sample Sequence Input Multiplexer Select 2"]
 pub mod ssmux2;
-#[doc = "ADC Sample Sequence Control 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssctl2](ssctl2) module"]
+#[doc = "ADC Sample Sequence Control 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssctl2](ssctl2) module"]
 pub type SSCTL2 = crate::Reg<u32, _SSCTL2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -482,7 +482,7 @@ impl crate::Readable for SSCTL2 {}
 impl crate::Writable for SSCTL2 {}
 #[doc = "ADC Sample Sequence Control 2"]
 pub mod ssctl2;
-#[doc = "ADC Sample Sequence Result FIFO 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssfifo2](ssfifo2) module"]
+#[doc = "ADC Sample Sequence Result FIFO 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssfifo2](ssfifo2) module"]
 pub type SSFIFO2 = crate::Reg<u32, _SSFIFO2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -491,7 +491,7 @@ pub struct _SSFIFO2;
 impl crate::Readable for SSFIFO2 {}
 #[doc = "ADC Sample Sequence Result FIFO 2"]
 pub mod ssfifo2;
-#[doc = "ADC Sample Sequence FIFO 2 Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssfstat2](ssfstat2) module"]
+#[doc = "ADC Sample Sequence FIFO 2 Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssfstat2](ssfstat2) module"]
 pub type SSFSTAT2 = crate::Reg<u32, _SSFSTAT2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -500,7 +500,7 @@ pub struct _SSFSTAT2;
 impl crate::Readable for SSFSTAT2 {}
 #[doc = "ADC Sample Sequence FIFO 2 Status"]
 pub mod ssfstat2;
-#[doc = "ADC Sample Sequence 2 Operation\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssop2](ssop2) module"]
+#[doc = "ADC Sample Sequence 2 Operation\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssop2](ssop2) module"]
 pub type SSOP2 = crate::Reg<u32, _SSOP2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -511,7 +511,7 @@ impl crate::Readable for SSOP2 {}
 impl crate::Writable for SSOP2 {}
 #[doc = "ADC Sample Sequence 2 Operation"]
 pub mod ssop2;
-#[doc = "ADC Sample Sequence 2 Digital Comparator Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssdc2](ssdc2) module"]
+#[doc = "ADC Sample Sequence 2 Digital Comparator Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssdc2](ssdc2) module"]
 pub type SSDC2 = crate::Reg<u32, _SSDC2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -522,7 +522,7 @@ impl crate::Readable for SSDC2 {}
 impl crate::Writable for SSDC2 {}
 #[doc = "ADC Sample Sequence 2 Digital Comparator Select"]
 pub mod ssdc2;
-#[doc = "ADC Sample Sequence Extended Input Multiplexer Select 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssemux2](ssemux2) module"]
+#[doc = "ADC Sample Sequence Extended Input Multiplexer Select 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssemux2](ssemux2) module"]
 pub type SSEMUX2 = crate::Reg<u32, _SSEMUX2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -533,7 +533,7 @@ impl crate::Readable for SSEMUX2 {}
 impl crate::Writable for SSEMUX2 {}
 #[doc = "ADC Sample Sequence Extended Input Multiplexer Select 2"]
 pub mod ssemux2;
-#[doc = "ADC Sample Sequence 2 Sample and Hold Time\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sstsh2](sstsh2) module"]
+#[doc = "ADC Sample Sequence 2 Sample and Hold Time\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sstsh2](sstsh2) module"]
 pub type SSTSH2 = crate::Reg<u32, _SSTSH2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -544,7 +544,7 @@ impl crate::Readable for SSTSH2 {}
 impl crate::Writable for SSTSH2 {}
 #[doc = "ADC Sample Sequence 2 Sample and Hold Time"]
 pub mod sstsh2;
-#[doc = "ADC Sample Sequence Input Multiplexer Select 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssmux3](ssmux3) module"]
+#[doc = "ADC Sample Sequence Input Multiplexer Select 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssmux3](ssmux3) module"]
 pub type SSMUX3 = crate::Reg<u32, _SSMUX3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -555,7 +555,7 @@ impl crate::Readable for SSMUX3 {}
 impl crate::Writable for SSMUX3 {}
 #[doc = "ADC Sample Sequence Input Multiplexer Select 3"]
 pub mod ssmux3;
-#[doc = "ADC Sample Sequence Control 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssctl3](ssctl3) module"]
+#[doc = "ADC Sample Sequence Control 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssctl3](ssctl3) module"]
 pub type SSCTL3 = crate::Reg<u32, _SSCTL3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -566,7 +566,7 @@ impl crate::Readable for SSCTL3 {}
 impl crate::Writable for SSCTL3 {}
 #[doc = "ADC Sample Sequence Control 3"]
 pub mod ssctl3;
-#[doc = "ADC Sample Sequence Result FIFO 3\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssfifo3](ssfifo3) module"]
+#[doc = "ADC Sample Sequence Result FIFO 3\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssfifo3](ssfifo3) module"]
 pub type SSFIFO3 = crate::Reg<u32, _SSFIFO3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -575,7 +575,7 @@ pub struct _SSFIFO3;
 impl crate::Readable for SSFIFO3 {}
 #[doc = "ADC Sample Sequence Result FIFO 3"]
 pub mod ssfifo3;
-#[doc = "ADC Sample Sequence FIFO 3 Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssfstat3](ssfstat3) module"]
+#[doc = "ADC Sample Sequence FIFO 3 Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssfstat3](ssfstat3) module"]
 pub type SSFSTAT3 = crate::Reg<u32, _SSFSTAT3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -584,7 +584,7 @@ pub struct _SSFSTAT3;
 impl crate::Readable for SSFSTAT3 {}
 #[doc = "ADC Sample Sequence FIFO 3 Status"]
 pub mod ssfstat3;
-#[doc = "ADC Sample Sequence 3 Operation\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssop3](ssop3) module"]
+#[doc = "ADC Sample Sequence 3 Operation\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssop3](ssop3) module"]
 pub type SSOP3 = crate::Reg<u32, _SSOP3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -595,7 +595,7 @@ impl crate::Readable for SSOP3 {}
 impl crate::Writable for SSOP3 {}
 #[doc = "ADC Sample Sequence 3 Operation"]
 pub mod ssop3;
-#[doc = "ADC Sample Sequence 3 Digital Comparator Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssdc3](ssdc3) module"]
+#[doc = "ADC Sample Sequence 3 Digital Comparator Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssdc3](ssdc3) module"]
 pub type SSDC3 = crate::Reg<u32, _SSDC3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -606,7 +606,7 @@ impl crate::Readable for SSDC3 {}
 impl crate::Writable for SSDC3 {}
 #[doc = "ADC Sample Sequence 3 Digital Comparator Select"]
 pub mod ssdc3;
-#[doc = "ADC Sample Sequence Extended Input Multiplexer Select 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssemux3](ssemux3) module"]
+#[doc = "ADC Sample Sequence Extended Input Multiplexer Select 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssemux3](ssemux3) module"]
 pub type SSEMUX3 = crate::Reg<u32, _SSEMUX3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -617,7 +617,7 @@ impl crate::Readable for SSEMUX3 {}
 impl crate::Writable for SSEMUX3 {}
 #[doc = "ADC Sample Sequence Extended Input Multiplexer Select 3"]
 pub mod ssemux3;
-#[doc = "ADC Sample Sequence 3 Sample and Hold Time\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sstsh3](sstsh3) module"]
+#[doc = "ADC Sample Sequence 3 Sample and Hold Time\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sstsh3](sstsh3) module"]
 pub type SSTSH3 = crate::Reg<u32, _SSTSH3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -628,7 +628,7 @@ impl crate::Readable for SSTSH3 {}
 impl crate::Writable for SSTSH3 {}
 #[doc = "ADC Sample Sequence 3 Sample and Hold Time"]
 pub mod sstsh3;
-#[doc = "ADC Digital Comparator Reset Initial Conditions\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcric](dcric) module"]
+#[doc = "ADC Digital Comparator Reset Initial Conditions\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcric](dcric) module"]
 pub type DCRIC = crate::Reg<u32, _DCRIC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -637,7 +637,7 @@ pub struct _DCRIC;
 impl crate::Writable for DCRIC {}
 #[doc = "ADC Digital Comparator Reset Initial Conditions"]
 pub mod dcric;
-#[doc = "ADC Digital Comparator Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcctl0](dcctl0) module"]
+#[doc = "ADC Digital Comparator Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcctl0](dcctl0) module"]
 pub type DCCTL0 = crate::Reg<u32, _DCCTL0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -648,7 +648,7 @@ impl crate::Readable for DCCTL0 {}
 impl crate::Writable for DCCTL0 {}
 #[doc = "ADC Digital Comparator Control 0"]
 pub mod dcctl0;
-#[doc = "ADC Digital Comparator Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcctl1](dcctl1) module"]
+#[doc = "ADC Digital Comparator Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcctl1](dcctl1) module"]
 pub type DCCTL1 = crate::Reg<u32, _DCCTL1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -659,7 +659,7 @@ impl crate::Readable for DCCTL1 {}
 impl crate::Writable for DCCTL1 {}
 #[doc = "ADC Digital Comparator Control 1"]
 pub mod dcctl1;
-#[doc = "ADC Digital Comparator Control 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcctl2](dcctl2) module"]
+#[doc = "ADC Digital Comparator Control 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcctl2](dcctl2) module"]
 pub type DCCTL2 = crate::Reg<u32, _DCCTL2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -670,7 +670,7 @@ impl crate::Readable for DCCTL2 {}
 impl crate::Writable for DCCTL2 {}
 #[doc = "ADC Digital Comparator Control 2"]
 pub mod dcctl2;
-#[doc = "ADC Digital Comparator Control 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcctl3](dcctl3) module"]
+#[doc = "ADC Digital Comparator Control 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcctl3](dcctl3) module"]
 pub type DCCTL3 = crate::Reg<u32, _DCCTL3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -681,7 +681,7 @@ impl crate::Readable for DCCTL3 {}
 impl crate::Writable for DCCTL3 {}
 #[doc = "ADC Digital Comparator Control 3"]
 pub mod dcctl3;
-#[doc = "ADC Digital Comparator Control 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcctl4](dcctl4) module"]
+#[doc = "ADC Digital Comparator Control 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcctl4](dcctl4) module"]
 pub type DCCTL4 = crate::Reg<u32, _DCCTL4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -692,7 +692,7 @@ impl crate::Readable for DCCTL4 {}
 impl crate::Writable for DCCTL4 {}
 #[doc = "ADC Digital Comparator Control 4"]
 pub mod dcctl4;
-#[doc = "ADC Digital Comparator Control 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcctl5](dcctl5) module"]
+#[doc = "ADC Digital Comparator Control 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcctl5](dcctl5) module"]
 pub type DCCTL5 = crate::Reg<u32, _DCCTL5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -703,7 +703,7 @@ impl crate::Readable for DCCTL5 {}
 impl crate::Writable for DCCTL5 {}
 #[doc = "ADC Digital Comparator Control 5"]
 pub mod dcctl5;
-#[doc = "ADC Digital Comparator Control 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcctl6](dcctl6) module"]
+#[doc = "ADC Digital Comparator Control 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcctl6](dcctl6) module"]
 pub type DCCTL6 = crate::Reg<u32, _DCCTL6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -714,7 +714,7 @@ impl crate::Readable for DCCTL6 {}
 impl crate::Writable for DCCTL6 {}
 #[doc = "ADC Digital Comparator Control 6"]
 pub mod dcctl6;
-#[doc = "ADC Digital Comparator Control 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcctl7](dcctl7) module"]
+#[doc = "ADC Digital Comparator Control 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcctl7](dcctl7) module"]
 pub type DCCTL7 = crate::Reg<u32, _DCCTL7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -725,7 +725,7 @@ impl crate::Readable for DCCTL7 {}
 impl crate::Writable for DCCTL7 {}
 #[doc = "ADC Digital Comparator Control 7"]
 pub mod dcctl7;
-#[doc = "ADC Digital Comparator Range 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dccmp0](dccmp0) module"]
+#[doc = "ADC Digital Comparator Range 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dccmp0](dccmp0) module"]
 pub type DCCMP0 = crate::Reg<u32, _DCCMP0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -736,7 +736,7 @@ impl crate::Readable for DCCMP0 {}
 impl crate::Writable for DCCMP0 {}
 #[doc = "ADC Digital Comparator Range 0"]
 pub mod dccmp0;
-#[doc = "ADC Digital Comparator Range 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dccmp1](dccmp1) module"]
+#[doc = "ADC Digital Comparator Range 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dccmp1](dccmp1) module"]
 pub type DCCMP1 = crate::Reg<u32, _DCCMP1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -747,7 +747,7 @@ impl crate::Readable for DCCMP1 {}
 impl crate::Writable for DCCMP1 {}
 #[doc = "ADC Digital Comparator Range 1"]
 pub mod dccmp1;
-#[doc = "ADC Digital Comparator Range 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dccmp2](dccmp2) module"]
+#[doc = "ADC Digital Comparator Range 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dccmp2](dccmp2) module"]
 pub type DCCMP2 = crate::Reg<u32, _DCCMP2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -758,7 +758,7 @@ impl crate::Readable for DCCMP2 {}
 impl crate::Writable for DCCMP2 {}
 #[doc = "ADC Digital Comparator Range 2"]
 pub mod dccmp2;
-#[doc = "ADC Digital Comparator Range 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dccmp3](dccmp3) module"]
+#[doc = "ADC Digital Comparator Range 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dccmp3](dccmp3) module"]
 pub type DCCMP3 = crate::Reg<u32, _DCCMP3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -769,7 +769,7 @@ impl crate::Readable for DCCMP3 {}
 impl crate::Writable for DCCMP3 {}
 #[doc = "ADC Digital Comparator Range 3"]
 pub mod dccmp3;
-#[doc = "ADC Digital Comparator Range 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dccmp4](dccmp4) module"]
+#[doc = "ADC Digital Comparator Range 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dccmp4](dccmp4) module"]
 pub type DCCMP4 = crate::Reg<u32, _DCCMP4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -780,7 +780,7 @@ impl crate::Readable for DCCMP4 {}
 impl crate::Writable for DCCMP4 {}
 #[doc = "ADC Digital Comparator Range 4"]
 pub mod dccmp4;
-#[doc = "ADC Digital Comparator Range 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dccmp5](dccmp5) module"]
+#[doc = "ADC Digital Comparator Range 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dccmp5](dccmp5) module"]
 pub type DCCMP5 = crate::Reg<u32, _DCCMP5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -791,7 +791,7 @@ impl crate::Readable for DCCMP5 {}
 impl crate::Writable for DCCMP5 {}
 #[doc = "ADC Digital Comparator Range 5"]
 pub mod dccmp5;
-#[doc = "ADC Digital Comparator Range 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dccmp6](dccmp6) module"]
+#[doc = "ADC Digital Comparator Range 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dccmp6](dccmp6) module"]
 pub type DCCMP6 = crate::Reg<u32, _DCCMP6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -802,7 +802,7 @@ impl crate::Readable for DCCMP6 {}
 impl crate::Writable for DCCMP6 {}
 #[doc = "ADC Digital Comparator Range 6"]
 pub mod dccmp6;
-#[doc = "ADC Digital Comparator Range 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dccmp7](dccmp7) module"]
+#[doc = "ADC Digital Comparator Range 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dccmp7](dccmp7) module"]
 pub type DCCMP7 = crate::Reg<u32, _DCCMP7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -813,7 +813,7 @@ impl crate::Readable for DCCMP7 {}
 impl crate::Writable for DCCMP7 {}
 #[doc = "ADC Digital Comparator Range 7"]
 pub mod dccmp7;
-#[doc = "ADC Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "ADC Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -822,7 +822,7 @@ pub struct _PP;
 impl crate::Readable for PP {}
 #[doc = "ADC Peripheral Properties"]
 pub mod pp;
-#[doc = "ADC Peripheral Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pc](pc) module"]
+#[doc = "ADC Peripheral Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pc](pc) module"]
 pub type PC = crate::Reg<u32, _PC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -833,7 +833,7 @@ impl crate::Readable for PC {}
 impl crate::Writable for PC {}
 #[doc = "ADC Peripheral Configuration"]
 pub mod pc;
-#[doc = "ADC Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc](cc) module"]
+#[doc = "ADC Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cc](cc) module"]
 pub type CC = crate::Reg<u32, _CC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/adc0/cc.rs
+++ b/crates/tm4c129x/src/adc0/cc.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::CC {
 }
 #[doc = "ADC Clock Source\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CS_A {
     #[doc = "0: PLL VCO divided by CLKDIV"]
-    SYSPLL,
+    SYSPLL = 0,
     #[doc = "1: PIOSC"]
-    PIOSC,
+    PIOSC = 1,
     #[doc = "2: MOSC"]
-    MOSC,
+    MOSC = 2,
 }
 impl From<CS_A> for u8 {
     #[inline(always)]
     fn from(variant: CS_A) -> Self {
-        match variant {
-            CS_A::SYSPLL => 0,
-            CS_A::PIOSC => 1,
-            CS_A::MOSC => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CS`"]

--- a/crates/tm4c129x/src/adc0/ctl.rs
+++ b/crates/tm4c129x/src/adc0/ctl.rs
@@ -14,17 +14,14 @@ impl crate::ResetValue for super::CTL {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum VREF_A {
     #[doc = "0: VDDA and GNDA are the voltage references"]
-    INTERNAL,
+    INTERNAL = 0,
     #[doc = "1: The external VREFA+ and VREFA- inputs are the voltage references"]
-    EXT_3V,
+    EXT_3V = 1,
 }
 impl From<VREF_A> for bool {
     #[inline(always)]
     fn from(variant: VREF_A) -> Self {
-        match variant {
-            VREF_A::INTERNAL => false,
-            VREF_A::EXT_3V => true,
-        }
+        variant as u8 != 0
     }
 }
 #[doc = "Reader of field `VREF`"]

--- a/crates/tm4c129x/src/adc0/dcctl0.rs
+++ b/crates/tm4c129x/src/adc0/dcctl0.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::DCCTL0 {
 }
 #[doc = "Comparison Interrupt Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CIM_A> for u8 {
     #[inline(always)]
     fn from(variant: CIM_A) -> Self {
-        match variant {
-            CIM_A::ALWAYS => 0,
-            CIM_A::ONCE => 1,
-            CIM_A::HALWAYS => 2,
-            CIM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIM`"]
@@ -109,22 +105,19 @@ impl<'a> CIM_W<'a> {
 }
 #[doc = "Comparison Interrupt Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CIC_A> for u8 {
     #[inline(always)]
     fn from(variant: CIC_A) -> Self {
-        match variant {
-            CIC_A::LOW => 0,
-            CIC_A::MID => 1,
-            CIC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIC`"]
@@ -215,25 +208,21 @@ impl<'a> CIE_W<'a> {
 }
 #[doc = "Comparison Trigger Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CTM_A> for u8 {
     #[inline(always)]
     fn from(variant: CTM_A) -> Self {
-        match variant {
-            CTM_A::ALWAYS => 0,
-            CTM_A::ONCE => 1,
-            CTM_A::HALWAYS => 2,
-            CTM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTM`"]
@@ -312,22 +301,19 @@ impl<'a> CTM_W<'a> {
 }
 #[doc = "Comparison Trigger Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CTC_A> for u8 {
     #[inline(always)]
     fn from(variant: CTC_A) -> Self {
-        match variant {
-            CTC_A::LOW => 0,
-            CTC_A::MID => 1,
-            CTC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTC`"]

--- a/crates/tm4c129x/src/adc0/dcctl1.rs
+++ b/crates/tm4c129x/src/adc0/dcctl1.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::DCCTL1 {
 }
 #[doc = "Comparison Interrupt Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CIM_A> for u8 {
     #[inline(always)]
     fn from(variant: CIM_A) -> Self {
-        match variant {
-            CIM_A::ALWAYS => 0,
-            CIM_A::ONCE => 1,
-            CIM_A::HALWAYS => 2,
-            CIM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIM`"]
@@ -109,22 +105,19 @@ impl<'a> CIM_W<'a> {
 }
 #[doc = "Comparison Interrupt Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CIC_A> for u8 {
     #[inline(always)]
     fn from(variant: CIC_A) -> Self {
-        match variant {
-            CIC_A::LOW => 0,
-            CIC_A::MID => 1,
-            CIC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIC`"]
@@ -215,25 +208,21 @@ impl<'a> CIE_W<'a> {
 }
 #[doc = "Comparison Trigger Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CTM_A> for u8 {
     #[inline(always)]
     fn from(variant: CTM_A) -> Self {
-        match variant {
-            CTM_A::ALWAYS => 0,
-            CTM_A::ONCE => 1,
-            CTM_A::HALWAYS => 2,
-            CTM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTM`"]
@@ -312,22 +301,19 @@ impl<'a> CTM_W<'a> {
 }
 #[doc = "Comparison Trigger Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CTC_A> for u8 {
     #[inline(always)]
     fn from(variant: CTC_A) -> Self {
-        match variant {
-            CTC_A::LOW => 0,
-            CTC_A::MID => 1,
-            CTC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTC`"]

--- a/crates/tm4c129x/src/adc0/dcctl2.rs
+++ b/crates/tm4c129x/src/adc0/dcctl2.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::DCCTL2 {
 }
 #[doc = "Comparison Interrupt Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CIM_A> for u8 {
     #[inline(always)]
     fn from(variant: CIM_A) -> Self {
-        match variant {
-            CIM_A::ALWAYS => 0,
-            CIM_A::ONCE => 1,
-            CIM_A::HALWAYS => 2,
-            CIM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIM`"]
@@ -109,22 +105,19 @@ impl<'a> CIM_W<'a> {
 }
 #[doc = "Comparison Interrupt Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CIC_A> for u8 {
     #[inline(always)]
     fn from(variant: CIC_A) -> Self {
-        match variant {
-            CIC_A::LOW => 0,
-            CIC_A::MID => 1,
-            CIC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIC`"]
@@ -215,25 +208,21 @@ impl<'a> CIE_W<'a> {
 }
 #[doc = "Comparison Trigger Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CTM_A> for u8 {
     #[inline(always)]
     fn from(variant: CTM_A) -> Self {
-        match variant {
-            CTM_A::ALWAYS => 0,
-            CTM_A::ONCE => 1,
-            CTM_A::HALWAYS => 2,
-            CTM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTM`"]
@@ -312,22 +301,19 @@ impl<'a> CTM_W<'a> {
 }
 #[doc = "Comparison Trigger Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CTC_A> for u8 {
     #[inline(always)]
     fn from(variant: CTC_A) -> Self {
-        match variant {
-            CTC_A::LOW => 0,
-            CTC_A::MID => 1,
-            CTC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTC`"]

--- a/crates/tm4c129x/src/adc0/dcctl3.rs
+++ b/crates/tm4c129x/src/adc0/dcctl3.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::DCCTL3 {
 }
 #[doc = "Comparison Interrupt Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CIM_A> for u8 {
     #[inline(always)]
     fn from(variant: CIM_A) -> Self {
-        match variant {
-            CIM_A::ALWAYS => 0,
-            CIM_A::ONCE => 1,
-            CIM_A::HALWAYS => 2,
-            CIM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIM`"]
@@ -109,22 +105,19 @@ impl<'a> CIM_W<'a> {
 }
 #[doc = "Comparison Interrupt Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CIC_A> for u8 {
     #[inline(always)]
     fn from(variant: CIC_A) -> Self {
-        match variant {
-            CIC_A::LOW => 0,
-            CIC_A::MID => 1,
-            CIC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIC`"]
@@ -215,25 +208,21 @@ impl<'a> CIE_W<'a> {
 }
 #[doc = "Comparison Trigger Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CTM_A> for u8 {
     #[inline(always)]
     fn from(variant: CTM_A) -> Self {
-        match variant {
-            CTM_A::ALWAYS => 0,
-            CTM_A::ONCE => 1,
-            CTM_A::HALWAYS => 2,
-            CTM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTM`"]
@@ -312,22 +301,19 @@ impl<'a> CTM_W<'a> {
 }
 #[doc = "Comparison Trigger Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CTC_A> for u8 {
     #[inline(always)]
     fn from(variant: CTC_A) -> Self {
-        match variant {
-            CTC_A::LOW => 0,
-            CTC_A::MID => 1,
-            CTC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTC`"]

--- a/crates/tm4c129x/src/adc0/dcctl4.rs
+++ b/crates/tm4c129x/src/adc0/dcctl4.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::DCCTL4 {
 }
 #[doc = "Comparison Interrupt Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CIM_A> for u8 {
     #[inline(always)]
     fn from(variant: CIM_A) -> Self {
-        match variant {
-            CIM_A::ALWAYS => 0,
-            CIM_A::ONCE => 1,
-            CIM_A::HALWAYS => 2,
-            CIM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIM`"]
@@ -109,22 +105,19 @@ impl<'a> CIM_W<'a> {
 }
 #[doc = "Comparison Interrupt Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CIC_A> for u8 {
     #[inline(always)]
     fn from(variant: CIC_A) -> Self {
-        match variant {
-            CIC_A::LOW => 0,
-            CIC_A::MID => 1,
-            CIC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIC`"]
@@ -215,25 +208,21 @@ impl<'a> CIE_W<'a> {
 }
 #[doc = "Comparison Trigger Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CTM_A> for u8 {
     #[inline(always)]
     fn from(variant: CTM_A) -> Self {
-        match variant {
-            CTM_A::ALWAYS => 0,
-            CTM_A::ONCE => 1,
-            CTM_A::HALWAYS => 2,
-            CTM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTM`"]
@@ -312,22 +301,19 @@ impl<'a> CTM_W<'a> {
 }
 #[doc = "Comparison Trigger Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CTC_A> for u8 {
     #[inline(always)]
     fn from(variant: CTC_A) -> Self {
-        match variant {
-            CTC_A::LOW => 0,
-            CTC_A::MID => 1,
-            CTC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTC`"]

--- a/crates/tm4c129x/src/adc0/dcctl5.rs
+++ b/crates/tm4c129x/src/adc0/dcctl5.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::DCCTL5 {
 }
 #[doc = "Comparison Interrupt Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CIM_A> for u8 {
     #[inline(always)]
     fn from(variant: CIM_A) -> Self {
-        match variant {
-            CIM_A::ALWAYS => 0,
-            CIM_A::ONCE => 1,
-            CIM_A::HALWAYS => 2,
-            CIM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIM`"]
@@ -109,22 +105,19 @@ impl<'a> CIM_W<'a> {
 }
 #[doc = "Comparison Interrupt Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CIC_A> for u8 {
     #[inline(always)]
     fn from(variant: CIC_A) -> Self {
-        match variant {
-            CIC_A::LOW => 0,
-            CIC_A::MID => 1,
-            CIC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIC`"]
@@ -215,25 +208,21 @@ impl<'a> CIE_W<'a> {
 }
 #[doc = "Comparison Trigger Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CTM_A> for u8 {
     #[inline(always)]
     fn from(variant: CTM_A) -> Self {
-        match variant {
-            CTM_A::ALWAYS => 0,
-            CTM_A::ONCE => 1,
-            CTM_A::HALWAYS => 2,
-            CTM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTM`"]
@@ -312,22 +301,19 @@ impl<'a> CTM_W<'a> {
 }
 #[doc = "Comparison Trigger Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CTC_A> for u8 {
     #[inline(always)]
     fn from(variant: CTC_A) -> Self {
-        match variant {
-            CTC_A::LOW => 0,
-            CTC_A::MID => 1,
-            CTC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTC`"]

--- a/crates/tm4c129x/src/adc0/dcctl6.rs
+++ b/crates/tm4c129x/src/adc0/dcctl6.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::DCCTL6 {
 }
 #[doc = "Comparison Interrupt Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CIM_A> for u8 {
     #[inline(always)]
     fn from(variant: CIM_A) -> Self {
-        match variant {
-            CIM_A::ALWAYS => 0,
-            CIM_A::ONCE => 1,
-            CIM_A::HALWAYS => 2,
-            CIM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIM`"]
@@ -109,22 +105,19 @@ impl<'a> CIM_W<'a> {
 }
 #[doc = "Comparison Interrupt Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CIC_A> for u8 {
     #[inline(always)]
     fn from(variant: CIC_A) -> Self {
-        match variant {
-            CIC_A::LOW => 0,
-            CIC_A::MID => 1,
-            CIC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIC`"]
@@ -215,25 +208,21 @@ impl<'a> CIE_W<'a> {
 }
 #[doc = "Comparison Trigger Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CTM_A> for u8 {
     #[inline(always)]
     fn from(variant: CTM_A) -> Self {
-        match variant {
-            CTM_A::ALWAYS => 0,
-            CTM_A::ONCE => 1,
-            CTM_A::HALWAYS => 2,
-            CTM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTM`"]
@@ -312,22 +301,19 @@ impl<'a> CTM_W<'a> {
 }
 #[doc = "Comparison Trigger Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CTC_A> for u8 {
     #[inline(always)]
     fn from(variant: CTC_A) -> Self {
-        match variant {
-            CTC_A::LOW => 0,
-            CTC_A::MID => 1,
-            CTC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTC`"]

--- a/crates/tm4c129x/src/adc0/dcctl7.rs
+++ b/crates/tm4c129x/src/adc0/dcctl7.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::DCCTL7 {
 }
 #[doc = "Comparison Interrupt Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CIM_A> for u8 {
     #[inline(always)]
     fn from(variant: CIM_A) -> Self {
-        match variant {
-            CIM_A::ALWAYS => 0,
-            CIM_A::ONCE => 1,
-            CIM_A::HALWAYS => 2,
-            CIM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIM`"]
@@ -109,22 +105,19 @@ impl<'a> CIM_W<'a> {
 }
 #[doc = "Comparison Interrupt Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CIC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CIC_A> for u8 {
     #[inline(always)]
     fn from(variant: CIC_A) -> Self {
-        match variant {
-            CIC_A::LOW => 0,
-            CIC_A::MID => 1,
-            CIC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CIC`"]
@@ -215,25 +208,21 @@ impl<'a> CIE_W<'a> {
 }
 #[doc = "Comparison Trigger Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTM_A {
     #[doc = "0: Always"]
-    ALWAYS,
+    ALWAYS = 0,
     #[doc = "1: Once"]
-    ONCE,
+    ONCE = 1,
     #[doc = "2: Hysteresis Always"]
-    HALWAYS,
+    HALWAYS = 2,
     #[doc = "3: Hysteresis Once"]
-    HONCE,
+    HONCE = 3,
 }
 impl From<CTM_A> for u8 {
     #[inline(always)]
     fn from(variant: CTM_A) -> Self {
-        match variant {
-            CTM_A::ALWAYS => 0,
-            CTM_A::ONCE => 1,
-            CTM_A::HALWAYS => 2,
-            CTM_A::HONCE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTM`"]
@@ -312,22 +301,19 @@ impl<'a> CTM_W<'a> {
 }
 #[doc = "Comparison Trigger Condition\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CTC_A {
     #[doc = "0: Low Band"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Mid Band"]
-    MID,
+    MID = 1,
     #[doc = "3: High Band"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<CTC_A> for u8 {
     #[inline(always)]
     fn from(variant: CTC_A) -> Self {
-        match variant {
-            CTC_A::LOW => 0,
-            CTC_A::MID => 1,
-            CTC_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CTC`"]

--- a/crates/tm4c129x/src/adc0/emux.rs
+++ b/crates/tm4c129x/src/adc0/emux.rs
@@ -12,49 +12,37 @@ impl crate::ResetValue for super::EMUX {
 }
 #[doc = "SS0 Trigger Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum EM0_A {
     #[doc = "0: Processor (default)"]
-    PROCESSOR,
+    PROCESSOR = 0,
     #[doc = "1: Analog Comparator 0"]
-    COMP0,
+    COMP0 = 1,
     #[doc = "2: Analog Comparator 1"]
-    COMP1,
+    COMP1 = 2,
     #[doc = "3: Analog Comparator 2"]
-    COMP2,
+    COMP2 = 3,
     #[doc = "4: External (GPIO Pins)"]
-    EXTERNAL,
+    EXTERNAL = 4,
     #[doc = "5: Timer"]
-    TIMER,
+    TIMER = 5,
     #[doc = "6: PWM generator 0"]
-    PWM0,
+    PWM0 = 6,
     #[doc = "7: PWM generator 1"]
-    PWM1,
+    PWM1 = 7,
     #[doc = "8: PWM generator 2"]
-    PWM2,
+    PWM2 = 8,
     #[doc = "9: PWM generator 3"]
-    PWM3,
+    PWM3 = 9,
     #[doc = "14: Never Trigger"]
-    NEVER,
+    NEVER = 14,
     #[doc = "15: Always (continuously sample)"]
-    ALWAYS,
+    ALWAYS = 15,
 }
 impl From<EM0_A> for u8 {
     #[inline(always)]
     fn from(variant: EM0_A) -> Self {
-        match variant {
-            EM0_A::PROCESSOR => 0,
-            EM0_A::COMP0 => 1,
-            EM0_A::COMP1 => 2,
-            EM0_A::COMP2 => 3,
-            EM0_A::EXTERNAL => 4,
-            EM0_A::TIMER => 5,
-            EM0_A::PWM0 => 6,
-            EM0_A::PWM1 => 7,
-            EM0_A::PWM2 => 8,
-            EM0_A::PWM3 => 9,
-            EM0_A::NEVER => 14,
-            EM0_A::ALWAYS => 15,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `EM0`"]
@@ -220,49 +208,37 @@ impl<'a> EM0_W<'a> {
 }
 #[doc = "SS1 Trigger Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum EM1_A {
     #[doc = "0: Processor (default)"]
-    PROCESSOR,
+    PROCESSOR = 0,
     #[doc = "1: Analog Comparator 0"]
-    COMP0,
+    COMP0 = 1,
     #[doc = "2: Analog Comparator 1"]
-    COMP1,
+    COMP1 = 2,
     #[doc = "3: Analog Comparator 2"]
-    COMP2,
+    COMP2 = 3,
     #[doc = "4: External (GPIO Pins)"]
-    EXTERNAL,
+    EXTERNAL = 4,
     #[doc = "5: Timer"]
-    TIMER,
+    TIMER = 5,
     #[doc = "6: PWM generator 0"]
-    PWM0,
+    PWM0 = 6,
     #[doc = "7: PWM generator 1"]
-    PWM1,
+    PWM1 = 7,
     #[doc = "8: PWM generator 2"]
-    PWM2,
+    PWM2 = 8,
     #[doc = "9: PWM generator 3"]
-    PWM3,
+    PWM3 = 9,
     #[doc = "14: Never Trigger"]
-    NEVER,
+    NEVER = 14,
     #[doc = "15: Always (continuously sample)"]
-    ALWAYS,
+    ALWAYS = 15,
 }
 impl From<EM1_A> for u8 {
     #[inline(always)]
     fn from(variant: EM1_A) -> Self {
-        match variant {
-            EM1_A::PROCESSOR => 0,
-            EM1_A::COMP0 => 1,
-            EM1_A::COMP1 => 2,
-            EM1_A::COMP2 => 3,
-            EM1_A::EXTERNAL => 4,
-            EM1_A::TIMER => 5,
-            EM1_A::PWM0 => 6,
-            EM1_A::PWM1 => 7,
-            EM1_A::PWM2 => 8,
-            EM1_A::PWM3 => 9,
-            EM1_A::NEVER => 14,
-            EM1_A::ALWAYS => 15,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `EM1`"]
@@ -428,49 +404,37 @@ impl<'a> EM1_W<'a> {
 }
 #[doc = "SS2 Trigger Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum EM2_A {
     #[doc = "0: Processor (default)"]
-    PROCESSOR,
+    PROCESSOR = 0,
     #[doc = "1: Analog Comparator 0"]
-    COMP0,
+    COMP0 = 1,
     #[doc = "2: Analog Comparator 1"]
-    COMP1,
+    COMP1 = 2,
     #[doc = "3: Analog Comparator 2"]
-    COMP2,
+    COMP2 = 3,
     #[doc = "4: External (GPIO Pins)"]
-    EXTERNAL,
+    EXTERNAL = 4,
     #[doc = "5: Timer"]
-    TIMER,
+    TIMER = 5,
     #[doc = "6: PWM generator 0"]
-    PWM0,
+    PWM0 = 6,
     #[doc = "7: PWM generator 1"]
-    PWM1,
+    PWM1 = 7,
     #[doc = "8: PWM generator 2"]
-    PWM2,
+    PWM2 = 8,
     #[doc = "9: PWM generator 3"]
-    PWM3,
+    PWM3 = 9,
     #[doc = "14: Never Trigger"]
-    NEVER,
+    NEVER = 14,
     #[doc = "15: Always (continuously sample)"]
-    ALWAYS,
+    ALWAYS = 15,
 }
 impl From<EM2_A> for u8 {
     #[inline(always)]
     fn from(variant: EM2_A) -> Self {
-        match variant {
-            EM2_A::PROCESSOR => 0,
-            EM2_A::COMP0 => 1,
-            EM2_A::COMP1 => 2,
-            EM2_A::COMP2 => 3,
-            EM2_A::EXTERNAL => 4,
-            EM2_A::TIMER => 5,
-            EM2_A::PWM0 => 6,
-            EM2_A::PWM1 => 7,
-            EM2_A::PWM2 => 8,
-            EM2_A::PWM3 => 9,
-            EM2_A::NEVER => 14,
-            EM2_A::ALWAYS => 15,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `EM2`"]
@@ -636,49 +600,37 @@ impl<'a> EM2_W<'a> {
 }
 #[doc = "SS3 Trigger Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum EM3_A {
     #[doc = "0: Processor (default)"]
-    PROCESSOR,
+    PROCESSOR = 0,
     #[doc = "1: Analog Comparator 0"]
-    COMP0,
+    COMP0 = 1,
     #[doc = "2: Analog Comparator 1"]
-    COMP1,
+    COMP1 = 2,
     #[doc = "3: Analog Comparator 2"]
-    COMP2,
+    COMP2 = 3,
     #[doc = "4: External (GPIO Pins)"]
-    EXTERNAL,
+    EXTERNAL = 4,
     #[doc = "5: Timer"]
-    TIMER,
+    TIMER = 5,
     #[doc = "6: PWM generator 0"]
-    PWM0,
+    PWM0 = 6,
     #[doc = "7: PWM generator 1"]
-    PWM1,
+    PWM1 = 7,
     #[doc = "8: PWM generator 2"]
-    PWM2,
+    PWM2 = 8,
     #[doc = "9: PWM generator 3"]
-    PWM3,
+    PWM3 = 9,
     #[doc = "14: Never Trigger"]
-    NEVER,
+    NEVER = 14,
     #[doc = "15: Always (continuously sample)"]
-    ALWAYS,
+    ALWAYS = 15,
 }
 impl From<EM3_A> for u8 {
     #[inline(always)]
     fn from(variant: EM3_A) -> Self {
-        match variant {
-            EM3_A::PROCESSOR => 0,
-            EM3_A::COMP0 => 1,
-            EM3_A::COMP1 => 2,
-            EM3_A::COMP2 => 3,
-            EM3_A::EXTERNAL => 4,
-            EM3_A::TIMER => 5,
-            EM3_A::PWM0 => 6,
-            EM3_A::PWM1 => 7,
-            EM3_A::PWM2 => 8,
-            EM3_A::PWM3 => 9,
-            EM3_A::NEVER => 14,
-            EM3_A::ALWAYS => 15,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `EM3`"]

--- a/crates/tm4c129x/src/adc0/pc.rs
+++ b/crates/tm4c129x/src/adc0/pc.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::PC {
 }
 #[doc = "Conversion Rate\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MCR_A {
     #[doc = "1: Eighth conversion rate. After a conversion completes, the logic pauses for 112 TADC periods before starting the next conversion"]
-    _1_8,
+    _1_8 = 1,
     #[doc = "3: Quarter conversion rate. After a conversion completes, the logic pauses for 48 TADC periods before starting the next conversion"]
-    _1_4,
+    _1_4 = 3,
     #[doc = "5: Half conversion rate. After a conversion completes, the logic pauses for 16 TADC periods before starting the next conversion"]
-    _1_2,
+    _1_2 = 5,
     #[doc = "7: Full conversion rate (FCONV) as defined by TADC and NSH"]
-    FULL,
+    FULL = 7,
 }
 impl From<MCR_A> for u8 {
     #[inline(always)]
     fn from(variant: MCR_A) -> Self {
-        match variant {
-            MCR_A::_1_8 => 1,
-            MCR_A::_1_4 => 3,
-            MCR_A::_1_2 => 5,
-            MCR_A::FULL => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MCR`"]

--- a/crates/tm4c129x/src/adc0/pp.rs
+++ b/crates/tm4c129x/src/adc0/pp.rs
@@ -2,16 +2,15 @@
 pub type R = crate::R<u32, super::PP>;
 #[doc = "Maximum Conversion Rate\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MCR_A {
     #[doc = "7: Full conversion rate (FCONV) as defined by TADC and NSH"]
-    FULL,
+    FULL = 7,
 }
 impl From<MCR_A> for u8 {
     #[inline(always)]
     fn from(variant: MCR_A) -> Self {
-        match variant {
-            MCR_A::FULL => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MCR`"]
@@ -38,16 +37,15 @@ pub type CH_R = crate::R<u8, u8>;
 pub type DC_R = crate::R<u8, u8>;
 #[doc = "ADC Architecture\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TYPE_A {
     #[doc = "0: SAR"]
-    SAR,
+    SAR = 0,
 }
 impl From<TYPE_A> for u8 {
     #[inline(always)]
     fn from(variant: TYPE_A) -> Self {
-        match variant {
-            TYPE_A::SAR => 0,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TYPE`"]

--- a/crates/tm4c129x/src/adc0/sac.rs
+++ b/crates/tm4c129x/src/adc0/sac.rs
@@ -12,34 +12,27 @@ impl crate::ResetValue for super::SAC {
 }
 #[doc = "Hardware Averaging Control\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum AVG_A {
     #[doc = "0: No hardware oversampling"]
-    OFF,
+    OFF = 0,
     #[doc = "1: 2x hardware oversampling"]
-    _2X,
+    _2X = 1,
     #[doc = "2: 4x hardware oversampling"]
-    _4X,
+    _4X = 2,
     #[doc = "3: 8x hardware oversampling"]
-    _8X,
+    _8X = 3,
     #[doc = "4: 16x hardware oversampling"]
-    _16X,
+    _16X = 4,
     #[doc = "5: 32x hardware oversampling"]
-    _32X,
+    _32X = 5,
     #[doc = "6: 64x hardware oversampling"]
-    _64X,
+    _64X = 6,
 }
 impl From<AVG_A> for u8 {
     #[inline(always)]
     fn from(variant: AVG_A) -> Self {
-        match variant {
-            AVG_A::OFF => 0,
-            AVG_A::_2X => 1,
-            AVG_A::_4X => 2,
-            AVG_A::_8X => 3,
-            AVG_A::_16X => 4,
-            AVG_A::_32X => 5,
-            AVG_A::_64X => 6,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `AVG`"]

--- a/crates/tm4c129x/src/adc0/spc.rs
+++ b/crates/tm4c129x/src/adc0/spc.rs
@@ -12,61 +12,45 @@ impl crate::ResetValue for super::SPC {
 }
 #[doc = "Phase Difference\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PHASE_A {
     #[doc = "0: ADC sample lags by 0.0"]
-    _0,
+    _0 = 0,
     #[doc = "1: ADC sample lags by 22.5"]
-    _22_5,
+    _22_5 = 1,
     #[doc = "2: ADC sample lags by 45.0"]
-    _45,
+    _45 = 2,
     #[doc = "3: ADC sample lags by 67.5"]
-    _67_5,
+    _67_5 = 3,
     #[doc = "4: ADC sample lags by 90.0"]
-    _90,
+    _90 = 4,
     #[doc = "5: ADC sample lags by 112.5"]
-    _112_5,
+    _112_5 = 5,
     #[doc = "6: ADC sample lags by 135.0"]
-    _135,
+    _135 = 6,
     #[doc = "7: ADC sample lags by 157.5"]
-    _157_5,
+    _157_5 = 7,
     #[doc = "8: ADC sample lags by 180.0"]
-    _180,
+    _180 = 8,
     #[doc = "9: ADC sample lags by 202.5"]
-    _202_5,
+    _202_5 = 9,
     #[doc = "10: ADC sample lags by 225.0"]
-    _225,
+    _225 = 10,
     #[doc = "11: ADC sample lags by 247.5"]
-    _247_5,
+    _247_5 = 11,
     #[doc = "12: ADC sample lags by 270.0"]
-    _270,
+    _270 = 12,
     #[doc = "13: ADC sample lags by 292.5"]
-    _292_5,
+    _292_5 = 13,
     #[doc = "14: ADC sample lags by 315.0"]
-    _315,
+    _315 = 14,
     #[doc = "15: ADC sample lags by 337.5"]
-    _337_5,
+    _337_5 = 15,
 }
 impl From<PHASE_A> for u8 {
     #[inline(always)]
     fn from(variant: PHASE_A) -> Self {
-        match variant {
-            PHASE_A::_0 => 0,
-            PHASE_A::_22_5 => 1,
-            PHASE_A::_45 => 2,
-            PHASE_A::_67_5 => 3,
-            PHASE_A::_90 => 4,
-            PHASE_A::_112_5 => 5,
-            PHASE_A::_135 => 6,
-            PHASE_A::_157_5 => 7,
-            PHASE_A::_180 => 8,
-            PHASE_A::_202_5 => 9,
-            PHASE_A::_225 => 10,
-            PHASE_A::_247_5 => 11,
-            PHASE_A::_270 => 12,
-            PHASE_A::_292_5 => 13,
-            PHASE_A::_315 => 14,
-            PHASE_A::_337_5 => 15,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PHASE`"]

--- a/crates/tm4c129x/src/adc0/sstsh0.rs
+++ b/crates/tm4c129x/src/adc0/sstsh0.rs
@@ -12,34 +12,27 @@ impl crate::ResetValue for super::SSTSH0 {
 }
 #[doc = "1st Sample and Hold Period Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TSH0_A {
     #[doc = "0: N_SH = 4"]
-    _4,
+    _4 = 0,
     #[doc = "2: N_SH = 8"]
-    _8,
+    _8 = 2,
     #[doc = "4: N_SH = 16"]
-    _16,
+    _16 = 4,
     #[doc = "6: N_SH = 32"]
-    _32,
+    _32 = 6,
     #[doc = "8: N_SH = 64"]
-    _64,
+    _64 = 8,
     #[doc = "10: N_SH = 128"]
-    _128,
+    _128 = 10,
     #[doc = "12: N_SH = 256"]
-    _256,
+    _256 = 12,
 }
 impl From<TSH0_A> for u8 {
     #[inline(always)]
     fn from(variant: TSH0_A) -> Self {
-        match variant {
-            TSH0_A::_4 => 0,
-            TSH0_A::_8 => 2,
-            TSH0_A::_16 => 4,
-            TSH0_A::_32 => 6,
-            TSH0_A::_64 => 8,
-            TSH0_A::_128 => 10,
-            TSH0_A::_256 => 12,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TSH0`"]
@@ -150,34 +143,27 @@ impl<'a> TSH0_W<'a> {
 }
 #[doc = "2nd Sample and Hold Period Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TSH1_A {
     #[doc = "0: N_SH = 4"]
-    _4,
+    _4 = 0,
     #[doc = "2: N_SH = 8"]
-    _8,
+    _8 = 2,
     #[doc = "4: N_SH = 16"]
-    _16,
+    _16 = 4,
     #[doc = "6: N_SH = 32"]
-    _32,
+    _32 = 6,
     #[doc = "8: N_SH = 64"]
-    _64,
+    _64 = 8,
     #[doc = "10: N_SH = 128"]
-    _128,
+    _128 = 10,
     #[doc = "12: N_SH = 256"]
-    _256,
+    _256 = 12,
 }
 impl From<TSH1_A> for u8 {
     #[inline(always)]
     fn from(variant: TSH1_A) -> Self {
-        match variant {
-            TSH1_A::_4 => 0,
-            TSH1_A::_8 => 2,
-            TSH1_A::_16 => 4,
-            TSH1_A::_32 => 6,
-            TSH1_A::_64 => 8,
-            TSH1_A::_128 => 10,
-            TSH1_A::_256 => 12,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TSH1`"]
@@ -288,34 +274,27 @@ impl<'a> TSH1_W<'a> {
 }
 #[doc = "3rd Sample and Hold Period Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TSH2_A {
     #[doc = "0: N_SH = 4"]
-    _4,
+    _4 = 0,
     #[doc = "2: N_SH = 8"]
-    _8,
+    _8 = 2,
     #[doc = "4: N_SH = 16"]
-    _16,
+    _16 = 4,
     #[doc = "6: N_SH = 32"]
-    _32,
+    _32 = 6,
     #[doc = "8: N_SH = 64"]
-    _64,
+    _64 = 8,
     #[doc = "10: N_SH = 128"]
-    _128,
+    _128 = 10,
     #[doc = "12: N_SH = 256"]
-    _256,
+    _256 = 12,
 }
 impl From<TSH2_A> for u8 {
     #[inline(always)]
     fn from(variant: TSH2_A) -> Self {
-        match variant {
-            TSH2_A::_4 => 0,
-            TSH2_A::_8 => 2,
-            TSH2_A::_16 => 4,
-            TSH2_A::_32 => 6,
-            TSH2_A::_64 => 8,
-            TSH2_A::_128 => 10,
-            TSH2_A::_256 => 12,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TSH2`"]
@@ -426,34 +405,27 @@ impl<'a> TSH2_W<'a> {
 }
 #[doc = "4th Sample and Hold Period Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TSH3_A {
     #[doc = "0: N_SH = 4"]
-    _4,
+    _4 = 0,
     #[doc = "2: N_SH = 8"]
-    _8,
+    _8 = 2,
     #[doc = "4: N_SH = 16"]
-    _16,
+    _16 = 4,
     #[doc = "6: N_SH = 32"]
-    _32,
+    _32 = 6,
     #[doc = "8: N_SH = 64"]
-    _64,
+    _64 = 8,
     #[doc = "10: N_SH = 128"]
-    _128,
+    _128 = 10,
     #[doc = "12: N_SH = 256"]
-    _256,
+    _256 = 12,
 }
 impl From<TSH3_A> for u8 {
     #[inline(always)]
     fn from(variant: TSH3_A) -> Self {
-        match variant {
-            TSH3_A::_4 => 0,
-            TSH3_A::_8 => 2,
-            TSH3_A::_16 => 4,
-            TSH3_A::_32 => 6,
-            TSH3_A::_64 => 8,
-            TSH3_A::_128 => 10,
-            TSH3_A::_256 => 12,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TSH3`"]
@@ -564,34 +536,27 @@ impl<'a> TSH3_W<'a> {
 }
 #[doc = "5th Sample and Hold Period Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TSH4_A {
     #[doc = "0: N_SH = 4"]
-    _4,
+    _4 = 0,
     #[doc = "2: N_SH = 8"]
-    _8,
+    _8 = 2,
     #[doc = "4: N_SH = 16"]
-    _16,
+    _16 = 4,
     #[doc = "6: N_SH = 32"]
-    _32,
+    _32 = 6,
     #[doc = "8: N_SH = 64"]
-    _64,
+    _64 = 8,
     #[doc = "10: N_SH = 128"]
-    _128,
+    _128 = 10,
     #[doc = "12: N_SH = 256"]
-    _256,
+    _256 = 12,
 }
 impl From<TSH4_A> for u8 {
     #[inline(always)]
     fn from(variant: TSH4_A) -> Self {
-        match variant {
-            TSH4_A::_4 => 0,
-            TSH4_A::_8 => 2,
-            TSH4_A::_16 => 4,
-            TSH4_A::_32 => 6,
-            TSH4_A::_64 => 8,
-            TSH4_A::_128 => 10,
-            TSH4_A::_256 => 12,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TSH4`"]
@@ -702,34 +667,27 @@ impl<'a> TSH4_W<'a> {
 }
 #[doc = "6th Sample and Hold Period Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TSH5_A {
     #[doc = "0: N_SH = 4"]
-    _4,
+    _4 = 0,
     #[doc = "2: N_SH = 8"]
-    _8,
+    _8 = 2,
     #[doc = "4: N_SH = 16"]
-    _16,
+    _16 = 4,
     #[doc = "6: N_SH = 32"]
-    _32,
+    _32 = 6,
     #[doc = "8: N_SH = 64"]
-    _64,
+    _64 = 8,
     #[doc = "10: N_SH = 128"]
-    _128,
+    _128 = 10,
     #[doc = "12: N_SH = 256"]
-    _256,
+    _256 = 12,
 }
 impl From<TSH5_A> for u8 {
     #[inline(always)]
     fn from(variant: TSH5_A) -> Self {
-        match variant {
-            TSH5_A::_4 => 0,
-            TSH5_A::_8 => 2,
-            TSH5_A::_16 => 4,
-            TSH5_A::_32 => 6,
-            TSH5_A::_64 => 8,
-            TSH5_A::_128 => 10,
-            TSH5_A::_256 => 12,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TSH5`"]
@@ -840,34 +798,27 @@ impl<'a> TSH5_W<'a> {
 }
 #[doc = "7th Sample and Hold Period Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TSH6_A {
     #[doc = "0: N_SH = 4"]
-    _4,
+    _4 = 0,
     #[doc = "2: N_SH = 8"]
-    _8,
+    _8 = 2,
     #[doc = "4: N_SH = 16"]
-    _16,
+    _16 = 4,
     #[doc = "6: N_SH = 32"]
-    _32,
+    _32 = 6,
     #[doc = "8: N_SH = 64"]
-    _64,
+    _64 = 8,
     #[doc = "10: N_SH = 128"]
-    _128,
+    _128 = 10,
     #[doc = "12: N_SH = 256"]
-    _256,
+    _256 = 12,
 }
 impl From<TSH6_A> for u8 {
     #[inline(always)]
     fn from(variant: TSH6_A) -> Self {
-        match variant {
-            TSH6_A::_4 => 0,
-            TSH6_A::_8 => 2,
-            TSH6_A::_16 => 4,
-            TSH6_A::_32 => 6,
-            TSH6_A::_64 => 8,
-            TSH6_A::_128 => 10,
-            TSH6_A::_256 => 12,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TSH6`"]
@@ -978,34 +929,27 @@ impl<'a> TSH6_W<'a> {
 }
 #[doc = "8th Sample and Hold Period Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TSH7_A {
     #[doc = "0: N_SH = 4"]
-    _4,
+    _4 = 0,
     #[doc = "2: N_SH = 8"]
-    _8,
+    _8 = 2,
     #[doc = "4: N_SH = 16"]
-    _16,
+    _16 = 4,
     #[doc = "6: N_SH = 32"]
-    _32,
+    _32 = 6,
     #[doc = "8: N_SH = 64"]
-    _64,
+    _64 = 8,
     #[doc = "10: N_SH = 128"]
-    _128,
+    _128 = 10,
     #[doc = "12: N_SH = 256"]
-    _256,
+    _256 = 12,
 }
 impl From<TSH7_A> for u8 {
     #[inline(always)]
     fn from(variant: TSH7_A) -> Self {
-        match variant {
-            TSH7_A::_4 => 0,
-            TSH7_A::_8 => 2,
-            TSH7_A::_16 => 4,
-            TSH7_A::_32 => 6,
-            TSH7_A::_64 => 8,
-            TSH7_A::_128 => 10,
-            TSH7_A::_256 => 12,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TSH7`"]

--- a/crates/tm4c129x/src/adc0/tssel.rs
+++ b/crates/tm4c129x/src/adc0/tssel.rs
@@ -12,16 +12,15 @@ impl crate::ResetValue for super::TSSEL {
 }
 #[doc = "Generator 0 PWM Module Trigger Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PS0_A {
     #[doc = "0: Use Generator 0 (and its trigger) in PWM module 0"]
-    _0,
+    _0 = 0,
 }
 impl From<PS0_A> for u8 {
     #[inline(always)]
     fn from(variant: PS0_A) -> Self {
-        match variant {
-            PS0_A::_0 => 0,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PS0`"]
@@ -66,16 +65,15 @@ impl<'a> PS0_W<'a> {
 }
 #[doc = "Generator 1 PWM Module Trigger Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PS1_A {
     #[doc = "0: Use Generator 1 (and its trigger) in PWM module 0"]
-    _0,
+    _0 = 0,
 }
 impl From<PS1_A> for u8 {
     #[inline(always)]
     fn from(variant: PS1_A) -> Self {
-        match variant {
-            PS1_A::_0 => 0,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PS1`"]
@@ -120,16 +118,15 @@ impl<'a> PS1_W<'a> {
 }
 #[doc = "Generator 2 PWM Module Trigger Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PS2_A {
     #[doc = "0: Use Generator 2 (and its trigger) in PWM module 0"]
-    _0,
+    _0 = 0,
 }
 impl From<PS2_A> for u8 {
     #[inline(always)]
     fn from(variant: PS2_A) -> Self {
-        match variant {
-            PS2_A::_0 => 0,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PS2`"]
@@ -174,16 +171,15 @@ impl<'a> PS2_W<'a> {
 }
 #[doc = "Generator 3 PWM Module Trigger Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PS3_A {
     #[doc = "0: Use Generator 3 (and its trigger) in PWM module 0"]
-    _0,
+    _0 = 0,
 }
 impl From<PS3_A> for u8 {
     #[inline(always)]
     fn from(variant: PS3_A) -> Self {
-        match variant {
-            PS3_A::_0 => 0,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PS3`"]

--- a/crates/tm4c129x/src/can0.rs
+++ b/crates/tm4c129x/src/can0.rs
@@ -82,7 +82,7 @@ pub struct RegisterBlock {
     #[doc = "0x164 - CAN Message 2 Valid"]
     pub msg2val: MSG2VAL,
 }
-#[doc = "CAN Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctl](ctl) module"]
+#[doc = "CAN Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctl](ctl) module"]
 pub type CTL = crate::Reg<u32, _CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -93,7 +93,7 @@ impl crate::Readable for CTL {}
 impl crate::Writable for CTL {}
 #[doc = "CAN Control"]
 pub mod ctl;
-#[doc = "CAN Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sts](sts) module"]
+#[doc = "CAN Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sts](sts) module"]
 pub type STS = crate::Reg<u32, _STS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -104,7 +104,7 @@ impl crate::Readable for STS {}
 impl crate::Writable for STS {}
 #[doc = "CAN Status"]
 pub mod sts;
-#[doc = "CAN Error Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [err](err) module"]
+#[doc = "CAN Error Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [err](err) module"]
 pub type ERR = crate::Reg<u32, _ERR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -113,7 +113,7 @@ pub struct _ERR;
 impl crate::Readable for ERR {}
 #[doc = "CAN Error Counter"]
 pub mod err;
-#[doc = "CAN Bit Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [bit_](bit_) module"]
+#[doc = "CAN Bit Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [bit_](bit_) module"]
 pub type BIT = crate::Reg<u32, _BIT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -124,7 +124,7 @@ impl crate::Readable for BIT {}
 impl crate::Writable for BIT {}
 #[doc = "CAN Bit Timing"]
 pub mod bit_;
-#[doc = "CAN Interrupt\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [int](int) module"]
+#[doc = "CAN Interrupt\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [int](int) module"]
 pub type INT = crate::Reg<u32, _INT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -133,7 +133,7 @@ pub struct _INT;
 impl crate::Readable for INT {}
 #[doc = "CAN Interrupt"]
 pub mod int;
-#[doc = "CAN Test\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tst](tst) module"]
+#[doc = "CAN Test\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tst](tst) module"]
 pub type TST = crate::Reg<u32, _TST>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -144,7 +144,7 @@ impl crate::Readable for TST {}
 impl crate::Writable for TST {}
 #[doc = "CAN Test"]
 pub mod tst;
-#[doc = "CAN Baud Rate Prescaler Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [brpe](brpe) module"]
+#[doc = "CAN Baud Rate Prescaler Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [brpe](brpe) module"]
 pub type BRPE = crate::Reg<u32, _BRPE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -155,7 +155,7 @@ impl crate::Readable for BRPE {}
 impl crate::Writable for BRPE {}
 #[doc = "CAN Baud Rate Prescaler Extension"]
 pub mod brpe;
-#[doc = "CAN IF1 Command Request\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1crq](if1crq) module"]
+#[doc = "CAN IF1 Command Request\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1crq](if1crq) module"]
 pub type IF1CRQ = crate::Reg<u32, _IF1CRQ>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -166,7 +166,7 @@ impl crate::Readable for IF1CRQ {}
 impl crate::Writable for IF1CRQ {}
 #[doc = "CAN IF1 Command Request"]
 pub mod if1crq;
-#[doc = "CAN IF1 Command Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1cmsk](if1cmsk) module"]
+#[doc = "CAN IF1 Command Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1cmsk](if1cmsk) module"]
 pub type IF1CMSK = crate::Reg<u32, _IF1CMSK>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -177,7 +177,7 @@ impl crate::Readable for IF1CMSK {}
 impl crate::Writable for IF1CMSK {}
 #[doc = "CAN IF1 Command Mask"]
 pub mod if1cmsk;
-#[doc = "CAN IF1 Mask 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1msk1](if1msk1) module"]
+#[doc = "CAN IF1 Mask 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1msk1](if1msk1) module"]
 pub type IF1MSK1 = crate::Reg<u32, _IF1MSK1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -188,7 +188,7 @@ impl crate::Readable for IF1MSK1 {}
 impl crate::Writable for IF1MSK1 {}
 #[doc = "CAN IF1 Mask 1"]
 pub mod if1msk1;
-#[doc = "CAN IF1 Mask 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1msk2](if1msk2) module"]
+#[doc = "CAN IF1 Mask 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1msk2](if1msk2) module"]
 pub type IF1MSK2 = crate::Reg<u32, _IF1MSK2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -199,7 +199,7 @@ impl crate::Readable for IF1MSK2 {}
 impl crate::Writable for IF1MSK2 {}
 #[doc = "CAN IF1 Mask 2"]
 pub mod if1msk2;
-#[doc = "CAN IF1 Arbitration 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1arb1](if1arb1) module"]
+#[doc = "CAN IF1 Arbitration 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1arb1](if1arb1) module"]
 pub type IF1ARB1 = crate::Reg<u32, _IF1ARB1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -210,7 +210,7 @@ impl crate::Readable for IF1ARB1 {}
 impl crate::Writable for IF1ARB1 {}
 #[doc = "CAN IF1 Arbitration 1"]
 pub mod if1arb1;
-#[doc = "CAN IF1 Arbitration 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1arb2](if1arb2) module"]
+#[doc = "CAN IF1 Arbitration 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1arb2](if1arb2) module"]
 pub type IF1ARB2 = crate::Reg<u32, _IF1ARB2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -221,7 +221,7 @@ impl crate::Readable for IF1ARB2 {}
 impl crate::Writable for IF1ARB2 {}
 #[doc = "CAN IF1 Arbitration 2"]
 pub mod if1arb2;
-#[doc = "CAN IF1 Message Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1mctl](if1mctl) module"]
+#[doc = "CAN IF1 Message Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1mctl](if1mctl) module"]
 pub type IF1MCTL = crate::Reg<u32, _IF1MCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -232,7 +232,7 @@ impl crate::Readable for IF1MCTL {}
 impl crate::Writable for IF1MCTL {}
 #[doc = "CAN IF1 Message Control"]
 pub mod if1mctl;
-#[doc = "CAN IF1 Data A1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1da1](if1da1) module"]
+#[doc = "CAN IF1 Data A1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1da1](if1da1) module"]
 pub type IF1DA1 = crate::Reg<u32, _IF1DA1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -243,7 +243,7 @@ impl crate::Readable for IF1DA1 {}
 impl crate::Writable for IF1DA1 {}
 #[doc = "CAN IF1 Data A1"]
 pub mod if1da1;
-#[doc = "CAN IF1 Data A2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1da2](if1da2) module"]
+#[doc = "CAN IF1 Data A2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1da2](if1da2) module"]
 pub type IF1DA2 = crate::Reg<u32, _IF1DA2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -254,7 +254,7 @@ impl crate::Readable for IF1DA2 {}
 impl crate::Writable for IF1DA2 {}
 #[doc = "CAN IF1 Data A2"]
 pub mod if1da2;
-#[doc = "CAN IF1 Data B1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1db1](if1db1) module"]
+#[doc = "CAN IF1 Data B1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1db1](if1db1) module"]
 pub type IF1DB1 = crate::Reg<u32, _IF1DB1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -265,7 +265,7 @@ impl crate::Readable for IF1DB1 {}
 impl crate::Writable for IF1DB1 {}
 #[doc = "CAN IF1 Data B1"]
 pub mod if1db1;
-#[doc = "CAN IF1 Data B2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if1db2](if1db2) module"]
+#[doc = "CAN IF1 Data B2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if1db2](if1db2) module"]
 pub type IF1DB2 = crate::Reg<u32, _IF1DB2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -276,7 +276,7 @@ impl crate::Readable for IF1DB2 {}
 impl crate::Writable for IF1DB2 {}
 #[doc = "CAN IF1 Data B2"]
 pub mod if1db2;
-#[doc = "CAN IF2 Command Request\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2crq](if2crq) module"]
+#[doc = "CAN IF2 Command Request\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2crq](if2crq) module"]
 pub type IF2CRQ = crate::Reg<u32, _IF2CRQ>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -287,7 +287,7 @@ impl crate::Readable for IF2CRQ {}
 impl crate::Writable for IF2CRQ {}
 #[doc = "CAN IF2 Command Request"]
 pub mod if2crq;
-#[doc = "CAN IF2 Command Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2cmsk](if2cmsk) module"]
+#[doc = "CAN IF2 Command Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2cmsk](if2cmsk) module"]
 pub type IF2CMSK = crate::Reg<u32, _IF2CMSK>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -298,7 +298,7 @@ impl crate::Readable for IF2CMSK {}
 impl crate::Writable for IF2CMSK {}
 #[doc = "CAN IF2 Command Mask"]
 pub mod if2cmsk;
-#[doc = "CAN IF2 Mask 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2msk1](if2msk1) module"]
+#[doc = "CAN IF2 Mask 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2msk1](if2msk1) module"]
 pub type IF2MSK1 = crate::Reg<u32, _IF2MSK1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -309,7 +309,7 @@ impl crate::Readable for IF2MSK1 {}
 impl crate::Writable for IF2MSK1 {}
 #[doc = "CAN IF2 Mask 1"]
 pub mod if2msk1;
-#[doc = "CAN IF2 Mask 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2msk2](if2msk2) module"]
+#[doc = "CAN IF2 Mask 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2msk2](if2msk2) module"]
 pub type IF2MSK2 = crate::Reg<u32, _IF2MSK2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -320,7 +320,7 @@ impl crate::Readable for IF2MSK2 {}
 impl crate::Writable for IF2MSK2 {}
 #[doc = "CAN IF2 Mask 2"]
 pub mod if2msk2;
-#[doc = "CAN IF2 Arbitration 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2arb1](if2arb1) module"]
+#[doc = "CAN IF2 Arbitration 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2arb1](if2arb1) module"]
 pub type IF2ARB1 = crate::Reg<u32, _IF2ARB1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -331,7 +331,7 @@ impl crate::Readable for IF2ARB1 {}
 impl crate::Writable for IF2ARB1 {}
 #[doc = "CAN IF2 Arbitration 1"]
 pub mod if2arb1;
-#[doc = "CAN IF2 Arbitration 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2arb2](if2arb2) module"]
+#[doc = "CAN IF2 Arbitration 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2arb2](if2arb2) module"]
 pub type IF2ARB2 = crate::Reg<u32, _IF2ARB2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -342,7 +342,7 @@ impl crate::Readable for IF2ARB2 {}
 impl crate::Writable for IF2ARB2 {}
 #[doc = "CAN IF2 Arbitration 2"]
 pub mod if2arb2;
-#[doc = "CAN IF2 Message Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2mctl](if2mctl) module"]
+#[doc = "CAN IF2 Message Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2mctl](if2mctl) module"]
 pub type IF2MCTL = crate::Reg<u32, _IF2MCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -353,7 +353,7 @@ impl crate::Readable for IF2MCTL {}
 impl crate::Writable for IF2MCTL {}
 #[doc = "CAN IF2 Message Control"]
 pub mod if2mctl;
-#[doc = "CAN IF2 Data A1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2da1](if2da1) module"]
+#[doc = "CAN IF2 Data A1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2da1](if2da1) module"]
 pub type IF2DA1 = crate::Reg<u32, _IF2DA1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -364,7 +364,7 @@ impl crate::Readable for IF2DA1 {}
 impl crate::Writable for IF2DA1 {}
 #[doc = "CAN IF2 Data A1"]
 pub mod if2da1;
-#[doc = "CAN IF2 Data A2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2da2](if2da2) module"]
+#[doc = "CAN IF2 Data A2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2da2](if2da2) module"]
 pub type IF2DA2 = crate::Reg<u32, _IF2DA2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -375,7 +375,7 @@ impl crate::Readable for IF2DA2 {}
 impl crate::Writable for IF2DA2 {}
 #[doc = "CAN IF2 Data A2"]
 pub mod if2da2;
-#[doc = "CAN IF2 Data B1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2db1](if2db1) module"]
+#[doc = "CAN IF2 Data B1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2db1](if2db1) module"]
 pub type IF2DB1 = crate::Reg<u32, _IF2DB1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -386,7 +386,7 @@ impl crate::Readable for IF2DB1 {}
 impl crate::Writable for IF2DB1 {}
 #[doc = "CAN IF2 Data B1"]
 pub mod if2db1;
-#[doc = "CAN IF2 Data B2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [if2db2](if2db2) module"]
+#[doc = "CAN IF2 Data B2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [if2db2](if2db2) module"]
 pub type IF2DB2 = crate::Reg<u32, _IF2DB2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -397,7 +397,7 @@ impl crate::Readable for IF2DB2 {}
 impl crate::Writable for IF2DB2 {}
 #[doc = "CAN IF2 Data B2"]
 pub mod if2db2;
-#[doc = "CAN Transmission Request 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txrq1](txrq1) module"]
+#[doc = "CAN Transmission Request 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txrq1](txrq1) module"]
 pub type TXRQ1 = crate::Reg<u32, _TXRQ1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -406,7 +406,7 @@ pub struct _TXRQ1;
 impl crate::Readable for TXRQ1 {}
 #[doc = "CAN Transmission Request 1"]
 pub mod txrq1;
-#[doc = "CAN Transmission Request 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txrq2](txrq2) module"]
+#[doc = "CAN Transmission Request 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txrq2](txrq2) module"]
 pub type TXRQ2 = crate::Reg<u32, _TXRQ2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -415,7 +415,7 @@ pub struct _TXRQ2;
 impl crate::Readable for TXRQ2 {}
 #[doc = "CAN Transmission Request 2"]
 pub mod txrq2;
-#[doc = "CAN New Data 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [nwda1](nwda1) module"]
+#[doc = "CAN New Data 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [nwda1](nwda1) module"]
 pub type NWDA1 = crate::Reg<u32, _NWDA1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -424,7 +424,7 @@ pub struct _NWDA1;
 impl crate::Readable for NWDA1 {}
 #[doc = "CAN New Data 1"]
 pub mod nwda1;
-#[doc = "CAN New Data 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [nwda2](nwda2) module"]
+#[doc = "CAN New Data 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [nwda2](nwda2) module"]
 pub type NWDA2 = crate::Reg<u32, _NWDA2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -433,7 +433,7 @@ pub struct _NWDA2;
 impl crate::Readable for NWDA2 {}
 #[doc = "CAN New Data 2"]
 pub mod nwda2;
-#[doc = "CAN Message 1 Interrupt Pending\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [msg1int](msg1int) module"]
+#[doc = "CAN Message 1 Interrupt Pending\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [msg1int](msg1int) module"]
 pub type MSG1INT = crate::Reg<u32, _MSG1INT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -442,7 +442,7 @@ pub struct _MSG1INT;
 impl crate::Readable for MSG1INT {}
 #[doc = "CAN Message 1 Interrupt Pending"]
 pub mod msg1int;
-#[doc = "CAN Message 2 Interrupt Pending\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [msg2int](msg2int) module"]
+#[doc = "CAN Message 2 Interrupt Pending\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [msg2int](msg2int) module"]
 pub type MSG2INT = crate::Reg<u32, _MSG2INT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -451,7 +451,7 @@ pub struct _MSG2INT;
 impl crate::Readable for MSG2INT {}
 #[doc = "CAN Message 2 Interrupt Pending"]
 pub mod msg2int;
-#[doc = "CAN Message 1 Valid\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [msg1val](msg1val) module"]
+#[doc = "CAN Message 1 Valid\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [msg1val](msg1val) module"]
 pub type MSG1VAL = crate::Reg<u32, _MSG1VAL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -460,7 +460,7 @@ pub struct _MSG1VAL;
 impl crate::Readable for MSG1VAL {}
 #[doc = "CAN Message 1 Valid"]
 pub mod msg1val;
-#[doc = "CAN Message 2 Valid\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [msg2val](msg2val) module"]
+#[doc = "CAN Message 2 Valid\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [msg2val](msg2val) module"]
 pub type MSG2VAL = crate::Reg<u32, _MSG2VAL>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/can0/int.rs
+++ b/crates/tm4c129x/src/can0/int.rs
@@ -2,19 +2,17 @@
 pub type R = crate::R<u32, super::INT>;
 #[doc = "Interrupt Identifier\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u16)]
 pub enum INTID_A {
     #[doc = "0: No interrupt pending"]
-    NONE,
+    NONE = 0,
     #[doc = "32768: Status Interrupt"]
-    STATUS,
+    STATUS = 32768,
 }
 impl From<INTID_A> for u16 {
     #[inline(always)]
     fn from(variant: INTID_A) -> Self {
-        match variant {
-            INTID_A::NONE => 0,
-            INTID_A::STATUS => 32768,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `INTID`"]

--- a/crates/tm4c129x/src/can0/sts.rs
+++ b/crates/tm4c129x/src/can0/sts.rs
@@ -12,37 +12,29 @@ impl crate::ResetValue for super::STS {
 }
 #[doc = "Last Error Code\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum LEC_A {
     #[doc = "0: No Error"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Stuff Error"]
-    STUFF,
+    STUFF = 1,
     #[doc = "2: Format Error"]
-    FORM,
+    FORM = 2,
     #[doc = "3: ACK Error"]
-    ACK,
+    ACK = 3,
     #[doc = "4: Bit 1 Error"]
-    BIT1,
+    BIT1 = 4,
     #[doc = "5: Bit 0 Error"]
-    BIT0,
+    BIT0 = 5,
     #[doc = "6: CRC Error"]
-    CRC,
+    CRC = 6,
     #[doc = "7: No Event"]
-    NOEVENT,
+    NOEVENT = 7,
 }
 impl From<LEC_A> for u8 {
     #[inline(always)]
     fn from(variant: LEC_A) -> Self {
-        match variant {
-            LEC_A::NONE => 0,
-            LEC_A::STUFF => 1,
-            LEC_A::FORM => 2,
-            LEC_A::ACK => 3,
-            LEC_A::BIT1 => 4,
-            LEC_A::BIT0 => 5,
-            LEC_A::CRC => 6,
-            LEC_A::NOEVENT => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `LEC`"]

--- a/crates/tm4c129x/src/can0/tst.rs
+++ b/crates/tm4c129x/src/can0/tst.rs
@@ -84,25 +84,21 @@ impl<'a> LBACK_W<'a> {
 }
 #[doc = "Transmit Control\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TX_A {
     #[doc = "0: CAN Module Control"]
-    CANCTL,
+    CANCTL = 0,
     #[doc = "1: Sample Point"]
-    SAMPLE,
+    SAMPLE = 1,
     #[doc = "2: Driven Low"]
-    DOMINANT,
+    DOMINANT = 2,
     #[doc = "3: Driven High"]
-    RECESSIVE,
+    RECESSIVE = 3,
 }
 impl From<TX_A> for u8 {
     #[inline(always)]
     fn from(variant: TX_A) -> Self {
-        match variant {
-            TX_A::CANCTL => 0,
-            TX_A::SAMPLE => 1,
-            TX_A::DOMINANT => 2,
-            TX_A::RECESSIVE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TX`"]

--- a/crates/tm4c129x/src/ccm0.rs
+++ b/crates/tm4c129x/src/ccm0.rs
@@ -12,7 +12,7 @@ pub struct RegisterBlock {
     #[doc = "0x418 - CRC Post Processing Result"]
     pub crcrsltpp: CRCRSLTPP,
 }
-#[doc = "CRC Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [crcctrl](crcctrl) module"]
+#[doc = "CRC Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [crcctrl](crcctrl) module"]
 pub type CRCCTRL = crate::Reg<u32, _CRCCTRL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -23,7 +23,7 @@ impl crate::Readable for CRCCTRL {}
 impl crate::Writable for CRCCTRL {}
 #[doc = "CRC Control"]
 pub mod crcctrl;
-#[doc = "CRC SEED/Context\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [crcseed](crcseed) module"]
+#[doc = "CRC SEED/Context\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [crcseed](crcseed) module"]
 pub type CRCSEED = crate::Reg<u32, _CRCSEED>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -34,7 +34,7 @@ impl crate::Readable for CRCSEED {}
 impl crate::Writable for CRCSEED {}
 #[doc = "CRC SEED/Context"]
 pub mod crcseed;
-#[doc = "CRC Data Input\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [crcdin](crcdin) module"]
+#[doc = "CRC Data Input\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [crcdin](crcdin) module"]
 pub type CRCDIN = crate::Reg<u32, _CRCDIN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -45,7 +45,7 @@ impl crate::Readable for CRCDIN {}
 impl crate::Writable for CRCDIN {}
 #[doc = "CRC Data Input"]
 pub mod crcdin;
-#[doc = "CRC Post Processing Result\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [crcrsltpp](crcrsltpp) module"]
+#[doc = "CRC Post Processing Result\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [crcrsltpp](crcrsltpp) module"]
 pub type CRCRSLTPP = crate::Reg<u32, _CRCRSLTPP>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/ccm0/crcctrl.rs
+++ b/crates/tm4c129x/src/ccm0/crcctrl.rs
@@ -12,28 +12,23 @@ impl crate::ResetValue for super::CRCCTRL {
 }
 #[doc = "Operation Type\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TYPE_A {
     #[doc = "0: Polynomial 0x8005"]
-    P8055,
+    P8055 = 0,
     #[doc = "1: Polynomial 0x1021"]
-    P1021,
+    P1021 = 1,
     #[doc = "2: Polynomial 0x4C11DB7"]
-    P4C11DB7,
+    P4C11DB7 = 2,
     #[doc = "3: Polynomial 0x1EDC6F41"]
-    P1EDC6F41,
+    P1EDC6F41 = 3,
     #[doc = "8: TCP checksum"]
-    TCPCHKSUM,
+    TCPCHKSUM = 8,
 }
 impl From<TYPE_A> for u8 {
     #[inline(always)]
     fn from(variant: TYPE_A) -> Self {
-        match variant {
-            TYPE_A::P8055 => 0,
-            TYPE_A::P1021 => 1,
-            TYPE_A::P4C11DB7 => 2,
-            TYPE_A::P1EDC6F41 => 3,
-            TYPE_A::TCPCHKSUM => 8,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TYPE`"]
@@ -122,25 +117,21 @@ impl<'a> TYPE_W<'a> {
 }
 #[doc = "Endian Control\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ENDIAN_A {
     #[doc = "0: Configuration unchanged. (B3, B2, B1, B0)"]
-    SBHW,
+    SBHW = 0,
     #[doc = "1: Bytes are swapped in half-words but half-words are not swapped (B2, B3, B0, B1)"]
-    SHW,
+    SHW = 1,
     #[doc = "2: Half-words are swapped but bytes are not swapped in half-word. (B1, B0, B3, B2)"]
-    SHWNB,
+    SHWNB = 2,
     #[doc = "3: Bytes are swapped in half-words and half-words are swapped. (B0, B1, B2, B3)"]
-    SBSW,
+    SBSW = 3,
 }
 impl From<ENDIAN_A> for u8 {
     #[inline(always)]
     fn from(variant: ENDIAN_A) -> Self {
-        match variant {
-            ENDIAN_A::SBHW => 0,
-            ENDIAN_A::SHW => 1,
-            ENDIAN_A::SHWNB => 2,
-            ENDIAN_A::SBSW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ENDIAN`"]
@@ -315,22 +306,19 @@ impl<'a> SIZE_W<'a> {
 }
 #[doc = "CRC Initialization\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum INIT_A {
     #[doc = "0: Use the CRCSEED register context as the starting value"]
-    SEED,
+    SEED = 0,
     #[doc = "2: Initialize to all '0s'"]
-    _0,
+    _0 = 2,
     #[doc = "3: Initialize to all '1s'"]
-    _1,
+    _1 = 3,
 }
 impl From<INIT_A> for u8 {
     #[inline(always)]
     fn from(variant: INIT_A) -> Self {
-        match variant {
-            INIT_A::SEED => 0,
-            INIT_A::_0 => 2,
-            INIT_A::_1 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `INIT`"]

--- a/crates/tm4c129x/src/comp.rs
+++ b/crates/tm4c129x/src/comp.rs
@@ -29,7 +29,7 @@ pub struct RegisterBlock {
     #[doc = "0xfc0 - Analog Comparator Peripheral Properties"]
     pub pp: PP,
 }
-#[doc = "Analog Comparator Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acmis](acmis) module"]
+#[doc = "Analog Comparator Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acmis](acmis) module"]
 pub type ACMIS = crate::Reg<u32, _ACMIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -40,7 +40,7 @@ impl crate::Readable for ACMIS {}
 impl crate::Writable for ACMIS {}
 #[doc = "Analog Comparator Masked Interrupt Status"]
 pub mod acmis;
-#[doc = "Analog Comparator Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acris](acris) module"]
+#[doc = "Analog Comparator Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acris](acris) module"]
 pub type ACRIS = crate::Reg<u32, _ACRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -49,7 +49,7 @@ pub struct _ACRIS;
 impl crate::Readable for ACRIS {}
 #[doc = "Analog Comparator Raw Interrupt Status"]
 pub mod acris;
-#[doc = "Analog Comparator Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acinten](acinten) module"]
+#[doc = "Analog Comparator Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acinten](acinten) module"]
 pub type ACINTEN = crate::Reg<u32, _ACINTEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -60,7 +60,7 @@ impl crate::Readable for ACINTEN {}
 impl crate::Writable for ACINTEN {}
 #[doc = "Analog Comparator Interrupt Enable"]
 pub mod acinten;
-#[doc = "Analog Comparator Reference Voltage Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acrefctl](acrefctl) module"]
+#[doc = "Analog Comparator Reference Voltage Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acrefctl](acrefctl) module"]
 pub type ACREFCTL = crate::Reg<u32, _ACREFCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -71,7 +71,7 @@ impl crate::Readable for ACREFCTL {}
 impl crate::Writable for ACREFCTL {}
 #[doc = "Analog Comparator Reference Voltage Control"]
 pub mod acrefctl;
-#[doc = "Analog Comparator Status 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acstat0](acstat0) module"]
+#[doc = "Analog Comparator Status 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acstat0](acstat0) module"]
 pub type ACSTAT0 = crate::Reg<u32, _ACSTAT0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -80,7 +80,7 @@ pub struct _ACSTAT0;
 impl crate::Readable for ACSTAT0 {}
 #[doc = "Analog Comparator Status 0"]
 pub mod acstat0;
-#[doc = "Analog Comparator Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acctl0](acctl0) module"]
+#[doc = "Analog Comparator Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acctl0](acctl0) module"]
 pub type ACCTL0 = crate::Reg<u32, _ACCTL0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -91,7 +91,7 @@ impl crate::Readable for ACCTL0 {}
 impl crate::Writable for ACCTL0 {}
 #[doc = "Analog Comparator Control 0"]
 pub mod acctl0;
-#[doc = "Analog Comparator Status 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acstat1](acstat1) module"]
+#[doc = "Analog Comparator Status 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acstat1](acstat1) module"]
 pub type ACSTAT1 = crate::Reg<u32, _ACSTAT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -100,7 +100,7 @@ pub struct _ACSTAT1;
 impl crate::Readable for ACSTAT1 {}
 #[doc = "Analog Comparator Status 1"]
 pub mod acstat1;
-#[doc = "Analog Comparator Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acctl1](acctl1) module"]
+#[doc = "Analog Comparator Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acctl1](acctl1) module"]
 pub type ACCTL1 = crate::Reg<u32, _ACCTL1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -111,7 +111,7 @@ impl crate::Readable for ACCTL1 {}
 impl crate::Writable for ACCTL1 {}
 #[doc = "Analog Comparator Control 1"]
 pub mod acctl1;
-#[doc = "Analog Comparator Status 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acstat2](acstat2) module"]
+#[doc = "Analog Comparator Status 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acstat2](acstat2) module"]
 pub type ACSTAT2 = crate::Reg<u32, _ACSTAT2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -120,7 +120,7 @@ pub struct _ACSTAT2;
 impl crate::Readable for ACSTAT2 {}
 #[doc = "Analog Comparator Status 2"]
 pub mod acstat2;
-#[doc = "Analog Comparator Control 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [acctl2](acctl2) module"]
+#[doc = "Analog Comparator Control 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [acctl2](acctl2) module"]
 pub type ACCTL2 = crate::Reg<u32, _ACCTL2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -131,7 +131,7 @@ impl crate::Readable for ACCTL2 {}
 impl crate::Writable for ACCTL2 {}
 #[doc = "Analog Comparator Control 2"]
 pub mod acctl2;
-#[doc = "Analog Comparator Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "Analog Comparator Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/comp/acctl0.rs
+++ b/crates/tm4c129x/src/comp/acctl0.rs
@@ -36,25 +36,21 @@ impl<'a> CINV_W<'a> {
 }
 #[doc = "Interrupt Sense\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ISEN_A {
     #[doc = "0: Level sense, see ISLVAL"]
-    LEVEL,
+    LEVEL = 0,
     #[doc = "1: Falling edge"]
-    FALL,
+    FALL = 1,
     #[doc = "2: Rising edge"]
-    RISE,
+    RISE = 2,
     #[doc = "3: Either edge"]
-    BOTH,
+    BOTH = 3,
 }
 impl From<ISEN_A> for u8 {
     #[inline(always)]
     fn from(variant: ISEN_A) -> Self {
-        match variant {
-            ISEN_A::LEVEL => 0,
-            ISEN_A::FALL => 1,
-            ISEN_A::RISE => 2,
-            ISEN_A::BOTH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ISEN`"]
@@ -157,25 +153,21 @@ impl<'a> ISLVAL_W<'a> {
 }
 #[doc = "Trigger Sense\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TSEN_A {
     #[doc = "0: Level sense, see TSLVAL"]
-    LEVEL,
+    LEVEL = 0,
     #[doc = "1: Falling edge"]
-    FALL,
+    FALL = 1,
     #[doc = "2: Rising edge"]
-    RISE,
+    RISE = 2,
     #[doc = "3: Either edge"]
-    BOTH,
+    BOTH = 3,
 }
 impl From<TSEN_A> for u8 {
     #[inline(always)]
     fn from(variant: TSEN_A) -> Self {
-        match variant {
-            TSEN_A::LEVEL => 0,
-            TSEN_A::FALL => 1,
-            TSEN_A::RISE => 2,
-            TSEN_A::BOTH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TSEN`"]
@@ -278,22 +270,19 @@ impl<'a> TSLVAL_W<'a> {
 }
 #[doc = "Analog Source Positive\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ASRCP_A {
     #[doc = "0: Pin value of Cn+"]
-    PIN,
+    PIN = 0,
     #[doc = "1: Pin value of C0+"]
-    PIN0,
+    PIN0 = 1,
     #[doc = "2: Internal voltage reference"]
-    REF,
+    REF = 2,
 }
 impl From<ASRCP_A> for u8 {
     #[inline(always)]
     fn from(variant: ASRCP_A) -> Self {
-        match variant {
-            ASRCP_A::PIN => 0,
-            ASRCP_A::PIN0 => 1,
-            ASRCP_A::REF => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ASRCP`"]

--- a/crates/tm4c129x/src/comp/acctl1.rs
+++ b/crates/tm4c129x/src/comp/acctl1.rs
@@ -36,25 +36,21 @@ impl<'a> CINV_W<'a> {
 }
 #[doc = "Interrupt Sense\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ISEN_A {
     #[doc = "0: Level sense, see ISLVAL"]
-    LEVEL,
+    LEVEL = 0,
     #[doc = "1: Falling edge"]
-    FALL,
+    FALL = 1,
     #[doc = "2: Rising edge"]
-    RISE,
+    RISE = 2,
     #[doc = "3: Either edge"]
-    BOTH,
+    BOTH = 3,
 }
 impl From<ISEN_A> for u8 {
     #[inline(always)]
     fn from(variant: ISEN_A) -> Self {
-        match variant {
-            ISEN_A::LEVEL => 0,
-            ISEN_A::FALL => 1,
-            ISEN_A::RISE => 2,
-            ISEN_A::BOTH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ISEN`"]
@@ -157,25 +153,21 @@ impl<'a> ISLVAL_W<'a> {
 }
 #[doc = "Trigger Sense\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TSEN_A {
     #[doc = "0: Level sense, see TSLVAL"]
-    LEVEL,
+    LEVEL = 0,
     #[doc = "1: Falling edge"]
-    FALL,
+    FALL = 1,
     #[doc = "2: Rising edge"]
-    RISE,
+    RISE = 2,
     #[doc = "3: Either edge"]
-    BOTH,
+    BOTH = 3,
 }
 impl From<TSEN_A> for u8 {
     #[inline(always)]
     fn from(variant: TSEN_A) -> Self {
-        match variant {
-            TSEN_A::LEVEL => 0,
-            TSEN_A::FALL => 1,
-            TSEN_A::RISE => 2,
-            TSEN_A::BOTH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TSEN`"]
@@ -278,22 +270,19 @@ impl<'a> TSLVAL_W<'a> {
 }
 #[doc = "Analog Source Positive\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ASRCP_A {
     #[doc = "0: Pin value of Cn+"]
-    PIN,
+    PIN = 0,
     #[doc = "1: Pin value of C0+"]
-    PIN0,
+    PIN0 = 1,
     #[doc = "2: Internal voltage reference"]
-    REF,
+    REF = 2,
 }
 impl From<ASRCP_A> for u8 {
     #[inline(always)]
     fn from(variant: ASRCP_A) -> Self {
-        match variant {
-            ASRCP_A::PIN => 0,
-            ASRCP_A::PIN0 => 1,
-            ASRCP_A::REF => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ASRCP`"]

--- a/crates/tm4c129x/src/comp/acctl2.rs
+++ b/crates/tm4c129x/src/comp/acctl2.rs
@@ -36,25 +36,21 @@ impl<'a> CINV_W<'a> {
 }
 #[doc = "Interrupt Sense\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ISEN_A {
     #[doc = "0: Level sense, see ISLVAL"]
-    LEVEL,
+    LEVEL = 0,
     #[doc = "1: Falling edge"]
-    FALL,
+    FALL = 1,
     #[doc = "2: Rising edge"]
-    RISE,
+    RISE = 2,
     #[doc = "3: Either edge"]
-    BOTH,
+    BOTH = 3,
 }
 impl From<ISEN_A> for u8 {
     #[inline(always)]
     fn from(variant: ISEN_A) -> Self {
-        match variant {
-            ISEN_A::LEVEL => 0,
-            ISEN_A::FALL => 1,
-            ISEN_A::RISE => 2,
-            ISEN_A::BOTH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ISEN`"]
@@ -157,25 +153,21 @@ impl<'a> ISLVAL_W<'a> {
 }
 #[doc = "Trigger Sense\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TSEN_A {
     #[doc = "0: Level sense, see TSLVAL"]
-    LEVEL,
+    LEVEL = 0,
     #[doc = "1: Falling edge"]
-    FALL,
+    FALL = 1,
     #[doc = "2: Rising edge"]
-    RISE,
+    RISE = 2,
     #[doc = "3: Either edge"]
-    BOTH,
+    BOTH = 3,
 }
 impl From<TSEN_A> for u8 {
     #[inline(always)]
     fn from(variant: TSEN_A) -> Self {
-        match variant {
-            TSEN_A::LEVEL => 0,
-            TSEN_A::FALL => 1,
-            TSEN_A::RISE => 2,
-            TSEN_A::BOTH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TSEN`"]
@@ -278,22 +270,19 @@ impl<'a> TSLVAL_W<'a> {
 }
 #[doc = "Analog Source Positive\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ASRCP_A {
     #[doc = "0: Pin value of Cn+"]
-    PIN,
+    PIN = 0,
     #[doc = "1: Pin value of C0+"]
-    PIN0,
+    PIN0 = 1,
     #[doc = "2: Internal voltage reference"]
-    REF,
+    REF = 2,
 }
 impl From<ASRCP_A> for u8 {
     #[inline(always)]
     fn from(variant: ASRCP_A) -> Self {
-        match variant {
-            ASRCP_A::PIN => 0,
-            ASRCP_A::PIN0 => 1,
-            ASRCP_A::REF => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ASRCP`"]

--- a/crates/tm4c129x/src/eeprom.rs
+++ b/crates/tm4c129x/src/eeprom.rs
@@ -43,7 +43,7 @@ pub struct RegisterBlock {
     #[doc = "0xfc0 - EEPROM Peripheral Properties"]
     pub pp: PP,
 }
-#[doc = "EEPROM Size Information\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eesize](eesize) module"]
+#[doc = "EEPROM Size Information\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eesize](eesize) module"]
 pub type EESIZE = crate::Reg<u32, _EESIZE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -52,7 +52,7 @@ pub struct _EESIZE;
 impl crate::Readable for EESIZE {}
 #[doc = "EEPROM Size Information"]
 pub mod eesize;
-#[doc = "EEPROM Current Block\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eeblock](eeblock) module"]
+#[doc = "EEPROM Current Block\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eeblock](eeblock) module"]
 pub type EEBLOCK = crate::Reg<u32, _EEBLOCK>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -63,7 +63,7 @@ impl crate::Readable for EEBLOCK {}
 impl crate::Writable for EEBLOCK {}
 #[doc = "EEPROM Current Block"]
 pub mod eeblock;
-#[doc = "EEPROM Current Offset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eeoffset](eeoffset) module"]
+#[doc = "EEPROM Current Offset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eeoffset](eeoffset) module"]
 pub type EEOFFSET = crate::Reg<u32, _EEOFFSET>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -74,7 +74,7 @@ impl crate::Readable for EEOFFSET {}
 impl crate::Writable for EEOFFSET {}
 #[doc = "EEPROM Current Offset"]
 pub mod eeoffset;
-#[doc = "EEPROM Read-Write\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eerdwr](eerdwr) module"]
+#[doc = "EEPROM Read-Write\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eerdwr](eerdwr) module"]
 pub type EERDWR = crate::Reg<u32, _EERDWR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -85,7 +85,7 @@ impl crate::Readable for EERDWR {}
 impl crate::Writable for EERDWR {}
 #[doc = "EEPROM Read-Write"]
 pub mod eerdwr;
-#[doc = "EEPROM Read-Write with Increment\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eerdwrinc](eerdwrinc) module"]
+#[doc = "EEPROM Read-Write with Increment\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eerdwrinc](eerdwrinc) module"]
 pub type EERDWRINC = crate::Reg<u32, _EERDWRINC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -96,7 +96,7 @@ impl crate::Readable for EERDWRINC {}
 impl crate::Writable for EERDWRINC {}
 #[doc = "EEPROM Read-Write with Increment"]
 pub mod eerdwrinc;
-#[doc = "EEPROM Done Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eedone](eedone) module"]
+#[doc = "EEPROM Done Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eedone](eedone) module"]
 pub type EEDONE = crate::Reg<u32, _EEDONE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -105,7 +105,7 @@ pub struct _EEDONE;
 impl crate::Readable for EEDONE {}
 #[doc = "EEPROM Done Status"]
 pub mod eedone;
-#[doc = "EEPROM Support Control and Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eesupp](eesupp) module"]
+#[doc = "EEPROM Support Control and Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eesupp](eesupp) module"]
 pub type EESUPP = crate::Reg<u32, _EESUPP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -116,7 +116,7 @@ impl crate::Readable for EESUPP {}
 impl crate::Writable for EESUPP {}
 #[doc = "EEPROM Support Control and Status"]
 pub mod eesupp;
-#[doc = "EEPROM Unlock\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eeunlock](eeunlock) module"]
+#[doc = "EEPROM Unlock\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eeunlock](eeunlock) module"]
 pub type EEUNLOCK = crate::Reg<u32, _EEUNLOCK>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -127,7 +127,7 @@ impl crate::Readable for EEUNLOCK {}
 impl crate::Writable for EEUNLOCK {}
 #[doc = "EEPROM Unlock"]
 pub mod eeunlock;
-#[doc = "EEPROM Protection\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eeprot](eeprot) module"]
+#[doc = "EEPROM Protection\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eeprot](eeprot) module"]
 pub type EEPROT = crate::Reg<u32, _EEPROT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -138,7 +138,7 @@ impl crate::Readable for EEPROT {}
 impl crate::Writable for EEPROT {}
 #[doc = "EEPROM Protection"]
 pub mod eeprot;
-#[doc = "EEPROM Password\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eepass0](eepass0) module"]
+#[doc = "EEPROM Password\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eepass0](eepass0) module"]
 pub type EEPASS0 = crate::Reg<u32, _EEPASS0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -149,7 +149,7 @@ impl crate::Readable for EEPASS0 {}
 impl crate::Writable for EEPASS0 {}
 #[doc = "EEPROM Password"]
 pub mod eepass0;
-#[doc = "EEPROM Password\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eepass1](eepass1) module"]
+#[doc = "EEPROM Password\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eepass1](eepass1) module"]
 pub type EEPASS1 = crate::Reg<u32, _EEPASS1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -160,7 +160,7 @@ impl crate::Readable for EEPASS1 {}
 impl crate::Writable for EEPASS1 {}
 #[doc = "EEPROM Password"]
 pub mod eepass1;
-#[doc = "EEPROM Password\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eepass2](eepass2) module"]
+#[doc = "EEPROM Password\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eepass2](eepass2) module"]
 pub type EEPASS2 = crate::Reg<u32, _EEPASS2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -171,7 +171,7 @@ impl crate::Readable for EEPASS2 {}
 impl crate::Writable for EEPASS2 {}
 #[doc = "EEPROM Password"]
 pub mod eepass2;
-#[doc = "EEPROM Interrupt\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eeint](eeint) module"]
+#[doc = "EEPROM Interrupt\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eeint](eeint) module"]
 pub type EEINT = crate::Reg<u32, _EEINT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -182,7 +182,7 @@ impl crate::Readable for EEINT {}
 impl crate::Writable for EEINT {}
 #[doc = "EEPROM Interrupt"]
 pub mod eeint;
-#[doc = "EEPROM Block Hide 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eehide0](eehide0) module"]
+#[doc = "EEPROM Block Hide 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eehide0](eehide0) module"]
 pub type EEHIDE0 = crate::Reg<u32, _EEHIDE0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -193,7 +193,7 @@ impl crate::Readable for EEHIDE0 {}
 impl crate::Writable for EEHIDE0 {}
 #[doc = "EEPROM Block Hide 0"]
 pub mod eehide0;
-#[doc = "EEPROM Block Hide 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eehide1](eehide1) module"]
+#[doc = "EEPROM Block Hide 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eehide1](eehide1) module"]
 pub type EEHIDE1 = crate::Reg<u32, _EEHIDE1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -204,7 +204,7 @@ impl crate::Readable for EEHIDE1 {}
 impl crate::Writable for EEHIDE1 {}
 #[doc = "EEPROM Block Hide 1"]
 pub mod eehide1;
-#[doc = "EEPROM Block Hide 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eehide2](eehide2) module"]
+#[doc = "EEPROM Block Hide 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eehide2](eehide2) module"]
 pub type EEHIDE2 = crate::Reg<u32, _EEHIDE2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -215,7 +215,7 @@ impl crate::Readable for EEHIDE2 {}
 impl crate::Writable for EEHIDE2 {}
 #[doc = "EEPROM Block Hide 2"]
 pub mod eehide2;
-#[doc = "EEPROM Debug Mass Erase\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eedbgme](eedbgme) module"]
+#[doc = "EEPROM Debug Mass Erase\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eedbgme](eedbgme) module"]
 pub type EEDBGME = crate::Reg<u32, _EEDBGME>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -226,7 +226,7 @@ impl crate::Readable for EEDBGME {}
 impl crate::Writable for EEDBGME {}
 #[doc = "EEPROM Debug Mass Erase"]
 pub mod eedbgme;
-#[doc = "EEPROM Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "EEPROM Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/eeprom/eeprot.rs
+++ b/crates/tm4c129x/src/eeprom/eeprot.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::EEPROT {
 }
 #[doc = "Protection Control\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROT_A {
     #[doc = "0: This setting is the default. If there is no password, the block is not protected and is readable and writable"]
-    RWNPW,
+    RWNPW = 0,
     #[doc = "1: If there is a password, the block is readable or writable only when unlocked"]
-    RWPW,
+    RWPW = 1,
     #[doc = "2: If there is no password, the block is readable, not writable"]
-    RONPW,
+    RONPW = 2,
 }
 impl From<PROT_A> for u8 {
     #[inline(always)]
     fn from(variant: PROT_A) -> Self {
-        match variant {
-            PROT_A::RWNPW => 0,
-            PROT_A::RWPW => 1,
-            PROT_A::RONPW => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROT`"]

--- a/crates/tm4c129x/src/eeprom/pp.rs
+++ b/crates/tm4c129x/src/eeprom/pp.rs
@@ -2,43 +2,33 @@
 pub type R = crate::R<u32, super::PP>;
 #[doc = "EEPROM Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u16)]
 pub enum SIZE_A {
     #[doc = "0: 64 bytes of EEPROM"]
-    _64,
+    _64 = 0,
     #[doc = "1: 128 bytes of EEPROM"]
-    _128,
+    _128 = 1,
     #[doc = "3: 256 bytes of EEPROM"]
-    _256,
+    _256 = 3,
     #[doc = "7: 512 bytes of EEPROM"]
-    _512,
+    _512 = 7,
     #[doc = "15: 1 KB of EEPROM"]
-    _1K,
+    _1K = 15,
     #[doc = "31: 2 KB of EEPROM"]
-    _2K,
+    _2K = 31,
     #[doc = "63: 3 KB of EEPROM"]
-    _3K,
+    _3K = 63,
     #[doc = "127: 4 KB of EEPROM"]
-    _4K,
+    _4K = 127,
     #[doc = "255: 5 KB of EEPROM"]
-    _5K,
+    _5K = 255,
     #[doc = "511: 6 KB of EEPROM"]
-    _6K,
+    _6K = 511,
 }
 impl From<SIZE_A> for u16 {
     #[inline(always)]
     fn from(variant: SIZE_A) -> Self {
-        match variant {
-            SIZE_A::_64 => 0,
-            SIZE_A::_128 => 1,
-            SIZE_A::_256 => 3,
-            SIZE_A::_512 => 7,
-            SIZE_A::_1K => 15,
-            SIZE_A::_2K => 31,
-            SIZE_A::_3K => 63,
-            SIZE_A::_4K => 127,
-            SIZE_A::_5K => 255,
-            SIZE_A::_6K => 511,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SIZE`"]

--- a/crates/tm4c129x/src/emac0.rs
+++ b/crates/tm4c129x/src/emac0.rs
@@ -172,7 +172,7 @@ impl crate::Readable for CFG {}
 impl crate::Writable for CFG {}
 #[doc = "Ethernet MAC Configuration"]
 pub mod cfg;
-#[doc = "Ethernet MAC Frame Filter\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [framefltr](framefltr) module"]
+#[doc = "Ethernet MAC Frame Filter\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [framefltr](framefltr) module"]
 pub type FRAMEFLTR = crate::Reg<u32, _FRAMEFLTR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -183,7 +183,7 @@ impl crate::Readable for FRAMEFLTR {}
 impl crate::Writable for FRAMEFLTR {}
 #[doc = "Ethernet MAC Frame Filter"]
 pub mod framefltr;
-#[doc = "Ethernet MAC Hash Table High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hashtblh](hashtblh) module"]
+#[doc = "Ethernet MAC Hash Table High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hashtblh](hashtblh) module"]
 pub type HASHTBLH = crate::Reg<u32, _HASHTBLH>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -194,7 +194,7 @@ impl crate::Readable for HASHTBLH {}
 impl crate::Writable for HASHTBLH {}
 #[doc = "Ethernet MAC Hash Table High"]
 pub mod hashtblh;
-#[doc = "Ethernet MAC Hash Table Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hashtbll](hashtbll) module"]
+#[doc = "Ethernet MAC Hash Table Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hashtbll](hashtbll) module"]
 pub type HASHTBLL = crate::Reg<u32, _HASHTBLL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -205,7 +205,7 @@ impl crate::Readable for HASHTBLL {}
 impl crate::Writable for HASHTBLL {}
 #[doc = "Ethernet MAC Hash Table Low"]
 pub mod hashtbll;
-#[doc = "Ethernet MAC MII Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [miiaddr](miiaddr) module"]
+#[doc = "Ethernet MAC MII Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [miiaddr](miiaddr) module"]
 pub type MIIADDR = crate::Reg<u32, _MIIADDR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -216,7 +216,7 @@ impl crate::Readable for MIIADDR {}
 impl crate::Writable for MIIADDR {}
 #[doc = "Ethernet MAC MII Address"]
 pub mod miiaddr;
-#[doc = "Ethernet MAC MII Data Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [miidata](miidata) module"]
+#[doc = "Ethernet MAC MII Data Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [miidata](miidata) module"]
 pub type MIIDATA = crate::Reg<u32, _MIIDATA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -227,7 +227,7 @@ impl crate::Readable for MIIDATA {}
 impl crate::Writable for MIIDATA {}
 #[doc = "Ethernet MAC MII Data Register"]
 pub mod miidata;
-#[doc = "Ethernet MAC Flow Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [flowctl](flowctl) module"]
+#[doc = "Ethernet MAC Flow Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [flowctl](flowctl) module"]
 pub type FLOWCTL = crate::Reg<u32, _FLOWCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -238,7 +238,7 @@ impl crate::Readable for FLOWCTL {}
 impl crate::Writable for FLOWCTL {}
 #[doc = "Ethernet MAC Flow Control"]
 pub mod flowctl;
-#[doc = "Ethernet MAC VLAN Tag\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [vlantg](vlantg) module"]
+#[doc = "Ethernet MAC VLAN Tag\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [vlantg](vlantg) module"]
 pub type VLANTG = crate::Reg<u32, _VLANTG>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -249,7 +249,7 @@ impl crate::Readable for VLANTG {}
 impl crate::Writable for VLANTG {}
 #[doc = "Ethernet MAC VLAN Tag"]
 pub mod vlantg;
-#[doc = "Ethernet MAC Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+#[doc = "Ethernet MAC Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [status](status) module"]
 pub type STATUS = crate::Reg<u32, _STATUS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -258,7 +258,7 @@ pub struct _STATUS;
 impl crate::Readable for STATUS {}
 #[doc = "Ethernet MAC Status"]
 pub mod status;
-#[doc = "Ethernet MAC Remote Wake-Up Frame Filter\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rwuff](rwuff) module"]
+#[doc = "Ethernet MAC Remote Wake-Up Frame Filter\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rwuff](rwuff) module"]
 pub type RWUFF = crate::Reg<u32, _RWUFF>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -269,7 +269,7 @@ impl crate::Readable for RWUFF {}
 impl crate::Writable for RWUFF {}
 #[doc = "Ethernet MAC Remote Wake-Up Frame Filter"]
 pub mod rwuff;
-#[doc = "Ethernet MAC PMT Control and Status Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pmtctlstat](pmtctlstat) module"]
+#[doc = "Ethernet MAC PMT Control and Status Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pmtctlstat](pmtctlstat) module"]
 pub type PMTCTLSTAT = crate::Reg<u32, _PMTCTLSTAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -280,7 +280,7 @@ impl crate::Readable for PMTCTLSTAT {}
 impl crate::Writable for PMTCTLSTAT {}
 #[doc = "Ethernet MAC PMT Control and Status Register"]
 pub mod pmtctlstat;
-#[doc = "Ethernet MAC Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "Ethernet MAC Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -289,7 +289,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "Ethernet MAC Raw Interrupt Status"]
 pub mod ris;
-#[doc = "Ethernet MAC Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [im](im) module"]
+#[doc = "Ethernet MAC Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [im](im) module"]
 pub type IM = crate::Reg<u32, _IM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -300,7 +300,7 @@ impl crate::Readable for IM {}
 impl crate::Writable for IM {}
 #[doc = "Ethernet MAC Interrupt Mask"]
 pub mod im;
-#[doc = "Ethernet MAC Address 0 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [addr0h](addr0h) module"]
+#[doc = "Ethernet MAC Address 0 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [addr0h](addr0h) module"]
 pub type ADDR0H = crate::Reg<u32, _ADDR0H>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -311,7 +311,7 @@ impl crate::Readable for ADDR0H {}
 impl crate::Writable for ADDR0H {}
 #[doc = "Ethernet MAC Address 0 High"]
 pub mod addr0h;
-#[doc = "Ethernet MAC Address 0 Low Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [addr0l](addr0l) module"]
+#[doc = "Ethernet MAC Address 0 Low Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [addr0l](addr0l) module"]
 pub type ADDR0L = crate::Reg<u32, _ADDR0L>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -322,7 +322,7 @@ impl crate::Readable for ADDR0L {}
 impl crate::Writable for ADDR0L {}
 #[doc = "Ethernet MAC Address 0 Low Register"]
 pub mod addr0l;
-#[doc = "Ethernet MAC Address 1 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [addr1h](addr1h) module"]
+#[doc = "Ethernet MAC Address 1 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [addr1h](addr1h) module"]
 pub type ADDR1H = crate::Reg<u32, _ADDR1H>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -333,7 +333,7 @@ impl crate::Readable for ADDR1H {}
 impl crate::Writable for ADDR1H {}
 #[doc = "Ethernet MAC Address 1 High"]
 pub mod addr1h;
-#[doc = "Ethernet MAC Address 1 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [addr1l](addr1l) module"]
+#[doc = "Ethernet MAC Address 1 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [addr1l](addr1l) module"]
 pub type ADDR1L = crate::Reg<u32, _ADDR1L>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -344,7 +344,7 @@ impl crate::Readable for ADDR1L {}
 impl crate::Writable for ADDR1L {}
 #[doc = "Ethernet MAC Address 1 Low"]
 pub mod addr1l;
-#[doc = "Ethernet MAC Address 2 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [addr2h](addr2h) module"]
+#[doc = "Ethernet MAC Address 2 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [addr2h](addr2h) module"]
 pub type ADDR2H = crate::Reg<u32, _ADDR2H>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -355,7 +355,7 @@ impl crate::Readable for ADDR2H {}
 impl crate::Writable for ADDR2H {}
 #[doc = "Ethernet MAC Address 2 High"]
 pub mod addr2h;
-#[doc = "Ethernet MAC Address 2 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [addr2l](addr2l) module"]
+#[doc = "Ethernet MAC Address 2 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [addr2l](addr2l) module"]
 pub type ADDR2L = crate::Reg<u32, _ADDR2L>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -366,7 +366,7 @@ impl crate::Readable for ADDR2L {}
 impl crate::Writable for ADDR2L {}
 #[doc = "Ethernet MAC Address 2 Low"]
 pub mod addr2l;
-#[doc = "Ethernet MAC Address 3 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [addr3h](addr3h) module"]
+#[doc = "Ethernet MAC Address 3 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [addr3h](addr3h) module"]
 pub type ADDR3H = crate::Reg<u32, _ADDR3H>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -377,7 +377,7 @@ impl crate::Readable for ADDR3H {}
 impl crate::Writable for ADDR3H {}
 #[doc = "Ethernet MAC Address 3 High"]
 pub mod addr3h;
-#[doc = "Ethernet MAC Address 3 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [addr3l](addr3l) module"]
+#[doc = "Ethernet MAC Address 3 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [addr3l](addr3l) module"]
 pub type ADDR3L = crate::Reg<u32, _ADDR3L>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -388,7 +388,7 @@ impl crate::Readable for ADDR3L {}
 impl crate::Writable for ADDR3L {}
 #[doc = "Ethernet MAC Address 3 Low"]
 pub mod addr3l;
-#[doc = "Ethernet MAC Watchdog Timeout\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [wdogto](wdogto) module"]
+#[doc = "Ethernet MAC Watchdog Timeout\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [wdogto](wdogto) module"]
 pub type WDOGTO = crate::Reg<u32, _WDOGTO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -399,7 +399,7 @@ impl crate::Readable for WDOGTO {}
 impl crate::Writable for WDOGTO {}
 #[doc = "Ethernet MAC Watchdog Timeout"]
 pub mod wdogto;
-#[doc = "Ethernet MAC MMC Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mmcctrl](mmcctrl) module"]
+#[doc = "Ethernet MAC MMC Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mmcctrl](mmcctrl) module"]
 pub type MMCCTRL = crate::Reg<u32, _MMCCTRL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -410,7 +410,7 @@ impl crate::Readable for MMCCTRL {}
 impl crate::Writable for MMCCTRL {}
 #[doc = "Ethernet MAC MMC Control"]
 pub mod mmcctrl;
-#[doc = "Ethernet MAC MMC Receive Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mmcrxris](mmcrxris) module"]
+#[doc = "Ethernet MAC MMC Receive Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mmcrxris](mmcrxris) module"]
 pub type MMCRXRIS = crate::Reg<u32, _MMCRXRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -419,7 +419,7 @@ pub struct _MMCRXRIS;
 impl crate::Readable for MMCRXRIS {}
 #[doc = "Ethernet MAC MMC Receive Raw Interrupt Status"]
 pub mod mmcrxris;
-#[doc = "Ethernet MAC MMC Transmit Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mmctxris](mmctxris) module"]
+#[doc = "Ethernet MAC MMC Transmit Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mmctxris](mmctxris) module"]
 pub type MMCTXRIS = crate::Reg<u32, _MMCTXRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -428,7 +428,7 @@ pub struct _MMCTXRIS;
 impl crate::Readable for MMCTXRIS {}
 #[doc = "Ethernet MAC MMC Transmit Raw Interrupt Status"]
 pub mod mmctxris;
-#[doc = "Ethernet MAC MMC Receive Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mmcrxim](mmcrxim) module"]
+#[doc = "Ethernet MAC MMC Receive Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mmcrxim](mmcrxim) module"]
 pub type MMCRXIM = crate::Reg<u32, _MMCRXIM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -439,7 +439,7 @@ impl crate::Readable for MMCRXIM {}
 impl crate::Writable for MMCRXIM {}
 #[doc = "Ethernet MAC MMC Receive Interrupt Mask"]
 pub mod mmcrxim;
-#[doc = "Ethernet MAC MMC Transmit Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mmctxim](mmctxim) module"]
+#[doc = "Ethernet MAC MMC Transmit Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mmctxim](mmctxim) module"]
 pub type MMCTXIM = crate::Reg<u32, _MMCTXIM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -450,7 +450,7 @@ impl crate::Readable for MMCTXIM {}
 impl crate::Writable for MMCTXIM {}
 #[doc = "Ethernet MAC MMC Transmit Interrupt Mask"]
 pub mod mmctxim;
-#[doc = "Ethernet MAC Transmit Frame Count for Good and Bad Frames\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcntgb](txcntgb) module"]
+#[doc = "Ethernet MAC Transmit Frame Count for Good and Bad Frames\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcntgb](txcntgb) module"]
 pub type TXCNTGB = crate::Reg<u32, _TXCNTGB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -459,7 +459,7 @@ pub struct _TXCNTGB;
 impl crate::Readable for TXCNTGB {}
 #[doc = "Ethernet MAC Transmit Frame Count for Good and Bad Frames"]
 pub mod txcntgb;
-#[doc = "Ethernet MAC Transmit Frame Count for Frames Transmitted after Single Collision\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcntscol](txcntscol) module"]
+#[doc = "Ethernet MAC Transmit Frame Count for Frames Transmitted after Single Collision\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcntscol](txcntscol) module"]
 pub type TXCNTSCOL = crate::Reg<u32, _TXCNTSCOL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -468,7 +468,7 @@ pub struct _TXCNTSCOL;
 impl crate::Readable for TXCNTSCOL {}
 #[doc = "Ethernet MAC Transmit Frame Count for Frames Transmitted after Single Collision"]
 pub mod txcntscol;
-#[doc = "Ethernet MAC Transmit Frame Count for Frames Transmitted after Multiple Collisions\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcntmcol](txcntmcol) module"]
+#[doc = "Ethernet MAC Transmit Frame Count for Frames Transmitted after Multiple Collisions\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcntmcol](txcntmcol) module"]
 pub type TXCNTMCOL = crate::Reg<u32, _TXCNTMCOL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -477,7 +477,7 @@ pub struct _TXCNTMCOL;
 impl crate::Readable for TXCNTMCOL {}
 #[doc = "Ethernet MAC Transmit Frame Count for Frames Transmitted after Multiple Collisions"]
 pub mod txcntmcol;
-#[doc = "Ethernet MAC Transmit Octet Count Good\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txoctcntg](txoctcntg) module"]
+#[doc = "Ethernet MAC Transmit Octet Count Good\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txoctcntg](txoctcntg) module"]
 pub type TXOCTCNTG = crate::Reg<u32, _TXOCTCNTG>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -486,7 +486,7 @@ pub struct _TXOCTCNTG;
 impl crate::Readable for TXOCTCNTG {}
 #[doc = "Ethernet MAC Transmit Octet Count Good"]
 pub mod txoctcntg;
-#[doc = "Ethernet MAC Receive Frame Count for Good and Bad Frames\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcntgb](rxcntgb) module"]
+#[doc = "Ethernet MAC Receive Frame Count for Good and Bad Frames\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcntgb](rxcntgb) module"]
 pub type RXCNTGB = crate::Reg<u32, _RXCNTGB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -495,7 +495,7 @@ pub struct _RXCNTGB;
 impl crate::Readable for RXCNTGB {}
 #[doc = "Ethernet MAC Receive Frame Count for Good and Bad Frames"]
 pub mod rxcntgb;
-#[doc = "Ethernet MAC Receive Frame Count for CRC Error Frames\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcntcrcerr](rxcntcrcerr) module"]
+#[doc = "Ethernet MAC Receive Frame Count for CRC Error Frames\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcntcrcerr](rxcntcrcerr) module"]
 pub type RXCNTCRCERR = crate::Reg<u32, _RXCNTCRCERR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -504,7 +504,7 @@ pub struct _RXCNTCRCERR;
 impl crate::Readable for RXCNTCRCERR {}
 #[doc = "Ethernet MAC Receive Frame Count for CRC Error Frames"]
 pub mod rxcntcrcerr;
-#[doc = "Ethernet MAC Receive Frame Count for Alignment Error Frames\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcntalgnerr](rxcntalgnerr) module"]
+#[doc = "Ethernet MAC Receive Frame Count for Alignment Error Frames\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcntalgnerr](rxcntalgnerr) module"]
 pub type RXCNTALGNERR = crate::Reg<u32, _RXCNTALGNERR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -513,7 +513,7 @@ pub struct _RXCNTALGNERR;
 impl crate::Readable for RXCNTALGNERR {}
 #[doc = "Ethernet MAC Receive Frame Count for Alignment Error Frames"]
 pub mod rxcntalgnerr;
-#[doc = "Ethernet MAC Receive Frame Count for Good Unicast Frames\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcntguni](rxcntguni) module"]
+#[doc = "Ethernet MAC Receive Frame Count for Good Unicast Frames\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcntguni](rxcntguni) module"]
 pub type RXCNTGUNI = crate::Reg<u32, _RXCNTGUNI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -522,7 +522,7 @@ pub struct _RXCNTGUNI;
 impl crate::Readable for RXCNTGUNI {}
 #[doc = "Ethernet MAC Receive Frame Count for Good Unicast Frames"]
 pub mod rxcntguni;
-#[doc = "Ethernet MAC VLAN Tag Inclusion or Replacement\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [vlnincrep](vlnincrep) module"]
+#[doc = "Ethernet MAC VLAN Tag Inclusion or Replacement\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [vlnincrep](vlnincrep) module"]
 pub type VLNINCREP = crate::Reg<u32, _VLNINCREP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -533,7 +533,7 @@ impl crate::Readable for VLNINCREP {}
 impl crate::Writable for VLNINCREP {}
 #[doc = "Ethernet MAC VLAN Tag Inclusion or Replacement"]
 pub mod vlnincrep;
-#[doc = "Ethernet MAC VLAN Hash Table\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [vlanhash](vlanhash) module"]
+#[doc = "Ethernet MAC VLAN Hash Table\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [vlanhash](vlanhash) module"]
 pub type VLANHASH = crate::Reg<u32, _VLANHASH>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -544,7 +544,7 @@ impl crate::Readable for VLANHASH {}
 impl crate::Writable for VLANHASH {}
 #[doc = "Ethernet MAC VLAN Hash Table"]
 pub mod vlanhash;
-#[doc = "Ethernet MAC Timestamp Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [timstctrl](timstctrl) module"]
+#[doc = "Ethernet MAC Timestamp Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [timstctrl](timstctrl) module"]
 pub type TIMSTCTRL = crate::Reg<u32, _TIMSTCTRL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -555,7 +555,7 @@ impl crate::Readable for TIMSTCTRL {}
 impl crate::Writable for TIMSTCTRL {}
 #[doc = "Ethernet MAC Timestamp Control"]
 pub mod timstctrl;
-#[doc = "Ethernet MAC Sub-Second Increment\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [subsecinc](subsecinc) module"]
+#[doc = "Ethernet MAC Sub-Second Increment\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [subsecinc](subsecinc) module"]
 pub type SUBSECINC = crate::Reg<u32, _SUBSECINC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -566,7 +566,7 @@ impl crate::Readable for SUBSECINC {}
 impl crate::Writable for SUBSECINC {}
 #[doc = "Ethernet MAC Sub-Second Increment"]
 pub mod subsecinc;
-#[doc = "Ethernet MAC System Time - Seconds\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [timsec](timsec) module"]
+#[doc = "Ethernet MAC System Time - Seconds\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [timsec](timsec) module"]
 pub type TIMSEC = crate::Reg<u32, _TIMSEC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -575,7 +575,7 @@ pub struct _TIMSEC;
 impl crate::Readable for TIMSEC {}
 #[doc = "Ethernet MAC System Time - Seconds"]
 pub mod timsec;
-#[doc = "Ethernet MAC System Time - Nanoseconds\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [timnano](timnano) module"]
+#[doc = "Ethernet MAC System Time - Nanoseconds\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [timnano](timnano) module"]
 pub type TIMNANO = crate::Reg<u32, _TIMNANO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -584,7 +584,7 @@ pub struct _TIMNANO;
 impl crate::Readable for TIMNANO {}
 #[doc = "Ethernet MAC System Time - Nanoseconds"]
 pub mod timnano;
-#[doc = "Ethernet MAC System Time - Seconds Update\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [timsecu](timsecu) module"]
+#[doc = "Ethernet MAC System Time - Seconds Update\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [timsecu](timsecu) module"]
 pub type TIMSECU = crate::Reg<u32, _TIMSECU>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -595,7 +595,7 @@ impl crate::Readable for TIMSECU {}
 impl crate::Writable for TIMSECU {}
 #[doc = "Ethernet MAC System Time - Seconds Update"]
 pub mod timsecu;
-#[doc = "Ethernet MAC System Time - Nanoseconds Update\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [timnanou](timnanou) module"]
+#[doc = "Ethernet MAC System Time - Nanoseconds Update\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [timnanou](timnanou) module"]
 pub type TIMNANOU = crate::Reg<u32, _TIMNANOU>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -606,7 +606,7 @@ impl crate::Readable for TIMNANOU {}
 impl crate::Writable for TIMNANOU {}
 #[doc = "Ethernet MAC System Time - Nanoseconds Update"]
 pub mod timnanou;
-#[doc = "Ethernet MAC Timestamp Addend\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [timadd](timadd) module"]
+#[doc = "Ethernet MAC Timestamp Addend\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [timadd](timadd) module"]
 pub type TIMADD = crate::Reg<u32, _TIMADD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -617,7 +617,7 @@ impl crate::Readable for TIMADD {}
 impl crate::Writable for TIMADD {}
 #[doc = "Ethernet MAC Timestamp Addend"]
 pub mod timadd;
-#[doc = "Ethernet MAC Target Time Seconds\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [targsec](targsec) module"]
+#[doc = "Ethernet MAC Target Time Seconds\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [targsec](targsec) module"]
 pub type TARGSEC = crate::Reg<u32, _TARGSEC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -628,7 +628,7 @@ impl crate::Readable for TARGSEC {}
 impl crate::Writable for TARGSEC {}
 #[doc = "Ethernet MAC Target Time Seconds"]
 pub mod targsec;
-#[doc = "Ethernet MAC Target Time Nanoseconds\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [targnano](targnano) module"]
+#[doc = "Ethernet MAC Target Time Nanoseconds\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [targnano](targnano) module"]
 pub type TARGNANO = crate::Reg<u32, _TARGNANO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -639,7 +639,7 @@ impl crate::Readable for TARGNANO {}
 impl crate::Writable for TARGNANO {}
 #[doc = "Ethernet MAC Target Time Nanoseconds"]
 pub mod targnano;
-#[doc = "Ethernet MAC System Time-Higher Word Seconds\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hwordsec](hwordsec) module"]
+#[doc = "Ethernet MAC System Time-Higher Word Seconds\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hwordsec](hwordsec) module"]
 pub type HWORDSEC = crate::Reg<u32, _HWORDSEC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -650,7 +650,7 @@ impl crate::Readable for HWORDSEC {}
 impl crate::Writable for HWORDSEC {}
 #[doc = "Ethernet MAC System Time-Higher Word Seconds"]
 pub mod hwordsec;
-#[doc = "Ethernet MAC Timestamp Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [timstat](timstat) module"]
+#[doc = "Ethernet MAC Timestamp Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [timstat](timstat) module"]
 pub type TIMSTAT = crate::Reg<u32, _TIMSTAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -659,7 +659,7 @@ pub struct _TIMSTAT;
 impl crate::Readable for TIMSTAT {}
 #[doc = "Ethernet MAC Timestamp Status"]
 pub mod timstat;
-#[doc = "Ethernet MAC PPS Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppsctrl](ppsctrl) module"]
+#[doc = "Ethernet MAC PPS Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppsctrl](ppsctrl) module"]
 pub type PPSCTRL = crate::Reg<u32, _PPSCTRL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -670,7 +670,7 @@ impl crate::Readable for PPSCTRL {}
 impl crate::Writable for PPSCTRL {}
 #[doc = "Ethernet MAC PPS Control"]
 pub mod ppsctrl;
-#[doc = "Ethernet MAC PPS0 Interval\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pps0intvl](pps0intvl) module"]
+#[doc = "Ethernet MAC PPS0 Interval\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pps0intvl](pps0intvl) module"]
 pub type PPS0INTVL = crate::Reg<u32, _PPS0INTVL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -681,7 +681,7 @@ impl crate::Readable for PPS0INTVL {}
 impl crate::Writable for PPS0INTVL {}
 #[doc = "Ethernet MAC PPS0 Interval"]
 pub mod pps0intvl;
-#[doc = "Ethernet MAC PPS0 Width\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pps0width](pps0width) module"]
+#[doc = "Ethernet MAC PPS0 Width\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pps0width](pps0width) module"]
 pub type PPS0WIDTH = crate::Reg<u32, _PPS0WIDTH>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -692,7 +692,7 @@ impl crate::Readable for PPS0WIDTH {}
 impl crate::Writable for PPS0WIDTH {}
 #[doc = "Ethernet MAC PPS0 Width"]
 pub mod pps0width;
-#[doc = "Ethernet MAC DMA Bus Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmabusmod](dmabusmod) module"]
+#[doc = "Ethernet MAC DMA Bus Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmabusmod](dmabusmod) module"]
 pub type DMABUSMOD = crate::Reg<u32, _DMABUSMOD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -703,7 +703,7 @@ impl crate::Readable for DMABUSMOD {}
 impl crate::Writable for DMABUSMOD {}
 #[doc = "Ethernet MAC DMA Bus Mode"]
 pub mod dmabusmod;
-#[doc = "Ethernet MAC Transmit Poll Demand\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txpolld](txpolld) module"]
+#[doc = "Ethernet MAC Transmit Poll Demand\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txpolld](txpolld) module"]
 pub type TXPOLLD = crate::Reg<u32, _TXPOLLD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -712,7 +712,7 @@ pub struct _TXPOLLD;
 impl crate::Writable for TXPOLLD {}
 #[doc = "Ethernet MAC Transmit Poll Demand"]
 pub mod txpolld;
-#[doc = "Ethernet MAC Receive Poll Demand\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxpolld](rxpolld) module"]
+#[doc = "Ethernet MAC Receive Poll Demand\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxpolld](rxpolld) module"]
 pub type RXPOLLD = crate::Reg<u32, _RXPOLLD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -721,7 +721,7 @@ pub struct _RXPOLLD;
 impl crate::Writable for RXPOLLD {}
 #[doc = "Ethernet MAC Receive Poll Demand"]
 pub mod rxpolld;
-#[doc = "Ethernet MAC Receive Descriptor List Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxdladdr](rxdladdr) module"]
+#[doc = "Ethernet MAC Receive Descriptor List Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxdladdr](rxdladdr) module"]
 pub type RXDLADDR = crate::Reg<u32, _RXDLADDR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -732,7 +732,7 @@ impl crate::Readable for RXDLADDR {}
 impl crate::Writable for RXDLADDR {}
 #[doc = "Ethernet MAC Receive Descriptor List Address"]
 pub mod rxdladdr;
-#[doc = "Ethernet MAC Transmit Descriptor List Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txdladdr](txdladdr) module"]
+#[doc = "Ethernet MAC Transmit Descriptor List Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txdladdr](txdladdr) module"]
 pub type TXDLADDR = crate::Reg<u32, _TXDLADDR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -743,7 +743,7 @@ impl crate::Readable for TXDLADDR {}
 impl crate::Writable for TXDLADDR {}
 #[doc = "Ethernet MAC Transmit Descriptor List Address"]
 pub mod txdladdr;
-#[doc = "Ethernet MAC DMA Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmaris](dmaris) module"]
+#[doc = "Ethernet MAC DMA Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmaris](dmaris) module"]
 pub type DMARIS = crate::Reg<u32, _DMARIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -754,7 +754,7 @@ impl crate::Readable for DMARIS {}
 impl crate::Writable for DMARIS {}
 #[doc = "Ethernet MAC DMA Interrupt Status"]
 pub mod dmaris;
-#[doc = "Ethernet MAC DMA Operation Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmaopmode](dmaopmode) module"]
+#[doc = "Ethernet MAC DMA Operation Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmaopmode](dmaopmode) module"]
 pub type DMAOPMODE = crate::Reg<u32, _DMAOPMODE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -765,7 +765,7 @@ impl crate::Readable for DMAOPMODE {}
 impl crate::Writable for DMAOPMODE {}
 #[doc = "Ethernet MAC DMA Operation Mode"]
 pub mod dmaopmode;
-#[doc = "Ethernet MAC DMA Interrupt Mask Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmaim](dmaim) module"]
+#[doc = "Ethernet MAC DMA Interrupt Mask Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmaim](dmaim) module"]
 pub type DMAIM = crate::Reg<u32, _DMAIM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -776,7 +776,7 @@ impl crate::Readable for DMAIM {}
 impl crate::Writable for DMAIM {}
 #[doc = "Ethernet MAC DMA Interrupt Mask Register"]
 pub mod dmaim;
-#[doc = "Ethernet MAC Missed Frame and Buffer Overflow Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mfboc](mfboc) module"]
+#[doc = "Ethernet MAC Missed Frame and Buffer Overflow Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mfboc](mfboc) module"]
 pub type MFBOC = crate::Reg<u32, _MFBOC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -785,7 +785,7 @@ pub struct _MFBOC;
 impl crate::Readable for MFBOC {}
 #[doc = "Ethernet MAC Missed Frame and Buffer Overflow Counter"]
 pub mod mfboc;
-#[doc = "Ethernet MAC Receive Interrupt Watchdog Timer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxintwdt](rxintwdt) module"]
+#[doc = "Ethernet MAC Receive Interrupt Watchdog Timer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxintwdt](rxintwdt) module"]
 pub type RXINTWDT = crate::Reg<u32, _RXINTWDT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -796,7 +796,7 @@ impl crate::Readable for RXINTWDT {}
 impl crate::Writable for RXINTWDT {}
 #[doc = "Ethernet MAC Receive Interrupt Watchdog Timer"]
 pub mod rxintwdt;
-#[doc = "Ethernet MAC Current Host Transmit Descriptor\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hostxdesc](hostxdesc) module"]
+#[doc = "Ethernet MAC Current Host Transmit Descriptor\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hostxdesc](hostxdesc) module"]
 pub type HOSTXDESC = crate::Reg<u32, _HOSTXDESC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -805,7 +805,7 @@ pub struct _HOSTXDESC;
 impl crate::Readable for HOSTXDESC {}
 #[doc = "Ethernet MAC Current Host Transmit Descriptor"]
 pub mod hostxdesc;
-#[doc = "Ethernet MAC Current Host Receive Descriptor\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hosrxdesc](hosrxdesc) module"]
+#[doc = "Ethernet MAC Current Host Receive Descriptor\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hosrxdesc](hosrxdesc) module"]
 pub type HOSRXDESC = crate::Reg<u32, _HOSRXDESC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -814,7 +814,7 @@ pub struct _HOSRXDESC;
 impl crate::Readable for HOSRXDESC {}
 #[doc = "Ethernet MAC Current Host Receive Descriptor"]
 pub mod hosrxdesc;
-#[doc = "Ethernet MAC Current Host Transmit Buffer Address\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hostxba](hostxba) module"]
+#[doc = "Ethernet MAC Current Host Transmit Buffer Address\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hostxba](hostxba) module"]
 pub type HOSTXBA = crate::Reg<u32, _HOSTXBA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -823,7 +823,7 @@ pub struct _HOSTXBA;
 impl crate::Readable for HOSTXBA {}
 #[doc = "Ethernet MAC Current Host Transmit Buffer Address"]
 pub mod hostxba;
-#[doc = "Ethernet MAC Current Host Receive Buffer Address\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hosrxba](hosrxba) module"]
+#[doc = "Ethernet MAC Current Host Receive Buffer Address\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hosrxba](hosrxba) module"]
 pub type HOSRXBA = crate::Reg<u32, _HOSRXBA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -832,7 +832,7 @@ pub struct _HOSRXBA;
 impl crate::Readable for HOSRXBA {}
 #[doc = "Ethernet MAC Current Host Receive Buffer Address"]
 pub mod hosrxba;
-#[doc = "Ethernet MAC Peripheral Property Register\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "Ethernet MAC Peripheral Property Register\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -841,7 +841,7 @@ pub struct _PP;
 impl crate::Readable for PP {}
 #[doc = "Ethernet MAC Peripheral Property Register"]
 pub mod pp;
-#[doc = "Ethernet MAC Peripheral Configuration Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pc](pc) module"]
+#[doc = "Ethernet MAC Peripheral Configuration Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pc](pc) module"]
 pub type PC = crate::Reg<u32, _PC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -852,7 +852,7 @@ impl crate::Readable for PC {}
 impl crate::Writable for PC {}
 #[doc = "Ethernet MAC Peripheral Configuration Register"]
 pub mod pc;
-#[doc = "Ethernet MAC Clock Configuration Register\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc](cc) module"]
+#[doc = "Ethernet MAC Clock Configuration Register\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cc](cc) module"]
 pub type CC = crate::Reg<u32, _CC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -861,7 +861,7 @@ pub struct _CC;
 impl crate::Readable for CC {}
 #[doc = "Ethernet MAC Clock Configuration Register"]
 pub mod cc;
-#[doc = "Ethernet PHY Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ephyris](ephyris) module"]
+#[doc = "Ethernet PHY Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ephyris](ephyris) module"]
 pub type EPHYRIS = crate::Reg<u32, _EPHYRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -870,7 +870,7 @@ pub struct _EPHYRIS;
 impl crate::Readable for EPHYRIS {}
 #[doc = "Ethernet PHY Raw Interrupt Status"]
 pub mod ephyris;
-#[doc = "Ethernet PHY Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ephyim](ephyim) module"]
+#[doc = "Ethernet PHY Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ephyim](ephyim) module"]
 pub type EPHYIM = crate::Reg<u32, _EPHYIM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -881,7 +881,7 @@ impl crate::Readable for EPHYIM {}
 impl crate::Writable for EPHYIM {}
 #[doc = "Ethernet PHY Interrupt Mask"]
 pub mod ephyim;
-#[doc = "Ethernet PHY Masked Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ephymisc](ephymisc) module"]
+#[doc = "Ethernet PHY Masked Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ephymisc](ephymisc) module"]
 pub type EPHYMISC = crate::Reg<u32, _EPHYMISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/emac0/cfg.rs
+++ b/crates/tm4c129x/src/emac0/cfg.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::CFG {
 }
 #[doc = "Preamble Length for Transmit Frames\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PRELEN_A {
     #[doc = "0: 7 bytes of preamble"]
-    _7,
+    _7 = 0,
     #[doc = "1: 5 bytes of preamble"]
-    _5,
+    _5 = 1,
     #[doc = "2: 3 bytes of preamble"]
-    _3,
+    _3 = 2,
 }
 impl From<PRELEN_A> for u8 {
     #[inline(always)]
     fn from(variant: PRELEN_A) -> Self {
-        match variant {
-            PRELEN_A::_7 => 0,
-            PRELEN_A::_5 => 1,
-            PRELEN_A::_3 => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PRELEN`"]
@@ -166,25 +163,21 @@ impl<'a> DC_W<'a> {
 }
 #[doc = "Back-Off Limit\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum BL_A {
     #[doc = "0: k = min (n,10)"]
-    _1024,
+    _1024 = 0,
     #[doc = "1: k = min (n,8)"]
-    _256,
+    _256 = 1,
     #[doc = "2: k = min (n,4)"]
-    _8,
+    _8 = 2,
     #[doc = "3: k = min (n,1)"]
-    _2,
+    _2 = 3,
 }
 impl From<BL_A> for u8 {
     #[inline(always)]
     fn from(variant: BL_A) -> Self {
-        match variant {
-            BL_A::_1024 => 0,
-            BL_A::_256 => 1,
-            BL_A::_8 => 2,
-            BL_A::_2 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `BL`"]
@@ -479,37 +472,29 @@ impl<'a> DISCRS_W<'a> {
 }
 #[doc = "Inter-Frame Gap (IFG)\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum IFG_A {
     #[doc = "0: 96 bit times"]
-    _96,
+    _96 = 0,
     #[doc = "1: 88 bit times"]
-    _88,
+    _88 = 1,
     #[doc = "2: 80 bit times"]
-    _80,
+    _80 = 2,
     #[doc = "3: 72 bit times"]
-    _72,
+    _72 = 3,
     #[doc = "4: 64 bit times"]
-    _64,
+    _64 = 4,
     #[doc = "5: 56 bit times"]
-    _56,
+    _56 = 5,
     #[doc = "6: 48 bit times"]
-    _48,
+    _48 = 6,
     #[doc = "7: 40 bit times"]
-    _40,
+    _40 = 7,
 }
 impl From<IFG_A> for u8 {
     #[inline(always)]
     fn from(variant: IFG_A) -> Self {
-        match variant {
-            IFG_A::_96 => 0,
-            IFG_A::_88 => 1,
-            IFG_A::_80 => 2,
-            IFG_A::_72 => 3,
-            IFG_A::_64 => 4,
-            IFG_A::_56 => 5,
-            IFG_A::_48 => 6,
-            IFG_A::_40 => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `IFG`"]

--- a/crates/tm4c129x/src/emac0/dmaopmode.rs
+++ b/crates/tm4c129x/src/emac0/dmaopmode.rs
@@ -60,25 +60,21 @@ impl<'a> OSF_W<'a> {
 }
 #[doc = "Receive Threshold Control\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum RTC_A {
     #[doc = "0: 64 bytes"]
-    _64,
+    _64 = 0,
     #[doc = "1: 32 bytes"]
-    _32,
+    _32 = 1,
     #[doc = "2: 96 bytes"]
-    _96,
+    _96 = 2,
     #[doc = "3: 128 bytes"]
-    _128,
+    _128 = 3,
 }
 impl From<RTC_A> for u8 {
     #[inline(always)]
     fn from(variant: RTC_A) -> Self {
-        match variant {
-            RTC_A::_64 => 0,
-            RTC_A::_32 => 1,
-            RTC_A::_96 => 2,
-            RTC_A::_128 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `RTC`"]
@@ -253,37 +249,29 @@ impl<'a> ST_W<'a> {
 }
 #[doc = "Transmit Threshold Control\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TTC_A {
     #[doc = "0: 64 bytes"]
-    _64,
+    _64 = 0,
     #[doc = "1: 128 bytes"]
-    _128,
+    _128 = 1,
     #[doc = "2: 192 bytes"]
-    _192,
+    _192 = 2,
     #[doc = "3: 256 bytes"]
-    _256,
+    _256 = 3,
     #[doc = "4: 40 bytes"]
-    _40,
+    _40 = 4,
     #[doc = "5: 32 bytes"]
-    _32,
+    _32 = 5,
     #[doc = "6: 24 bytes"]
-    _24,
+    _24 = 6,
     #[doc = "7: 16 bytes"]
-    _16,
+    _16 = 7,
 }
 impl From<TTC_A> for u8 {
     #[inline(always)]
     fn from(variant: TTC_A) -> Self {
-        match variant {
-            TTC_A::_64 => 0,
-            TTC_A::_128 => 1,
-            TTC_A::_192 => 2,
-            TTC_A::_256 => 3,
-            TTC_A::_40 => 4,
-            TTC_A::_32 => 5,
-            TTC_A::_24 => 6,
-            TTC_A::_16 => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TTC`"]

--- a/crates/tm4c129x/src/emac0/dmaris.rs
+++ b/crates/tm4c129x/src/emac0/dmaris.rs
@@ -372,34 +372,27 @@ impl<'a> NIS_W<'a> {
 }
 #[doc = "Received Process State\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum RS_A {
     #[doc = "0: Stopped: Reset or stop receive command issued"]
-    STOP,
+    STOP = 0,
     #[doc = "1: Running: Fetching receive transfer descriptor"]
-    RUNRXTD,
+    RUNRXTD = 1,
     #[doc = "3: Running: Waiting for receive packet"]
-    RUNRXD,
+    RUNRXD = 3,
     #[doc = "4: Suspended: Receive descriptor unavailable"]
-    SUSPEND,
+    SUSPEND = 4,
     #[doc = "5: Running: Closing receive descriptor"]
-    RUNCRD,
+    RUNCRD = 5,
     #[doc = "6: Writing Timestamp"]
-    TSWS,
+    TSWS = 6,
     #[doc = "7: Running: Transferring the receive packet data from receive buffer to host memory"]
-    RUNTXD,
+    RUNTXD = 7,
 }
 impl From<RS_A> for u8 {
     #[inline(always)]
     fn from(variant: RS_A) -> Self {
-        match variant {
-            RS_A::STOP => 0,
-            RS_A::RUNRXTD => 1,
-            RS_A::RUNRXD => 3,
-            RS_A::SUSPEND => 4,
-            RS_A::RUNCRD => 5,
-            RS_A::TSWS => 6,
-            RS_A::RUNTXD => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `RS`"]
@@ -510,34 +503,27 @@ impl<'a> RS_W<'a> {
 }
 #[doc = "Transmit Process State\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TS_A {
     #[doc = "0: Stopped; Reset or Stop transmit command processed"]
-    STOP,
+    STOP = 0,
     #[doc = "1: Running; Fetching transmit transfer descriptor"]
-    RUNTXTD,
+    RUNTXTD = 1,
     #[doc = "2: Running; Waiting for status"]
-    STATUS,
+    STATUS = 2,
     #[doc = "3: Running; Reading data from host memory buffer and queuing it to transmit buffer (TX FIFO)"]
-    RUNTX,
+    RUNTX = 3,
     #[doc = "4: Writing Timestamp"]
-    TSTAMP,
+    TSTAMP = 4,
     #[doc = "6: Suspended; Transmit descriptor unavailable or transmit buffer underflow"]
-    SUSPEND,
+    SUSPEND = 6,
     #[doc = "7: Running; Closing transmit descriptor"]
-    RUNCTD,
+    RUNCTD = 7,
 }
 impl From<TS_A> for u8 {
     #[inline(always)]
     fn from(variant: TS_A) -> Self {
-        match variant {
-            TS_A::STOP => 0,
-            TS_A::RUNTXTD => 1,
-            TS_A::STATUS => 2,
-            TS_A::RUNTX => 3,
-            TS_A::TSTAMP => 4,
-            TS_A::SUSPEND => 6,
-            TS_A::RUNCTD => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TS`"]
@@ -648,31 +634,25 @@ impl<'a> TS_W<'a> {
 }
 #[doc = "Access Error\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum AE_A {
     #[doc = "0: Error during RX DMA Write Data Transfer"]
-    RXDMAWD,
+    RXDMAWD = 0,
     #[doc = "3: Error during TX DMA Read Data Transfer"]
-    TXDMARD,
+    TXDMARD = 3,
     #[doc = "4: Error during RX DMA Descriptor Write Access"]
-    RXDMADW,
+    RXDMADW = 4,
     #[doc = "5: Error during TX DMA Descriptor Write Access"]
-    TXDMADW,
+    TXDMADW = 5,
     #[doc = "6: Error during RX DMA Descriptor Read Access"]
-    RXDMADR,
+    RXDMADR = 6,
     #[doc = "7: Error during TX DMA Descriptor Read Access"]
-    TXDMADR,
+    TXDMADR = 7,
 }
 impl From<AE_A> for u8 {
     #[inline(always)]
     fn from(variant: AE_A) -> Self {
-        match variant {
-            AE_A::RXDMAWD => 0,
-            AE_A::TXDMARD => 3,
-            AE_A::RXDMADW => 4,
-            AE_A::TXDMADW => 5,
-            AE_A::RXDMADR => 6,
-            AE_A::TXDMADR => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `AE`"]

--- a/crates/tm4c129x/src/emac0/framefltr.rs
+++ b/crates/tm4c129x/src/emac0/framefltr.rs
@@ -156,25 +156,21 @@ impl<'a> DBF_W<'a> {
 }
 #[doc = "Pass Control Frames\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PCF_A {
     #[doc = "0: The MAC filters all control frames from reaching application"]
-    ALL,
+    ALL = 0,
     #[doc = "1: MAC forwards all control frames except PAUSE control frames to application even if they fail the address filter"]
-    PAUSE,
+    PAUSE = 1,
     #[doc = "2: MAC forwards all control frames to application even if they fail the address Filter"]
-    NONE,
+    NONE = 2,
     #[doc = "3: MAC forwards control frames that pass the address Filter"]
-    ADDR,
+    ADDR = 3,
 }
 impl From<PCF_A> for u8 {
     #[inline(always)]
     fn from(variant: PCF_A) -> Self {
-        match variant {
-            PCF_A::ALL => 0,
-            PCF_A::PAUSE => 1,
-            PCF_A::NONE => 2,
-            PCF_A::ADDR => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PCF`"]

--- a/crates/tm4c129x/src/emac0/miiaddr.rs
+++ b/crates/tm4c129x/src/emac0/miiaddr.rs
@@ -60,25 +60,21 @@ impl<'a> MIIW_W<'a> {
 }
 #[doc = "Clock Reference Frequency Selection\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CR_A {
     #[doc = "0: The frequency of the System Clock is 60 to 100 MHz providing a MDIO clock of SYSCLK/42"]
-    _60_100,
+    _60_100 = 0,
     #[doc = "1: The frequency of the System Clock is 100 to 150 MHz providing a MDIO clock of SYSCLK/62"]
-    _100_150,
+    _100_150 = 1,
     #[doc = "2: The frequency of the System Clock is 20-35 MHz providing a MDIO clock of System Clock/16"]
-    _20_35,
+    _20_35 = 2,
     #[doc = "3: The frequency of the System Clock is 35 to 60 MHz providing a MDIO clock of System Clock/26"]
-    _35_60,
+    _35_60 = 3,
 }
 impl From<CR_A> for u8 {
     #[inline(always)]
     fn from(variant: CR_A) -> Self {
-        match variant {
-            CR_A::_60_100 => 0,
-            CR_A::_100_150 => 1,
-            CR_A::_20_35 => 2,
-            CR_A::_35_60 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CR`"]

--- a/crates/tm4c129x/src/emac0/pc.rs
+++ b/crates/tm4c129x/src/emac0/pc.rs
@@ -36,25 +36,21 @@ impl<'a> PHYHOLD_W<'a> {
 }
 #[doc = "Auto Negotiation Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ANMODE_A {
     #[doc = "0: When ANEN = 0x0, the mode is 10Base-T, Half-Duplex"]
-    _10HD,
+    _10HD = 0,
     #[doc = "1: When ANEN = 0x0, the mode is 10Base-T, Full-Duplex"]
-    _10FD,
+    _10FD = 1,
     #[doc = "2: When ANEN = 0x0, the mode is 100Base-TX, Half-Duplex"]
-    _100HD,
+    _100HD = 2,
     #[doc = "3: When ANEN = 0x0, the mode is 100Base-TX, Full-Duplex"]
-    _100FD,
+    _100FD = 3,
 }
 impl From<ANMODE_A> for u8 {
     #[inline(always)]
     fn from(variant: ANMODE_A) -> Self {
-        match variant {
-            ANMODE_A::_10HD => 0,
-            ANMODE_A::_10FD => 1,
-            ANMODE_A::_100HD => 2,
-            ANMODE_A::_100FD => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ANMODE`"]
@@ -545,19 +541,17 @@ impl<'a> DIGRESTART_W<'a> {
 }
 #[doc = "Ethernet Interface Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PINTFS_A {
     #[doc = "0: MII (default) Used for internal PHY or external PHY connected via MII"]
-    IMII,
+    IMII = 0,
     #[doc = "4: RMII: Used for external PHY connected via RMII"]
-    RMII,
+    RMII = 4,
 }
 impl From<PINTFS_A> for u8 {
     #[inline(always)]
     fn from(variant: PINTFS_A) -> Self {
-        match variant {
-            PINTFS_A::IMII => 0,
-            PINTFS_A::RMII => 4,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PINTFS`"]

--- a/crates/tm4c129x/src/emac0/pp.rs
+++ b/crates/tm4c129x/src/emac0/pp.rs
@@ -2,19 +2,17 @@
 pub type R = crate::R<u32, super::PP>;
 #[doc = "Ethernet PHY Type\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PHYTYPE_A {
     #[doc = "0: No PHY"]
-    NONE,
+    NONE = 0,
     #[doc = "3: Snowflake class PHY"]
-    _1,
+    _1 = 3,
 }
 impl From<PHYTYPE_A> for u8 {
     #[inline(always)]
     fn from(variant: PHYTYPE_A) -> Self {
-        match variant {
-            PHYTYPE_A::NONE => 0,
-            PHYTYPE_A::_1 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PHYTYPE`"]

--- a/crates/tm4c129x/src/emac0/ppsctrl.rs
+++ b/crates/tm4c129x/src/emac0/ppsctrl.rs
@@ -50,22 +50,19 @@ impl<'a> PPSEN0_W<'a> {
 }
 #[doc = "Target Time Register Mode for PPS0 Output\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TRGMODS0_A {
     #[doc = "0: Indicates that the Target Time registers are programmed only for generating the interrupt event"]
-    INTONLY,
+    INTONLY = 0,
     #[doc = "2: Indicates that the Target Time registers are programmed for generating the interrupt event and starting or stopping the generation of the EN0PPS output signal"]
-    INTPPS0,
+    INTPPS0 = 2,
     #[doc = "3: Indicates that the Target Time registers are programmed only for starting or stopping the generation of the EN0PPS output signal. No interrupt is asserted"]
-    PPS0ONLY,
+    PPS0ONLY = 3,
 }
 impl From<TRGMODS0_A> for u8 {
     #[inline(always)]
     fn from(variant: TRGMODS0_A) -> Self {
-        match variant {
-            TRGMODS0_A::INTONLY => 0,
-            TRGMODS0_A::INTPPS0 => 2,
-            TRGMODS0_A::PPS0ONLY => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TRGMODS0`"]

--- a/crates/tm4c129x/src/emac0/status.rs
+++ b/crates/tm4c129x/src/emac0/status.rs
@@ -8,25 +8,21 @@ pub type RFCFC_R = crate::R<u8, u8>;
 pub type RWC_R = crate::R<bool, bool>;
 #[doc = "TX/RX Controller Read Controller State\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum RRC_A {
     #[doc = "0: IDLE state"]
-    IDLE,
+    IDLE = 0,
     #[doc = "1: Reading frame data"]
-    STATUS,
+    STATUS = 1,
     #[doc = "2: Reading frame status (or timestamp)"]
-    DATA,
+    DATA = 2,
     #[doc = "3: Flushing the frame data and status"]
-    FLUSH,
+    FLUSH = 3,
 }
 impl From<RRC_A> for u8 {
     #[inline(always)]
     fn from(variant: RRC_A) -> Self {
-        match variant {
-            RRC_A::IDLE => 0,
-            RRC_A::STATUS => 1,
-            RRC_A::DATA => 2,
-            RRC_A::FLUSH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `RRC`"]
@@ -66,25 +62,21 @@ impl RRC_R {
 }
 #[doc = "TX/RX Controller RX FIFO Fill-level Status\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum RXF_A {
     #[doc = "0: RX FIFO Empty"]
-    EMPTY,
+    EMPTY = 0,
     #[doc = "1: RX FIFO fill level is below the flow-control deactivate threshold"]
-    BELOW,
+    BELOW = 1,
     #[doc = "2: RX FIFO fill level is above the flow-control activate threshold"]
-    ABOVE,
+    ABOVE = 2,
     #[doc = "3: RX FIFO Full"]
-    FULL,
+    FULL = 3,
 }
 impl From<RXF_A> for u8 {
     #[inline(always)]
     fn from(variant: RXF_A) -> Self {
-        match variant {
-            RXF_A::EMPTY => 0,
-            RXF_A::BELOW => 1,
-            RXF_A::ABOVE => 2,
-            RXF_A::FULL => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `RXF`"]
@@ -126,25 +118,21 @@ impl RXF_R {
 pub type TPE_R = crate::R<bool, bool>;
 #[doc = "MAC Transmit Frame Controller Status\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TFC_A {
     #[doc = "0: IDLE state"]
-    IDLE,
+    IDLE = 0,
     #[doc = "1: Waiting for status of previous frame or IFG or backoff period to be over"]
-    STATUS,
+    STATUS = 1,
     #[doc = "2: Generating and transmitting a PAUSE control frame (in the full-duplex mode)"]
-    PAUSE,
+    PAUSE = 2,
     #[doc = "3: Transferring input frame for transmission"]
-    INPUT,
+    INPUT = 3,
 }
 impl From<TFC_A> for u8 {
     #[inline(always)]
     fn from(variant: TFC_A) -> Self {
-        match variant {
-            TFC_A::IDLE => 0,
-            TFC_A::STATUS => 1,
-            TFC_A::PAUSE => 2,
-            TFC_A::INPUT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TFC`"]
@@ -186,25 +174,21 @@ impl TFC_R {
 pub type TXPAUSED_R = crate::R<bool, bool>;
 #[doc = "TX/RX Controller's TX FIFO Read Controller Status\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TRC_A {
     #[doc = "0: IDLE state"]
-    IDLE,
+    IDLE = 0,
     #[doc = "1: READ state (transferring data to MAC transmitter)"]
-    READ,
+    READ = 1,
     #[doc = "2: Waiting for TX Status from MAC transmitter"]
-    WAIT,
+    WAIT = 2,
     #[doc = "3: Writing the received TX Status or flushing the TX FIFO"]
-    WRFLUSH,
+    WRFLUSH = 3,
 }
 impl From<TRC_A> for u8 {
     #[inline(always)]
     fn from(variant: TRC_A) -> Self {
-        match variant {
-            TRC_A::IDLE => 0,
-            TRC_A::READ => 1,
-            TRC_A::WAIT => 2,
-            TRC_A::WRFLUSH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TRC`"]

--- a/crates/tm4c129x/src/emac0/vlnincrep.rs
+++ b/crates/tm4c129x/src/emac0/vlnincrep.rs
@@ -26,25 +26,21 @@ impl<'a> VLT_W<'a> {
 }
 #[doc = "VLAN Tag Control in Transmit Frames\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum VLC_A {
     #[doc = "0: No VLAN tag deletion, insertion, or replacement"]
-    NONE,
+    NONE = 0,
     #[doc = "1: VLAN tag deletion"]
-    TAGDEL,
+    TAGDEL = 1,
     #[doc = "2: VLAN tag insertion"]
-    TAGINS,
+    TAGINS = 2,
     #[doc = "3: VLAN tag replacement"]
-    TAGREP,
+    TAGREP = 3,
 }
 impl From<VLC_A> for u8 {
     #[inline(always)]
     fn from(variant: VLC_A) -> Self {
-        match variant {
-            VLC_A::NONE => 0,
-            VLC_A::TAGDEL => 1,
-            VLC_A::TAGINS => 2,
-            VLC_A::TAGREP => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `VLC`"]

--- a/crates/tm4c129x/src/epi0.rs
+++ b/crates/tm4c129x/src/epi0.rs
@@ -268,7 +268,7 @@ impl crate::Readable for CFG {}
 impl crate::Writable for CFG {}
 #[doc = "EPI Configuration"]
 pub mod cfg;
-#[doc = "EPI Main Baud Rate\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [baud](baud) module"]
+#[doc = "EPI Main Baud Rate\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [baud](baud) module"]
 pub type BAUD = crate::Reg<u32, _BAUD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -279,7 +279,7 @@ impl crate::Readable for BAUD {}
 impl crate::Writable for BAUD {}
 #[doc = "EPI Main Baud Rate"]
 pub mod baud;
-#[doc = "EPI Main Baud Rate\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [baud2](baud2) module"]
+#[doc = "EPI Main Baud Rate\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [baud2](baud2) module"]
 pub type BAUD2 = crate::Reg<u32, _BAUD2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -290,7 +290,7 @@ impl crate::Readable for BAUD2 {}
 impl crate::Writable for BAUD2 {}
 #[doc = "EPI Main Baud Rate"]
 pub mod baud2;
-#[doc = "EPI Host-Bus 16 Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hb16cfg](hb16cfg) module"]
+#[doc = "EPI Host-Bus 16 Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hb16cfg](hb16cfg) module"]
 pub type HB16CFG = crate::Reg<u32, _HB16CFG>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -301,7 +301,7 @@ impl crate::Readable for HB16CFG {}
 impl crate::Writable for HB16CFG {}
 #[doc = "EPI Host-Bus 16 Configuration"]
 pub mod hb16cfg;
-#[doc = "EPI General-Purpose Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [gpcfg](gpcfg) module"]
+#[doc = "EPI General-Purpose Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [gpcfg](gpcfg) module"]
 pub type GPCFG = crate::Reg<u32, _GPCFG>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -312,7 +312,7 @@ impl crate::Readable for GPCFG {}
 impl crate::Writable for GPCFG {}
 #[doc = "EPI General-Purpose Configuration"]
 pub mod gpcfg;
-#[doc = "EPI SDRAM Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sdramcfg](sdramcfg) module"]
+#[doc = "EPI SDRAM Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sdramcfg](sdramcfg) module"]
 pub type SDRAMCFG = crate::Reg<u32, _SDRAMCFG>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -323,7 +323,7 @@ impl crate::Readable for SDRAMCFG {}
 impl crate::Writable for SDRAMCFG {}
 #[doc = "EPI SDRAM Configuration"]
 pub mod sdramcfg;
-#[doc = "EPI Host-Bus 8 Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hb8cfg](hb8cfg) module"]
+#[doc = "EPI Host-Bus 8 Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hb8cfg](hb8cfg) module"]
 pub type HB8CFG = crate::Reg<u32, _HB8CFG>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -334,7 +334,7 @@ impl crate::Readable for HB8CFG {}
 impl crate::Writable for HB8CFG {}
 #[doc = "EPI Host-Bus 8 Configuration"]
 pub mod hb8cfg;
-#[doc = "EPI Host-Bus 8 Configuration 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hb8cfg2](hb8cfg2) module"]
+#[doc = "EPI Host-Bus 8 Configuration 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hb8cfg2](hb8cfg2) module"]
 pub type HB8CFG2 = crate::Reg<u32, _HB8CFG2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -345,7 +345,7 @@ impl crate::Readable for HB8CFG2 {}
 impl crate::Writable for HB8CFG2 {}
 #[doc = "EPI Host-Bus 8 Configuration 2"]
 pub mod hb8cfg2;
-#[doc = "EPI Host-Bus 16 Configuration 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hb16cfg2](hb16cfg2) module"]
+#[doc = "EPI Host-Bus 16 Configuration 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hb16cfg2](hb16cfg2) module"]
 pub type HB16CFG2 = crate::Reg<u32, _HB16CFG2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -356,7 +356,7 @@ impl crate::Readable for HB16CFG2 {}
 impl crate::Writable for HB16CFG2 {}
 #[doc = "EPI Host-Bus 16 Configuration 2"]
 pub mod hb16cfg2;
-#[doc = "EPI Address Map\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [addrmap](addrmap) module"]
+#[doc = "EPI Address Map\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [addrmap](addrmap) module"]
 pub type ADDRMAP = crate::Reg<u32, _ADDRMAP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -367,7 +367,7 @@ impl crate::Readable for ADDRMAP {}
 impl crate::Writable for ADDRMAP {}
 #[doc = "EPI Address Map"]
 pub mod addrmap;
-#[doc = "EPI Read Size 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rsize0](rsize0) module"]
+#[doc = "EPI Read Size 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rsize0](rsize0) module"]
 pub type RSIZE0 = crate::Reg<u32, _RSIZE0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -378,7 +378,7 @@ impl crate::Readable for RSIZE0 {}
 impl crate::Writable for RSIZE0 {}
 #[doc = "EPI Read Size 0"]
 pub mod rsize0;
-#[doc = "EPI Read Address 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [raddr0](raddr0) module"]
+#[doc = "EPI Read Address 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [raddr0](raddr0) module"]
 pub type RADDR0 = crate::Reg<u32, _RADDR0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -389,7 +389,7 @@ impl crate::Readable for RADDR0 {}
 impl crate::Writable for RADDR0 {}
 #[doc = "EPI Read Address 0"]
 pub mod raddr0;
-#[doc = "EPI Non-Blocking Read Data 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rpstd0](rpstd0) module"]
+#[doc = "EPI Non-Blocking Read Data 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rpstd0](rpstd0) module"]
 pub type RPSTD0 = crate::Reg<u32, _RPSTD0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -400,7 +400,7 @@ impl crate::Readable for RPSTD0 {}
 impl crate::Writable for RPSTD0 {}
 #[doc = "EPI Non-Blocking Read Data 0"]
 pub mod rpstd0;
-#[doc = "EPI Read Size 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rsize1](rsize1) module"]
+#[doc = "EPI Read Size 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rsize1](rsize1) module"]
 pub type RSIZE1 = crate::Reg<u32, _RSIZE1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -411,7 +411,7 @@ impl crate::Readable for RSIZE1 {}
 impl crate::Writable for RSIZE1 {}
 #[doc = "EPI Read Size 1"]
 pub mod rsize1;
-#[doc = "EPI Read Address 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [raddr1](raddr1) module"]
+#[doc = "EPI Read Address 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [raddr1](raddr1) module"]
 pub type RADDR1 = crate::Reg<u32, _RADDR1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -422,7 +422,7 @@ impl crate::Readable for RADDR1 {}
 impl crate::Writable for RADDR1 {}
 #[doc = "EPI Read Address 1"]
 pub mod raddr1;
-#[doc = "EPI Non-Blocking Read Data 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rpstd1](rpstd1) module"]
+#[doc = "EPI Non-Blocking Read Data 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rpstd1](rpstd1) module"]
 pub type RPSTD1 = crate::Reg<u32, _RPSTD1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -433,7 +433,7 @@ impl crate::Readable for RPSTD1 {}
 impl crate::Writable for RPSTD1 {}
 #[doc = "EPI Non-Blocking Read Data 1"]
 pub mod rpstd1;
-#[doc = "EPI Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [stat](stat) module"]
+#[doc = "EPI Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [stat](stat) module"]
 pub type STAT = crate::Reg<u32, _STAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -442,7 +442,7 @@ pub struct _STAT;
 impl crate::Readable for STAT {}
 #[doc = "EPI Status"]
 pub mod stat;
-#[doc = "EPI Read FIFO Count\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rfifocnt](rfifocnt) module"]
+#[doc = "EPI Read FIFO Count\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rfifocnt](rfifocnt) module"]
 pub type RFIFOCNT = crate::Reg<u32, _RFIFOCNT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -451,7 +451,7 @@ pub struct _RFIFOCNT;
 impl crate::Readable for RFIFOCNT {}
 #[doc = "EPI Read FIFO Count"]
 pub mod rfifocnt;
-#[doc = "EPI Read FIFO\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [readfifo0](readfifo0) module"]
+#[doc = "EPI Read FIFO\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [readfifo0](readfifo0) module"]
 pub type READFIFO0 = crate::Reg<u32, _READFIFO0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -460,7 +460,7 @@ pub struct _READFIFO0;
 impl crate::Readable for READFIFO0 {}
 #[doc = "EPI Read FIFO"]
 pub mod readfifo0;
-#[doc = "EPI Read FIFO Alias 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [readfifo1](readfifo1) module"]
+#[doc = "EPI Read FIFO Alias 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [readfifo1](readfifo1) module"]
 pub type READFIFO1 = crate::Reg<u32, _READFIFO1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -469,7 +469,7 @@ pub struct _READFIFO1;
 impl crate::Readable for READFIFO1 {}
 #[doc = "EPI Read FIFO Alias 1"]
 pub mod readfifo1;
-#[doc = "EPI Read FIFO Alias 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [readfifo2](readfifo2) module"]
+#[doc = "EPI Read FIFO Alias 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [readfifo2](readfifo2) module"]
 pub type READFIFO2 = crate::Reg<u32, _READFIFO2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -478,7 +478,7 @@ pub struct _READFIFO2;
 impl crate::Readable for READFIFO2 {}
 #[doc = "EPI Read FIFO Alias 2"]
 pub mod readfifo2;
-#[doc = "EPI Read FIFO Alias 3\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [readfifo3](readfifo3) module"]
+#[doc = "EPI Read FIFO Alias 3\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [readfifo3](readfifo3) module"]
 pub type READFIFO3 = crate::Reg<u32, _READFIFO3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -487,7 +487,7 @@ pub struct _READFIFO3;
 impl crate::Readable for READFIFO3 {}
 #[doc = "EPI Read FIFO Alias 3"]
 pub mod readfifo3;
-#[doc = "EPI Read FIFO Alias 4\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [readfifo4](readfifo4) module"]
+#[doc = "EPI Read FIFO Alias 4\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [readfifo4](readfifo4) module"]
 pub type READFIFO4 = crate::Reg<u32, _READFIFO4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -496,7 +496,7 @@ pub struct _READFIFO4;
 impl crate::Readable for READFIFO4 {}
 #[doc = "EPI Read FIFO Alias 4"]
 pub mod readfifo4;
-#[doc = "EPI Read FIFO Alias 5\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [readfifo5](readfifo5) module"]
+#[doc = "EPI Read FIFO Alias 5\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [readfifo5](readfifo5) module"]
 pub type READFIFO5 = crate::Reg<u32, _READFIFO5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -505,7 +505,7 @@ pub struct _READFIFO5;
 impl crate::Readable for READFIFO5 {}
 #[doc = "EPI Read FIFO Alias 5"]
 pub mod readfifo5;
-#[doc = "EPI Read FIFO Alias 6\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [readfifo6](readfifo6) module"]
+#[doc = "EPI Read FIFO Alias 6\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [readfifo6](readfifo6) module"]
 pub type READFIFO6 = crate::Reg<u32, _READFIFO6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -514,7 +514,7 @@ pub struct _READFIFO6;
 impl crate::Readable for READFIFO6 {}
 #[doc = "EPI Read FIFO Alias 6"]
 pub mod readfifo6;
-#[doc = "EPI Read FIFO Alias 7\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [readfifo7](readfifo7) module"]
+#[doc = "EPI Read FIFO Alias 7\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [readfifo7](readfifo7) module"]
 pub type READFIFO7 = crate::Reg<u32, _READFIFO7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -523,7 +523,7 @@ pub struct _READFIFO7;
 impl crate::Readable for READFIFO7 {}
 #[doc = "EPI Read FIFO Alias 7"]
 pub mod readfifo7;
-#[doc = "EPI FIFO Level Selects\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifolvl](fifolvl) module"]
+#[doc = "EPI FIFO Level Selects\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifolvl](fifolvl) module"]
 pub type FIFOLVL = crate::Reg<u32, _FIFOLVL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -534,7 +534,7 @@ impl crate::Readable for FIFOLVL {}
 impl crate::Writable for FIFOLVL {}
 #[doc = "EPI FIFO Level Selects"]
 pub mod fifolvl;
-#[doc = "EPI Write FIFO Count\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [wfifocnt](wfifocnt) module"]
+#[doc = "EPI Write FIFO Count\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [wfifocnt](wfifocnt) module"]
 pub type WFIFOCNT = crate::Reg<u32, _WFIFOCNT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -543,7 +543,7 @@ pub struct _WFIFOCNT;
 impl crate::Readable for WFIFOCNT {}
 #[doc = "EPI Write FIFO Count"]
 pub mod wfifocnt;
-#[doc = "EPI DMA Transmit Count\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmatxcnt](dmatxcnt) module"]
+#[doc = "EPI DMA Transmit Count\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmatxcnt](dmatxcnt) module"]
 pub type DMATXCNT = crate::Reg<u32, _DMATXCNT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -554,7 +554,7 @@ impl crate::Readable for DMATXCNT {}
 impl crate::Writable for DMATXCNT {}
 #[doc = "EPI DMA Transmit Count"]
 pub mod dmatxcnt;
-#[doc = "EPI Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [im](im) module"]
+#[doc = "EPI Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [im](im) module"]
 pub type IM = crate::Reg<u32, _IM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -565,7 +565,7 @@ impl crate::Readable for IM {}
 impl crate::Writable for IM {}
 #[doc = "EPI Interrupt Mask"]
 pub mod im;
-#[doc = "EPI Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "EPI Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -574,7 +574,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "EPI Raw Interrupt Status"]
 pub mod ris;
-#[doc = "EPI Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mis](mis) module"]
+#[doc = "EPI Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mis](mis) module"]
 pub type MIS = crate::Reg<u32, _MIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -583,7 +583,7 @@ pub struct _MIS;
 impl crate::Readable for MIS {}
 #[doc = "EPI Masked Interrupt Status"]
 pub mod mis;
-#[doc = "EPI Error and Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [eisc](eisc) module"]
+#[doc = "EPI Error and Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [eisc](eisc) module"]
 pub type EISC = crate::Reg<u32, _EISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -594,7 +594,7 @@ impl crate::Readable for EISC {}
 impl crate::Writable for EISC {}
 #[doc = "EPI Error and Interrupt Status and Clear"]
 pub mod eisc;
-#[doc = "EPI Host-Bus 8 Configuration 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hb8cfg3](hb8cfg3) module"]
+#[doc = "EPI Host-Bus 8 Configuration 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hb8cfg3](hb8cfg3) module"]
 pub type HB8CFG3 = crate::Reg<u32, _HB8CFG3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -605,7 +605,7 @@ impl crate::Readable for HB8CFG3 {}
 impl crate::Writable for HB8CFG3 {}
 #[doc = "EPI Host-Bus 8 Configuration 3"]
 pub mod hb8cfg3;
-#[doc = "EPI Host-Bus 16 Configuration 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hb16cfg3](hb16cfg3) module"]
+#[doc = "EPI Host-Bus 16 Configuration 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hb16cfg3](hb16cfg3) module"]
 pub type HB16CFG3 = crate::Reg<u32, _HB16CFG3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -616,7 +616,7 @@ impl crate::Readable for HB16CFG3 {}
 impl crate::Writable for HB16CFG3 {}
 #[doc = "EPI Host-Bus 16 Configuration 3"]
 pub mod hb16cfg3;
-#[doc = "EPI Host-Bus 16 Configuration 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hb16cfg4](hb16cfg4) module"]
+#[doc = "EPI Host-Bus 16 Configuration 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hb16cfg4](hb16cfg4) module"]
 pub type HB16CFG4 = crate::Reg<u32, _HB16CFG4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -627,7 +627,7 @@ impl crate::Readable for HB16CFG4 {}
 impl crate::Writable for HB16CFG4 {}
 #[doc = "EPI Host-Bus 16 Configuration 4"]
 pub mod hb16cfg4;
-#[doc = "EPI Host-Bus 8 Configuration 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hb8cfg4](hb8cfg4) module"]
+#[doc = "EPI Host-Bus 8 Configuration 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hb8cfg4](hb8cfg4) module"]
 pub type HB8CFG4 = crate::Reg<u32, _HB8CFG4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -638,7 +638,7 @@ impl crate::Readable for HB8CFG4 {}
 impl crate::Writable for HB8CFG4 {}
 #[doc = "EPI Host-Bus 8 Configuration 4"]
 pub mod hb8cfg4;
-#[doc = "EPI Host-Bus 8 Timing Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hb8time](hb8time) module"]
+#[doc = "EPI Host-Bus 8 Timing Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hb8time](hb8time) module"]
 pub type HB8TIME = crate::Reg<u32, _HB8TIME>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -649,7 +649,7 @@ impl crate::Readable for HB8TIME {}
 impl crate::Writable for HB8TIME {}
 #[doc = "EPI Host-Bus 8 Timing Extension"]
 pub mod hb8time;
-#[doc = "EPI Host-Bus 16 Timing Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hb16time](hb16time) module"]
+#[doc = "EPI Host-Bus 16 Timing Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hb16time](hb16time) module"]
 pub type HB16TIME = crate::Reg<u32, _HB16TIME>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -660,7 +660,7 @@ impl crate::Readable for HB16TIME {}
 impl crate::Writable for HB16TIME {}
 #[doc = "EPI Host-Bus 16 Timing Extension"]
 pub mod hb16time;
-#[doc = "EPI Host-Bus 8 Timing Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hb8time2](hb8time2) module"]
+#[doc = "EPI Host-Bus 8 Timing Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hb8time2](hb8time2) module"]
 pub type HB8TIME2 = crate::Reg<u32, _HB8TIME2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -671,7 +671,7 @@ impl crate::Readable for HB8TIME2 {}
 impl crate::Writable for HB8TIME2 {}
 #[doc = "EPI Host-Bus 8 Timing Extension"]
 pub mod hb8time2;
-#[doc = "EPI Host-Bus 16 Timing Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hb16time2](hb16time2) module"]
+#[doc = "EPI Host-Bus 16 Timing Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hb16time2](hb16time2) module"]
 pub type HB16TIME2 = crate::Reg<u32, _HB16TIME2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -682,7 +682,7 @@ impl crate::Readable for HB16TIME2 {}
 impl crate::Writable for HB16TIME2 {}
 #[doc = "EPI Host-Bus 16 Timing Extension"]
 pub mod hb16time2;
-#[doc = "EPI Host-Bus 16 Timing Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hb16time3](hb16time3) module"]
+#[doc = "EPI Host-Bus 16 Timing Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hb16time3](hb16time3) module"]
 pub type HB16TIME3 = crate::Reg<u32, _HB16TIME3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -693,7 +693,7 @@ impl crate::Readable for HB16TIME3 {}
 impl crate::Writable for HB16TIME3 {}
 #[doc = "EPI Host-Bus 16 Timing Extension"]
 pub mod hb16time3;
-#[doc = "EPI Host-Bus 8 Timing Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hb8time3](hb8time3) module"]
+#[doc = "EPI Host-Bus 8 Timing Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hb8time3](hb8time3) module"]
 pub type HB8TIME3 = crate::Reg<u32, _HB8TIME3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -704,7 +704,7 @@ impl crate::Readable for HB8TIME3 {}
 impl crate::Writable for HB8TIME3 {}
 #[doc = "EPI Host-Bus 8 Timing Extension"]
 pub mod hb8time3;
-#[doc = "EPI Host-Bus 8 Timing Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hb8time4](hb8time4) module"]
+#[doc = "EPI Host-Bus 8 Timing Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hb8time4](hb8time4) module"]
 pub type HB8TIME4 = crate::Reg<u32, _HB8TIME4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -715,7 +715,7 @@ impl crate::Readable for HB8TIME4 {}
 impl crate::Writable for HB8TIME4 {}
 #[doc = "EPI Host-Bus 8 Timing Extension"]
 pub mod hb8time4;
-#[doc = "EPI Host-Bus 16 Timing Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hb16time4](hb16time4) module"]
+#[doc = "EPI Host-Bus 16 Timing Extension\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hb16time4](hb16time4) module"]
 pub type HB16TIME4 = crate::Reg<u32, _HB16TIME4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -726,7 +726,7 @@ impl crate::Readable for HB16TIME4 {}
 impl crate::Writable for HB16TIME4 {}
 #[doc = "EPI Host-Bus 16 Timing Extension"]
 pub mod hb16time4;
-#[doc = "EPI Host-Bus PSRAM\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hbpsram](hbpsram) module"]
+#[doc = "EPI Host-Bus PSRAM\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hbpsram](hbpsram) module"]
 pub type HBPSRAM = crate::Reg<u32, _HBPSRAM>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/epi0/addrmap.rs
+++ b/crates/tm4c129x/src/epi0/addrmap.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::ADDRMAP {
 }
 #[doc = "External RAM Address\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ERADR_A {
     #[doc = "0: Not mapped"]
-    NONE,
+    NONE = 0,
     #[doc = "1: At 0x6000.0000"]
-    _6000,
+    _6000 = 1,
     #[doc = "2: At 0x8000.0000"]
-    _8000,
+    _8000 = 2,
     #[doc = "3: Only to be used with Host Bus quad chip select. In quad chip select mode, CS0n maps to 0x6000.0000 and CS1n maps to 0x8000.0000"]
-    HBQS,
+    HBQS = 3,
 }
 impl From<ERADR_A> for u8 {
     #[inline(always)]
     fn from(variant: ERADR_A) -> Self {
-        match variant {
-            ERADR_A::NONE => 0,
-            ERADR_A::_6000 => 1,
-            ERADR_A::_8000 => 2,
-            ERADR_A::HBQS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ERADR`"]
@@ -109,25 +105,21 @@ impl<'a> ERADR_W<'a> {
 }
 #[doc = "External RAM Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ERSZ_A {
     #[doc = "0: 256 bytes; lower address range: 0x00 to 0xFF"]
-    _256B,
+    _256B = 0,
     #[doc = "1: 64 KB; lower address range: 0x0000 to 0xFFFF"]
-    _64KB,
+    _64KB = 1,
     #[doc = "2: 16 MB; lower address range: 0x00.0000 to 0xFF.FFFF"]
-    _16MB,
+    _16MB = 2,
     #[doc = "3: 256 MB; lower address range: 0x000.0000 to 0xFFF.FFFF"]
-    _256MB,
+    _256MB = 3,
 }
 impl From<ERSZ_A> for u8 {
     #[inline(always)]
     fn from(variant: ERSZ_A) -> Self {
-        match variant {
-            ERSZ_A::_256B => 0,
-            ERSZ_A::_64KB => 1,
-            ERSZ_A::_16MB => 2,
-            ERSZ_A::_256MB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ERSZ`"]
@@ -206,25 +198,21 @@ impl<'a> ERSZ_W<'a> {
 }
 #[doc = "External Peripheral Address\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum EPADR_A {
     #[doc = "0: Not mapped"]
-    NONE,
+    NONE = 0,
     #[doc = "1: At 0xA000.0000"]
-    A000,
+    A000 = 1,
     #[doc = "2: At 0xC000.0000"]
-    C000,
+    C000 = 2,
     #[doc = "3: Only to be used with Host Bus quad chip select. In quad chip select mode, CS2n maps to 0xA000.0000 and CS3n maps to 0xC000.0000"]
-    HBQS,
+    HBQS = 3,
 }
 impl From<EPADR_A> for u8 {
     #[inline(always)]
     fn from(variant: EPADR_A) -> Self {
-        match variant {
-            EPADR_A::NONE => 0,
-            EPADR_A::A000 => 1,
-            EPADR_A::C000 => 2,
-            EPADR_A::HBQS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `EPADR`"]
@@ -303,25 +291,21 @@ impl<'a> EPADR_W<'a> {
 }
 #[doc = "External Peripheral Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum EPSZ_A {
     #[doc = "0: 256 bytes; lower address range: 0x00 to 0xFF"]
-    _256B,
+    _256B = 0,
     #[doc = "1: 64 KB; lower address range: 0x0000 to 0xFFFF"]
-    _64KB,
+    _64KB = 1,
     #[doc = "2: 16 MB; lower address range: 0x00.0000 to 0xFF.FFFF"]
-    _16MB,
+    _16MB = 2,
     #[doc = "3: 256 MB; lower address range: 0x000.0000 to 0xFFF.FFFF"]
-    _256MB,
+    _256MB = 3,
 }
 impl From<EPSZ_A> for u8 {
     #[inline(always)]
     fn from(variant: EPSZ_A) -> Self {
-        match variant {
-            EPSZ_A::_256B => 0,
-            EPSZ_A::_64KB => 1,
-            EPSZ_A::_16MB => 2,
-            EPSZ_A::_256MB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `EPSZ`"]
@@ -400,19 +384,17 @@ impl<'a> EPSZ_W<'a> {
 }
 #[doc = "External Code Address\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ECADR_A {
     #[doc = "0: Not mapped"]
-    NONE,
+    NONE = 0,
     #[doc = "1: At 0x1000.0000"]
-    _1000,
+    _1000 = 1,
 }
 impl From<ECADR_A> for u8 {
     #[inline(always)]
     fn from(variant: ECADR_A) -> Self {
-        match variant {
-            ECADR_A::NONE => 0,
-            ECADR_A::_1000 => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ECADR`"]
@@ -468,25 +450,21 @@ impl<'a> ECADR_W<'a> {
 }
 #[doc = "External Code Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ECSZ_A {
     #[doc = "0: 256 bytes; lower address range: 0x00 to 0xFF"]
-    _256B,
+    _256B = 0,
     #[doc = "1: 64 KB; lower address range: 0x0000 to 0xFFFF"]
-    _64KB,
+    _64KB = 1,
     #[doc = "2: 16 MB; lower address range: 0x00.0000 to 0xFF.FFFF"]
-    _16MB,
+    _16MB = 2,
     #[doc = "3: 256MB; lower address range: 0x000.0000 to 0x0FFF.FFFF"]
-    _256MB,
+    _256MB = 3,
 }
 impl From<ECSZ_A> for u8 {
     #[inline(always)]
     fn from(variant: ECSZ_A) -> Self {
-        match variant {
-            ECSZ_A::_256B => 0,
-            ECSZ_A::_64KB => 1,
-            ECSZ_A::_16MB => 2,
-            ECSZ_A::_256MB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ECSZ`"]

--- a/crates/tm4c129x/src/epi0/cfg.rs
+++ b/crates/tm4c129x/src/epi0/cfg.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::CFG {
 }
 #[doc = "Mode Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MODE_A {
     #[doc = "0: General Purpose"]
-    NONE,
+    NONE = 0,
     #[doc = "1: SDRAM"]
-    SDRAM,
+    SDRAM = 1,
     #[doc = "2: 8-Bit Host-Bus (HB8)"]
-    HB8,
+    HB8 = 2,
     #[doc = "3: 16-Bit Host-Bus (HB16)"]
-    HB16,
+    HB16 = 3,
 }
 impl From<MODE_A> for u8 {
     #[inline(always)]
     fn from(variant: MODE_A) -> Self {
-        match variant {
-            MODE_A::NONE => 0,
-            MODE_A::SDRAM => 1,
-            MODE_A::HB8 => 2,
-            MODE_A::HB16 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MODE`"]

--- a/crates/tm4c129x/src/epi0/fifolvl.rs
+++ b/crates/tm4c129x/src/epi0/fifolvl.rs
@@ -12,31 +12,25 @@ impl crate::ResetValue for super::FIFOLVL {
 }
 #[doc = "Read FIFO\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum RDFIFO_A {
     #[doc = "1: Trigger when there are 1 or more entries in the NBRFIFO"]
-    _1,
+    _1 = 1,
     #[doc = "2: Trigger when there are 2 or more entries in the NBRFIFO"]
-    _2,
+    _2 = 2,
     #[doc = "3: Trigger when there are 4 or more entries in the NBRFIFO"]
-    _4,
+    _4 = 3,
     #[doc = "4: Trigger when there are 6 or more entries in the NBRFIFO"]
-    _6,
+    _6 = 4,
     #[doc = "5: Trigger when there are 7 or more entries in the NBRFIFO"]
-    _7,
+    _7 = 5,
     #[doc = "6: Trigger when there are 8 entries in the NBRFIFO"]
-    _8,
+    _8 = 6,
 }
 impl From<RDFIFO_A> for u8 {
     #[inline(always)]
     fn from(variant: RDFIFO_A) -> Self {
-        match variant {
-            RDFIFO_A::_1 => 1,
-            RDFIFO_A::_2 => 2,
-            RDFIFO_A::_4 => 3,
-            RDFIFO_A::_6 => 4,
-            RDFIFO_A::_7 => 5,
-            RDFIFO_A::_8 => 6,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `RDFIFO`"]
@@ -136,25 +130,21 @@ impl<'a> RDFIFO_W<'a> {
 }
 #[doc = "Write FIFO\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum WRFIFO_A {
     #[doc = "0: Interrupt is triggered while WRFIFO is empty."]
-    EMPT,
+    EMPT = 0,
     #[doc = "2: Interrupt is triggered until there are only two slots available. Thus, trigger is deasserted when there are two WRFIFO entries present. This configuration is optimized for bursts of 2"]
-    _2,
+    _2 = 2,
     #[doc = "3: Interrupt is triggered until there is one WRFIFO entry available. This configuration expects only single writes"]
-    _1,
+    _1 = 3,
     #[doc = "4: Trigger interrupt when WRFIFO is not full, meaning trigger will continue to assert until there are four entries in the WRFIFO"]
-    NFULL,
+    NFULL = 4,
 }
 impl From<WRFIFO_A> for u8 {
     #[inline(always)]
     fn from(variant: WRFIFO_A) -> Self {
-        match variant {
-            WRFIFO_A::EMPT => 0,
-            WRFIFO_A::_2 => 2,
-            WRFIFO_A::_1 => 3,
-            WRFIFO_A::NFULL => 4,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `WRFIFO`"]

--- a/crates/tm4c129x/src/epi0/gpcfg.rs
+++ b/crates/tm4c129x/src/epi0/gpcfg.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::GPCFG {
 }
 #[doc = "Size of Data Bus\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DSIZE_A {
     #[doc = "0: 8 Bits Wide (EPI0S0 to EPI0S7)"]
-    _4BIT,
+    _4BIT = 0,
     #[doc = "1: 16 Bits Wide (EPI0S0 to EPI0S15)"]
-    _16BIT,
+    _16BIT = 1,
     #[doc = "2: 24 Bits Wide (EPI0S0 to EPI0S23)"]
-    _24BIT,
+    _24BIT = 2,
     #[doc = "3: 32 Bits Wide (EPI0S0 to EPI0S31)"]
-    _32BIT,
+    _32BIT = 3,
 }
 impl From<DSIZE_A> for u8 {
     #[inline(always)]
     fn from(variant: DSIZE_A) -> Self {
-        match variant {
-            DSIZE_A::_4BIT => 0,
-            DSIZE_A::_16BIT => 1,
-            DSIZE_A::_24BIT => 2,
-            DSIZE_A::_32BIT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DSIZE`"]
@@ -109,25 +105,21 @@ impl<'a> DSIZE_W<'a> {
 }
 #[doc = "Address Bus Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ASIZE_A {
     #[doc = "0: No address"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Up to 4 bits wide"]
-    _4BIT,
+    _4BIT = 1,
     #[doc = "2: Up to 12 bits wide. This size cannot be used with 24-bit data"]
-    _12BIT,
+    _12BIT = 2,
     #[doc = "3: Up to 20 bits wide. This size cannot be used with data sizes other than 8"]
-    _20BIT,
+    _20BIT = 3,
 }
 impl From<ASIZE_A> for u8 {
     #[inline(always)]
     fn from(variant: ASIZE_A) -> Self {
-        match variant {
-            ASIZE_A::NONE => 0,
-            ASIZE_A::_4BIT => 1,
-            ASIZE_A::_12BIT => 2,
-            ASIZE_A::_20BIT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ASIZE`"]

--- a/crates/tm4c129x/src/epi0/hb16cfg.rs
+++ b/crates/tm4c129x/src/epi0/hb16cfg.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::HB16CFG {
 }
 #[doc = "Host Bus Sub-Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MODE_A {
     #[doc = "0: ADMUX - AD\\[15:0\\]"]
-    ADMUX,
+    ADMUX = 0,
     #[doc = "1: ADNONMUX - D\\[15:0\\]"]
-    ADNMUX,
+    ADNMUX = 1,
     #[doc = "2: Continuous Read - D\\[15:0\\]"]
-    SRAM,
+    SRAM = 2,
     #[doc = "3: XFIFO - D\\[15:0\\]"]
-    XFIFO,
+    XFIFO = 3,
 }
 impl From<MODE_A> for u8 {
     #[inline(always)]
     fn from(variant: MODE_A) -> Self {
-        match variant {
-            MODE_A::ADMUX => 0,
-            MODE_A::ADNMUX => 1,
-            MODE_A::SRAM => 2,
-            MODE_A::XFIFO => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MODE`"]
@@ -133,25 +129,21 @@ impl<'a> BSEL_W<'a> {
 }
 #[doc = "Read Wait States\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum RDWS_A {
     #[doc = "0: Active RDn is 2 EPI clocks"]
-    _2,
+    _2 = 0,
     #[doc = "1: Active RDn is 4 EPI clocks"]
-    _4,
+    _4 = 1,
     #[doc = "2: Active RDn is 6 EPI clocks"]
-    _6,
+    _6 = 2,
     #[doc = "3: Active RDn is 8 EPI clocks"]
-    _8,
+    _8 = 3,
 }
 impl From<RDWS_A> for u8 {
     #[inline(always)]
     fn from(variant: RDWS_A) -> Self {
-        match variant {
-            RDWS_A::_2 => 0,
-            RDWS_A::_4 => 1,
-            RDWS_A::_6 => 2,
-            RDWS_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `RDWS`"]
@@ -230,25 +222,21 @@ impl<'a> RDWS_W<'a> {
 }
 #[doc = "Write Wait States\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum WRWS_A {
     #[doc = "0: Active WRn is 2 EPI clocks"]
-    _2,
+    _2 = 0,
     #[doc = "1: Active WRn is 4 EPI clocks"]
-    _4,
+    _4 = 1,
     #[doc = "2: Active WRn is 6 EPI clocks"]
-    _6,
+    _6 = 2,
     #[doc = "3: Active WRn is 8 EPI clocks"]
-    _8,
+    _8 = 3,
 }
 impl From<WRWS_A> for u8 {
     #[inline(always)]
     fn from(variant: WRWS_A) -> Self {
-        match variant {
-            WRWS_A::_2 => 0,
-            WRWS_A::_4 => 1,
-            WRWS_A::_6 => 2,
-            WRWS_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `WRWS`"]

--- a/crates/tm4c129x/src/epi0/hb16cfg2.rs
+++ b/crates/tm4c129x/src/epi0/hb16cfg2.rs
@@ -12,19 +12,17 @@ impl crate::ResetValue for super::HB16CFG2 {
 }
 #[doc = "CS1n Host Bus Sub-Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MODE_A {
     #[doc = "0: ADMUX - AD\\[15:0\\]"]
-    ADMUX,
+    ADMUX = 0,
     #[doc = "1: ADNONMUX - D\\[15:0\\]"]
-    AD,
+    AD = 1,
 }
 impl From<MODE_A> for u8 {
     #[inline(always)]
     fn from(variant: MODE_A) -> Self {
-        match variant {
-            MODE_A::ADMUX => 0,
-            MODE_A::AD => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MODE`"]
@@ -80,25 +78,21 @@ impl<'a> MODE_W<'a> {
 }
 #[doc = "CS1n Read Wait States\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum RDWS_A {
     #[doc = "0: Active RDn is 2 EPI clocks"]
-    _2,
+    _2 = 0,
     #[doc = "1: Active RDn is 4 EPI clocks"]
-    _4,
+    _4 = 1,
     #[doc = "2: Active RDn is 6 EPI clocks"]
-    _6,
+    _6 = 2,
     #[doc = "3: Active RDn is 8 EPI clocks"]
-    _8,
+    _8 = 3,
 }
 impl From<RDWS_A> for u8 {
     #[inline(always)]
     fn from(variant: RDWS_A) -> Self {
-        match variant {
-            RDWS_A::_2 => 0,
-            RDWS_A::_4 => 1,
-            RDWS_A::_6 => 2,
-            RDWS_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `RDWS`"]
@@ -177,25 +171,21 @@ impl<'a> RDWS_W<'a> {
 }
 #[doc = "CS1n Write Wait States\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum WRWS_A {
     #[doc = "0: Active WRn is 2 EPI clocks"]
-    _2,
+    _2 = 0,
     #[doc = "1: Active WRn is 4 EPI clocks"]
-    _4,
+    _4 = 1,
     #[doc = "2: Active WRn is 6 EPI clocks"]
-    _6,
+    _6 = 2,
     #[doc = "3: Active WRn is 8 EPI clocks"]
-    _8,
+    _8 = 3,
 }
 impl From<WRWS_A> for u8 {
     #[inline(always)]
     fn from(variant: WRWS_A) -> Self {
-        match variant {
-            WRWS_A::_2 => 0,
-            WRWS_A::_4 => 1,
-            WRWS_A::_6 => 2,
-            WRWS_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `WRWS`"]
@@ -418,25 +408,21 @@ impl<'a> WRHIGH_W<'a> {
 }
 #[doc = "Chip Select Configuration\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CSCFG_A {
     #[doc = "0: ALE Configuration"]
-    ALE,
+    ALE = 0,
     #[doc = "1: CSn Configuration"]
-    CS,
+    CS = 1,
     #[doc = "2: Dual CSn Configuration"]
-    DCS,
+    DCS = 2,
     #[doc = "3: ALE with Dual CSn Configuration"]
-    ADCS,
+    ADCS = 3,
 }
 impl From<CSCFG_A> for u8 {
     #[inline(always)]
     fn from(variant: CSCFG_A) -> Self {
-        match variant {
-            CSCFG_A::ALE => 0,
-            CSCFG_A::CS => 1,
-            CSCFG_A::DCS => 2,
-            CSCFG_A::ADCS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CSCFG`"]

--- a/crates/tm4c129x/src/epi0/hb16cfg3.rs
+++ b/crates/tm4c129x/src/epi0/hb16cfg3.rs
@@ -12,19 +12,17 @@ impl crate::ResetValue for super::HB16CFG3 {
 }
 #[doc = "CS2n Host Bus Sub-Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MODE_A {
     #[doc = "0: ADMUX - AD\\[15:0\\]"]
-    ADMUX,
+    ADMUX = 0,
     #[doc = "1: ADNONMUX - D\\[15:0\\]"]
-    AD,
+    AD = 1,
 }
 impl From<MODE_A> for u8 {
     #[inline(always)]
     fn from(variant: MODE_A) -> Self {
-        match variant {
-            MODE_A::ADMUX => 0,
-            MODE_A::AD => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MODE`"]
@@ -80,25 +78,21 @@ impl<'a> MODE_W<'a> {
 }
 #[doc = "CS2n Read Wait States\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum RDWS_A {
     #[doc = "0: Active RDn is 2 EPI clocks"]
-    _2,
+    _2 = 0,
     #[doc = "1: Active RDn is 4 EPI clocks"]
-    _4,
+    _4 = 1,
     #[doc = "2: Active RDn is 6 EPI clocks"]
-    _6,
+    _6 = 2,
     #[doc = "3: Active RDn is 8 EPI clocks"]
-    _8,
+    _8 = 3,
 }
 impl From<RDWS_A> for u8 {
     #[inline(always)]
     fn from(variant: RDWS_A) -> Self {
-        match variant {
-            RDWS_A::_2 => 0,
-            RDWS_A::_4 => 1,
-            RDWS_A::_6 => 2,
-            RDWS_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `RDWS`"]
@@ -177,25 +171,21 @@ impl<'a> RDWS_W<'a> {
 }
 #[doc = "CS2n Write Wait States\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum WRWS_A {
     #[doc = "0: Active WRn is 2 EPI clocks"]
-    _2,
+    _2 = 0,
     #[doc = "1: Active WRn is 4 EPI clocks"]
-    _4,
+    _4 = 1,
     #[doc = "2: Active WRn is 6 EPI clocks"]
-    _6,
+    _6 = 2,
     #[doc = "3: Active WRn is 8 EPI clocks"]
-    _8,
+    _8 = 3,
 }
 impl From<WRWS_A> for u8 {
     #[inline(always)]
     fn from(variant: WRWS_A) -> Self {
-        match variant {
-            WRWS_A::_2 => 0,
-            WRWS_A::_4 => 1,
-            WRWS_A::_6 => 2,
-            WRWS_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `WRWS`"]

--- a/crates/tm4c129x/src/epi0/hb16cfg4.rs
+++ b/crates/tm4c129x/src/epi0/hb16cfg4.rs
@@ -12,19 +12,17 @@ impl crate::ResetValue for super::HB16CFG4 {
 }
 #[doc = "CS3n Host Bus Sub-Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MODE_A {
     #[doc = "0: ADMUX - AD\\[15:0\\]"]
-    ADMUX,
+    ADMUX = 0,
     #[doc = "1: ADNONMUX - D\\[15:0\\]"]
-    AD,
+    AD = 1,
 }
 impl From<MODE_A> for u8 {
     #[inline(always)]
     fn from(variant: MODE_A) -> Self {
-        match variant {
-            MODE_A::ADMUX => 0,
-            MODE_A::AD => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MODE`"]
@@ -80,25 +78,21 @@ impl<'a> MODE_W<'a> {
 }
 #[doc = "CS3n Read Wait States\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum RDWS_A {
     #[doc = "0: Active RDn is 2 EPI clocks"]
-    _2,
+    _2 = 0,
     #[doc = "1: Active RDn is 4 EPI clocks"]
-    _4,
+    _4 = 1,
     #[doc = "2: Active RDn is 6 EPI clocks"]
-    _6,
+    _6 = 2,
     #[doc = "3: Active RDn is 8 EPI clocks"]
-    _8,
+    _8 = 3,
 }
 impl From<RDWS_A> for u8 {
     #[inline(always)]
     fn from(variant: RDWS_A) -> Self {
-        match variant {
-            RDWS_A::_2 => 0,
-            RDWS_A::_4 => 1,
-            RDWS_A::_6 => 2,
-            RDWS_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `RDWS`"]
@@ -177,25 +171,21 @@ impl<'a> RDWS_W<'a> {
 }
 #[doc = "CS3n Write Wait States\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum WRWS_A {
     #[doc = "0: Active WRn is 2 EPI clocks"]
-    _2,
+    _2 = 0,
     #[doc = "1: Active WRn is 4 EPI clocks"]
-    _4,
+    _4 = 1,
     #[doc = "2: Active WRn is 6 EPI clocks"]
-    _6,
+    _6 = 2,
     #[doc = "3: Active WRn is 8 EPI clocks"]
-    _8,
+    _8 = 3,
 }
 impl From<WRWS_A> for u8 {
     #[inline(always)]
     fn from(variant: WRWS_A) -> Self {
-        match variant {
-            WRWS_A::_2 => 0,
-            WRWS_A::_4 => 1,
-            WRWS_A::_6 => 2,
-            WRWS_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `WRWS`"]

--- a/crates/tm4c129x/src/epi0/hb16time.rs
+++ b/crates/tm4c129x/src/epi0/hb16time.rs
@@ -74,37 +74,29 @@ impl<'a> CAPWIDTH_W<'a> {
 }
 #[doc = "PSRAM Row Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PSRAMSZ_A {
     #[doc = "0: No row size limitation"]
-    _0,
+    _0 = 0,
     #[doc = "1: 128 B"]
-    _128B,
+    _128B = 1,
     #[doc = "2: 256 B"]
-    _256B,
+    _256B = 2,
     #[doc = "3: 512 B"]
-    _512B,
+    _512B = 3,
     #[doc = "4: 1024 B"]
-    _1KB,
+    _1KB = 4,
     #[doc = "5: 2048 B"]
-    _2KB,
+    _2KB = 5,
     #[doc = "6: 4096 B"]
-    _4KB,
+    _4KB = 6,
     #[doc = "7: 8192 B"]
-    _8KB,
+    _8KB = 7,
 }
 impl From<PSRAMSZ_A> for u8 {
     #[inline(always)]
     fn from(variant: PSRAMSZ_A) -> Self {
-        match variant {
-            PSRAMSZ_A::_0 => 0,
-            PSRAMSZ_A::_128B => 1,
-            PSRAMSZ_A::_256B => 2,
-            PSRAMSZ_A::_512B => 3,
-            PSRAMSZ_A::_1KB => 4,
-            PSRAMSZ_A::_2KB => 5,
-            PSRAMSZ_A::_4KB => 6,
-            PSRAMSZ_A::_8KB => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PSRAMSZ`"]

--- a/crates/tm4c129x/src/epi0/hb16time2.rs
+++ b/crates/tm4c129x/src/epi0/hb16time2.rs
@@ -74,37 +74,29 @@ impl<'a> CAPWIDTH_W<'a> {
 }
 #[doc = "PSRAM Row Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PSRAMSZ_A {
     #[doc = "0: No row size limitation"]
-    _0,
+    _0 = 0,
     #[doc = "1: 128 B"]
-    _128B,
+    _128B = 1,
     #[doc = "2: 256 B"]
-    _256B,
+    _256B = 2,
     #[doc = "3: 512 B"]
-    _512B,
+    _512B = 3,
     #[doc = "4: 1024 B"]
-    _1KB,
+    _1KB = 4,
     #[doc = "5: 2048 B"]
-    _2KB,
+    _2KB = 5,
     #[doc = "6: 4096 B"]
-    _4KB,
+    _4KB = 6,
     #[doc = "7: 8192 B"]
-    _8KB,
+    _8KB = 7,
 }
 impl From<PSRAMSZ_A> for u8 {
     #[inline(always)]
     fn from(variant: PSRAMSZ_A) -> Self {
-        match variant {
-            PSRAMSZ_A::_0 => 0,
-            PSRAMSZ_A::_128B => 1,
-            PSRAMSZ_A::_256B => 2,
-            PSRAMSZ_A::_512B => 3,
-            PSRAMSZ_A::_1KB => 4,
-            PSRAMSZ_A::_2KB => 5,
-            PSRAMSZ_A::_4KB => 6,
-            PSRAMSZ_A::_8KB => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PSRAMSZ`"]

--- a/crates/tm4c129x/src/epi0/hb16time3.rs
+++ b/crates/tm4c129x/src/epi0/hb16time3.rs
@@ -74,37 +74,29 @@ impl<'a> CAPWIDTH_W<'a> {
 }
 #[doc = "PSRAM Row Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PSRAMSZ_A {
     #[doc = "0: No row size limitation"]
-    _0,
+    _0 = 0,
     #[doc = "1: 128 B"]
-    _128B,
+    _128B = 1,
     #[doc = "2: 256 B"]
-    _256B,
+    _256B = 2,
     #[doc = "3: 512 B"]
-    _512B,
+    _512B = 3,
     #[doc = "4: 1024 B"]
-    _1KB,
+    _1KB = 4,
     #[doc = "5: 2048 B"]
-    _2KB,
+    _2KB = 5,
     #[doc = "6: 4096 B"]
-    _4KB,
+    _4KB = 6,
     #[doc = "7: 8192 B"]
-    _8KB,
+    _8KB = 7,
 }
 impl From<PSRAMSZ_A> for u8 {
     #[inline(always)]
     fn from(variant: PSRAMSZ_A) -> Self {
-        match variant {
-            PSRAMSZ_A::_0 => 0,
-            PSRAMSZ_A::_128B => 1,
-            PSRAMSZ_A::_256B => 2,
-            PSRAMSZ_A::_512B => 3,
-            PSRAMSZ_A::_1KB => 4,
-            PSRAMSZ_A::_2KB => 5,
-            PSRAMSZ_A::_4KB => 6,
-            PSRAMSZ_A::_8KB => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PSRAMSZ`"]

--- a/crates/tm4c129x/src/epi0/hb16time4.rs
+++ b/crates/tm4c129x/src/epi0/hb16time4.rs
@@ -74,37 +74,29 @@ impl<'a> CAPWIDTH_W<'a> {
 }
 #[doc = "PSRAM Row Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PSRAMSZ_A {
     #[doc = "0: No row size limitation"]
-    _0,
+    _0 = 0,
     #[doc = "1: 128 B"]
-    _128B,
+    _128B = 1,
     #[doc = "2: 256 B"]
-    _256B,
+    _256B = 2,
     #[doc = "3: 512 B"]
-    _512B,
+    _512B = 3,
     #[doc = "4: 1024 B"]
-    _1KB,
+    _1KB = 4,
     #[doc = "5: 2048 B"]
-    _2KB,
+    _2KB = 5,
     #[doc = "6: 4096 B"]
-    _4KB,
+    _4KB = 6,
     #[doc = "7: 8192 B"]
-    _8KB,
+    _8KB = 7,
 }
 impl From<PSRAMSZ_A> for u8 {
     #[inline(always)]
     fn from(variant: PSRAMSZ_A) -> Self {
-        match variant {
-            PSRAMSZ_A::_0 => 0,
-            PSRAMSZ_A::_128B => 1,
-            PSRAMSZ_A::_256B => 2,
-            PSRAMSZ_A::_512B => 3,
-            PSRAMSZ_A::_1KB => 4,
-            PSRAMSZ_A::_2KB => 5,
-            PSRAMSZ_A::_4KB => 6,
-            PSRAMSZ_A::_8KB => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PSRAMSZ`"]

--- a/crates/tm4c129x/src/epi0/hb8cfg.rs
+++ b/crates/tm4c129x/src/epi0/hb8cfg.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::HB8CFG {
 }
 #[doc = "Host Bus Sub-Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MODE_A {
     #[doc = "0: ADMUX - AD\\[7:0\\]"]
-    MUX,
+    MUX = 0,
     #[doc = "1: ADNONMUX - D\\[7:0\\]"]
-    NMUX,
+    NMUX = 1,
     #[doc = "2: Continuous Read - D\\[7:0\\]"]
-    SRAM,
+    SRAM = 2,
     #[doc = "3: XFIFO - D\\[7:0\\]"]
-    FIFO,
+    FIFO = 3,
 }
 impl From<MODE_A> for u8 {
     #[inline(always)]
     fn from(variant: MODE_A) -> Self {
-        match variant {
-            MODE_A::MUX => 0,
-            MODE_A::NMUX => 1,
-            MODE_A::SRAM => 2,
-            MODE_A::FIFO => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MODE`"]
@@ -109,25 +105,21 @@ impl<'a> MODE_W<'a> {
 }
 #[doc = "Read Wait States\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum RDWS_A {
     #[doc = "0: Active RDn is 2 EPI clocks"]
-    _2,
+    _2 = 0,
     #[doc = "1: Active RDn is 4 EPI clocks"]
-    _4,
+    _4 = 1,
     #[doc = "2: Active RDn is 6 EPI clocks"]
-    _6,
+    _6 = 2,
     #[doc = "3: Active RDn is 8 EPI clocks"]
-    _8,
+    _8 = 3,
 }
 impl From<RDWS_A> for u8 {
     #[inline(always)]
     fn from(variant: RDWS_A) -> Self {
-        match variant {
-            RDWS_A::_2 => 0,
-            RDWS_A::_4 => 1,
-            RDWS_A::_6 => 2,
-            RDWS_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `RDWS`"]
@@ -206,25 +198,21 @@ impl<'a> RDWS_W<'a> {
 }
 #[doc = "Write Wait States\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum WRWS_A {
     #[doc = "0: Active WRn is 2 EPI clocks"]
-    _2,
+    _2 = 0,
     #[doc = "1: Active WRn is 4 EPI clocks"]
-    _4,
+    _4 = 1,
     #[doc = "2: Active WRn is 6 EPI clocks"]
-    _6,
+    _6 = 2,
     #[doc = "3: Active WRn is 8 EPI clocks"]
-    _8,
+    _8 = 3,
 }
 impl From<WRWS_A> for u8 {
     #[inline(always)]
     fn from(variant: WRWS_A) -> Self {
-        match variant {
-            WRWS_A::_2 => 0,
-            WRWS_A::_4 => 1,
-            WRWS_A::_6 => 2,
-            WRWS_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `WRWS`"]

--- a/crates/tm4c129x/src/epi0/hb8cfg2.rs
+++ b/crates/tm4c129x/src/epi0/hb8cfg2.rs
@@ -12,19 +12,17 @@ impl crate::ResetValue for super::HB8CFG2 {
 }
 #[doc = "CS1n Host Bus Sub-Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MODE_A {
     #[doc = "0: ADMUX - AD\\[7:0\\]"]
-    ADMUX,
+    ADMUX = 0,
     #[doc = "1: ADNONMUX - D\\[7:0\\]"]
-    AD,
+    AD = 1,
 }
 impl From<MODE_A> for u8 {
     #[inline(always)]
     fn from(variant: MODE_A) -> Self {
-        match variant {
-            MODE_A::ADMUX => 0,
-            MODE_A::AD => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MODE`"]
@@ -80,25 +78,21 @@ impl<'a> MODE_W<'a> {
 }
 #[doc = "CS1n Read Wait States\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum RDWS_A {
     #[doc = "0: Active RDn is 2 EPI clocks"]
-    _2,
+    _2 = 0,
     #[doc = "1: Active RDn is 4 EPI clocks"]
-    _4,
+    _4 = 1,
     #[doc = "2: Active RDn is 6 EPI clocks"]
-    _6,
+    _6 = 2,
     #[doc = "3: Active RDn is 8 EPI clocks"]
-    _8,
+    _8 = 3,
 }
 impl From<RDWS_A> for u8 {
     #[inline(always)]
     fn from(variant: RDWS_A) -> Self {
-        match variant {
-            RDWS_A::_2 => 0,
-            RDWS_A::_4 => 1,
-            RDWS_A::_6 => 2,
-            RDWS_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `RDWS`"]
@@ -177,25 +171,21 @@ impl<'a> RDWS_W<'a> {
 }
 #[doc = "CS1n Write Wait States\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum WRWS_A {
     #[doc = "0: Active WRn is 2 EPI clocks"]
-    _2,
+    _2 = 0,
     #[doc = "1: Active WRn is 4 EPI clocks"]
-    _4,
+    _4 = 1,
     #[doc = "2: Active WRn is 6 EPI clocks"]
-    _6,
+    _6 = 2,
     #[doc = "3: Active WRn is 8 EPI clocks"]
-    _8,
+    _8 = 3,
 }
 impl From<WRWS_A> for u8 {
     #[inline(always)]
     fn from(variant: WRWS_A) -> Self {
-        match variant {
-            WRWS_A::_2 => 0,
-            WRWS_A::_4 => 1,
-            WRWS_A::_6 => 2,
-            WRWS_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `WRWS`"]
@@ -346,25 +336,21 @@ impl<'a> WRHIGH_W<'a> {
 }
 #[doc = "Chip Select Configuration\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CSCFG_A {
     #[doc = "0: ALE Configuration"]
-    ALE,
+    ALE = 0,
     #[doc = "1: CSn Configuration"]
-    CS,
+    CS = 1,
     #[doc = "2: Dual CSn Configuration"]
-    DCS,
+    DCS = 2,
     #[doc = "3: ALE with Dual CSn Configuration"]
-    ADCS,
+    ADCS = 3,
 }
 impl From<CSCFG_A> for u8 {
     #[inline(always)]
     fn from(variant: CSCFG_A) -> Self {
-        match variant {
-            CSCFG_A::ALE => 0,
-            CSCFG_A::CS => 1,
-            CSCFG_A::DCS => 2,
-            CSCFG_A::ADCS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CSCFG`"]

--- a/crates/tm4c129x/src/epi0/hb8cfg3.rs
+++ b/crates/tm4c129x/src/epi0/hb8cfg3.rs
@@ -12,19 +12,17 @@ impl crate::ResetValue for super::HB8CFG3 {
 }
 #[doc = "CS2n Host Bus Sub-Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MODE_A {
     #[doc = "0: ADMUX - AD\\[7:0\\]"]
-    ADMUX,
+    ADMUX = 0,
     #[doc = "1: ADNONMUX - D\\[7:0\\]"]
-    AD,
+    AD = 1,
 }
 impl From<MODE_A> for u8 {
     #[inline(always)]
     fn from(variant: MODE_A) -> Self {
-        match variant {
-            MODE_A::ADMUX => 0,
-            MODE_A::AD => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MODE`"]
@@ -80,25 +78,21 @@ impl<'a> MODE_W<'a> {
 }
 #[doc = "CS2n Read Wait States\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum RDWS_A {
     #[doc = "0: Active RDn is 2 EPI clocks"]
-    _2,
+    _2 = 0,
     #[doc = "1: Active RDn is 4 EPI clocks"]
-    _4,
+    _4 = 1,
     #[doc = "2: Active RDn is 6 EPI clocks"]
-    _6,
+    _6 = 2,
     #[doc = "3: Active RDn is 8 EPI clocks"]
-    _8,
+    _8 = 3,
 }
 impl From<RDWS_A> for u8 {
     #[inline(always)]
     fn from(variant: RDWS_A) -> Self {
-        match variant {
-            RDWS_A::_2 => 0,
-            RDWS_A::_4 => 1,
-            RDWS_A::_6 => 2,
-            RDWS_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `RDWS`"]
@@ -177,25 +171,21 @@ impl<'a> RDWS_W<'a> {
 }
 #[doc = "CS2n Write Wait States\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum WRWS_A {
     #[doc = "0: Active WRn is 2 EPI clocks"]
-    _2,
+    _2 = 0,
     #[doc = "1: Active WRn is 4 EPI clocks"]
-    _4,
+    _4 = 1,
     #[doc = "2: Active WRn is 6 EPI clocks"]
-    _6,
+    _6 = 2,
     #[doc = "3: Active WRn is 8 EPI clocks"]
-    _8,
+    _8 = 3,
 }
 impl From<WRWS_A> for u8 {
     #[inline(always)]
     fn from(variant: WRWS_A) -> Self {
-        match variant {
-            WRWS_A::_2 => 0,
-            WRWS_A::_4 => 1,
-            WRWS_A::_6 => 2,
-            WRWS_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `WRWS`"]

--- a/crates/tm4c129x/src/epi0/hb8cfg4.rs
+++ b/crates/tm4c129x/src/epi0/hb8cfg4.rs
@@ -12,19 +12,17 @@ impl crate::ResetValue for super::HB8CFG4 {
 }
 #[doc = "CS3n Host Bus Sub-Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MODE_A {
     #[doc = "0: ADMUX - AD\\[7:0\\]"]
-    ADMUX,
+    ADMUX = 0,
     #[doc = "1: ADNONMUX - D\\[7:0\\]"]
-    AD,
+    AD = 1,
 }
 impl From<MODE_A> for u8 {
     #[inline(always)]
     fn from(variant: MODE_A) -> Self {
-        match variant {
-            MODE_A::ADMUX => 0,
-            MODE_A::AD => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MODE`"]
@@ -80,25 +78,21 @@ impl<'a> MODE_W<'a> {
 }
 #[doc = "CS3n Read Wait States\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum RDWS_A {
     #[doc = "0: Active RDn is 2 EPI clocks"]
-    _2,
+    _2 = 0,
     #[doc = "1: Active RDn is 4 EPI clocks"]
-    _4,
+    _4 = 1,
     #[doc = "2: Active RDn is 6 EPI clocks"]
-    _6,
+    _6 = 2,
     #[doc = "3: Active RDn is 8 EPI clocks"]
-    _8,
+    _8 = 3,
 }
 impl From<RDWS_A> for u8 {
     #[inline(always)]
     fn from(variant: RDWS_A) -> Self {
-        match variant {
-            RDWS_A::_2 => 0,
-            RDWS_A::_4 => 1,
-            RDWS_A::_6 => 2,
-            RDWS_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `RDWS`"]
@@ -177,25 +171,21 @@ impl<'a> RDWS_W<'a> {
 }
 #[doc = "CS3n Write Wait States\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum WRWS_A {
     #[doc = "0: Active WRn is 2 EPI clocks"]
-    _2,
+    _2 = 0,
     #[doc = "1: Active WRn is 4 EPI clocks"]
-    _4,
+    _4 = 1,
     #[doc = "2: Active WRn is 6 EPI clocks"]
-    _6,
+    _6 = 2,
     #[doc = "3: Active WRn is 8 EPI clocks"]
-    _8,
+    _8 = 3,
 }
 impl From<WRWS_A> for u8 {
     #[inline(always)]
     fn from(variant: WRWS_A) -> Self {
-        match variant {
-            WRWS_A::_2 => 0,
-            WRWS_A::_4 => 1,
-            WRWS_A::_6 => 2,
-            WRWS_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `WRWS`"]

--- a/crates/tm4c129x/src/epi0/rsize0.rs
+++ b/crates/tm4c129x/src/epi0/rsize0.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::RSIZE0 {
 }
 #[doc = "Current Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SIZE_A {
     #[doc = "1: Byte (8 bits)"]
-    _8BIT,
+    _8BIT = 1,
     #[doc = "2: Half-word (16 bits)"]
-    _16BIT,
+    _16BIT = 2,
     #[doc = "3: Word (32 bits)"]
-    _32BIT,
+    _32BIT = 3,
 }
 impl From<SIZE_A> for u8 {
     #[inline(always)]
     fn from(variant: SIZE_A) -> Self {
-        match variant {
-            SIZE_A::_8BIT => 1,
-            SIZE_A::_16BIT => 2,
-            SIZE_A::_32BIT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SIZE`"]

--- a/crates/tm4c129x/src/epi0/rsize1.rs
+++ b/crates/tm4c129x/src/epi0/rsize1.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::RSIZE1 {
 }
 #[doc = "Current Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SIZE_A {
     #[doc = "1: Byte (8 bits)"]
-    _8BIT,
+    _8BIT = 1,
     #[doc = "2: Half-word (16 bits)"]
-    _16BIT,
+    _16BIT = 2,
     #[doc = "3: Word (32 bits)"]
-    _32BIT,
+    _32BIT = 3,
 }
 impl From<SIZE_A> for u8 {
     #[inline(always)]
     fn from(variant: SIZE_A) -> Self {
-        match variant {
-            SIZE_A::_8BIT => 1,
-            SIZE_A::_16BIT => 2,
-            SIZE_A::_32BIT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SIZE`"]

--- a/crates/tm4c129x/src/epi0/sdramcfg.rs
+++ b/crates/tm4c129x/src/epi0/sdramcfg.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::SDRAMCFG {
 }
 #[doc = "Size of SDRAM\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SIZE_A {
     #[doc = "0: 64 megabits (8MB)"]
-    _8MB,
+    _8MB = 0,
     #[doc = "1: 128 megabits (16MB)"]
-    _16MB,
+    _16MB = 1,
     #[doc = "2: 256 megabits (32MB)"]
-    _32MB,
+    _32MB = 2,
     #[doc = "3: 512 megabits (64MB)"]
-    _64MB,
+    _64MB = 3,
 }
 impl From<SIZE_A> for u8 {
     #[inline(always)]
     fn from(variant: SIZE_A) -> Self {
-        match variant {
-            SIZE_A::_8MB => 0,
-            SIZE_A::_16MB => 1,
-            SIZE_A::_32MB => 2,
-            SIZE_A::_64MB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SIZE`"]
@@ -147,22 +143,19 @@ impl<'a> RFSH_W<'a> {
 }
 #[doc = "EPI Frequency Range\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum FREQ_A {
     #[doc = "0: 0 - 15 MHz"]
-    NONE,
+    NONE = 0,
     #[doc = "1: 15 - 30 MHz"]
-    _15MHZ,
+    _15MHZ = 1,
     #[doc = "2: 30 - 50 MHz"]
-    _30MHZ,
+    _30MHZ = 2,
 }
 impl From<FREQ_A> for u8 {
     #[inline(always)]
     fn from(variant: FREQ_A) -> Self {
-        match variant {
-            FREQ_A::NONE => 0,
-            FREQ_A::_15MHZ => 1,
-            FREQ_A::_30MHZ => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `FREQ`"]

--- a/crates/tm4c129x/src/flash_ctrl.rs
+++ b/crates/tm4c129x/src/flash_ctrl.rs
@@ -120,7 +120,7 @@ pub struct RegisterBlock {
     #[doc = "0x143c - Flash Memory Protection Program Enable 15"]
     pub fmppe15: FMPPE15,
 }
-#[doc = "Flash Memory Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fma](fma) module"]
+#[doc = "Flash Memory Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fma](fma) module"]
 pub type FMA = crate::Reg<u32, _FMA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -131,7 +131,7 @@ impl crate::Readable for FMA {}
 impl crate::Writable for FMA {}
 #[doc = "Flash Memory Address"]
 pub mod fma;
-#[doc = "Flash Memory Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmd](fmd) module"]
+#[doc = "Flash Memory Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmd](fmd) module"]
 pub type FMD = crate::Reg<u32, _FMD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -142,7 +142,7 @@ impl crate::Readable for FMD {}
 impl crate::Writable for FMD {}
 #[doc = "Flash Memory Data"]
 pub mod fmd;
-#[doc = "Flash Memory Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmc](fmc) module"]
+#[doc = "Flash Memory Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmc](fmc) module"]
 pub type FMC = crate::Reg<u32, _FMC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -153,7 +153,7 @@ impl crate::Readable for FMC {}
 impl crate::Writable for FMC {}
 #[doc = "Flash Memory Control"]
 pub mod fmc;
-#[doc = "Flash Controller Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fcris](fcris) module"]
+#[doc = "Flash Controller Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fcris](fcris) module"]
 pub type FCRIS = crate::Reg<u32, _FCRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -162,7 +162,7 @@ pub struct _FCRIS;
 impl crate::Readable for FCRIS {}
 #[doc = "Flash Controller Raw Interrupt Status"]
 pub mod fcris;
-#[doc = "Flash Controller Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fcim](fcim) module"]
+#[doc = "Flash Controller Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fcim](fcim) module"]
 pub type FCIM = crate::Reg<u32, _FCIM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -173,7 +173,7 @@ impl crate::Readable for FCIM {}
 impl crate::Writable for FCIM {}
 #[doc = "Flash Controller Interrupt Mask"]
 pub mod fcim;
-#[doc = "Flash Controller Masked Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fcmisc](fcmisc) module"]
+#[doc = "Flash Controller Masked Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fcmisc](fcmisc) module"]
 pub type FCMISC = crate::Reg<u32, _FCMISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -184,7 +184,7 @@ impl crate::Readable for FCMISC {}
 impl crate::Writable for FCMISC {}
 #[doc = "Flash Controller Masked Interrupt Status and Clear"]
 pub mod fcmisc;
-#[doc = "Flash Memory Control 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmc2](fmc2) module"]
+#[doc = "Flash Memory Control 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmc2](fmc2) module"]
 pub type FMC2 = crate::Reg<u32, _FMC2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -195,7 +195,7 @@ impl crate::Readable for FMC2 {}
 impl crate::Writable for FMC2 {}
 #[doc = "Flash Memory Control 2"]
 pub mod fmc2;
-#[doc = "Flash Write Buffer Valid\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fwbval](fwbval) module"]
+#[doc = "Flash Write Buffer Valid\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fwbval](fwbval) module"]
 pub type FWBVAL = crate::Reg<u32, _FWBVAL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -206,7 +206,7 @@ impl crate::Readable for FWBVAL {}
 impl crate::Writable for FWBVAL {}
 #[doc = "Flash Write Buffer Valid"]
 pub mod fwbval;
-#[doc = "Flash Program/Erase Key\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [flpekey](flpekey) module"]
+#[doc = "Flash Program/Erase Key\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [flpekey](flpekey) module"]
 pub type FLPEKEY = crate::Reg<u32, _FLPEKEY>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -217,7 +217,7 @@ impl crate::Readable for FLPEKEY {}
 impl crate::Writable for FLPEKEY {}
 #[doc = "Flash Program/Erase Key"]
 pub mod flpekey;
-#[doc = "Flash Write Buffer n\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fwbn](fwbn) module"]
+#[doc = "Flash Write Buffer n\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fwbn](fwbn) module"]
 pub type FWBN = crate::Reg<u32, _FWBN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -228,7 +228,7 @@ impl crate::Readable for FWBN {}
 impl crate::Writable for FWBN {}
 #[doc = "Flash Write Buffer n"]
 pub mod fwbn;
-#[doc = "Flash Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "Flash Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -237,7 +237,7 @@ pub struct _PP;
 impl crate::Readable for PP {}
 #[doc = "Flash Peripheral Properties"]
 pub mod pp;
-#[doc = "SRAM Size\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ssize](ssize) module"]
+#[doc = "SRAM Size\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ssize](ssize) module"]
 pub type SSIZE = crate::Reg<u32, _SSIZE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -246,7 +246,7 @@ pub struct _SSIZE;
 impl crate::Readable for SSIZE {}
 #[doc = "SRAM Size"]
 pub mod ssize;
-#[doc = "Flash Configuration Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [conf](conf) module"]
+#[doc = "Flash Configuration Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [conf](conf) module"]
 pub type CONF = crate::Reg<u32, _CONF>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -257,7 +257,7 @@ impl crate::Readable for CONF {}
 impl crate::Writable for CONF {}
 #[doc = "Flash Configuration Register"]
 pub mod conf;
-#[doc = "ROM Software Map\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [romswmap](romswmap) module"]
+#[doc = "ROM Software Map\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [romswmap](romswmap) module"]
 pub type ROMSWMAP = crate::Reg<u32, _ROMSWMAP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -266,7 +266,7 @@ pub struct _ROMSWMAP;
 impl crate::Readable for ROMSWMAP {}
 #[doc = "ROM Software Map"]
 pub mod romswmap;
-#[doc = "Flash DMA Address Size\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmasz](dmasz) module"]
+#[doc = "Flash DMA Address Size\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmasz](dmasz) module"]
 pub type DMASZ = crate::Reg<u32, _DMASZ>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -277,7 +277,7 @@ impl crate::Readable for DMASZ {}
 impl crate::Writable for DMASZ {}
 #[doc = "Flash DMA Address Size"]
 pub mod dmasz;
-#[doc = "Flash DMA Starting Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmast](dmast) module"]
+#[doc = "Flash DMA Starting Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmast](dmast) module"]
 pub type DMAST = crate::Reg<u32, _DMAST>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -288,7 +288,7 @@ impl crate::Readable for DMAST {}
 impl crate::Writable for DMAST {}
 #[doc = "Flash DMA Starting Address"]
 pub mod dmast;
-#[doc = "Reset Vector Pointer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rvp](rvp) module"]
+#[doc = "Reset Vector Pointer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rvp](rvp) module"]
 pub type RVP = crate::Reg<u32, _RVP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -299,7 +299,7 @@ impl crate::Readable for RVP {}
 impl crate::Writable for RVP {}
 #[doc = "Reset Vector Pointer"]
 pub mod rvp;
-#[doc = "Boot Configuration\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [bootcfg](bootcfg) module"]
+#[doc = "Boot Configuration\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [bootcfg](bootcfg) module"]
 pub type BOOTCFG = crate::Reg<u32, _BOOTCFG>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -308,7 +308,7 @@ pub struct _BOOTCFG;
 impl crate::Readable for BOOTCFG {}
 #[doc = "Boot Configuration"]
 pub mod bootcfg;
-#[doc = "User Register 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [userreg0](userreg0) module"]
+#[doc = "User Register 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [userreg0](userreg0) module"]
 pub type USERREG0 = crate::Reg<u32, _USERREG0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -319,7 +319,7 @@ impl crate::Readable for USERREG0 {}
 impl crate::Writable for USERREG0 {}
 #[doc = "User Register 0"]
 pub mod userreg0;
-#[doc = "User Register 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [userreg1](userreg1) module"]
+#[doc = "User Register 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [userreg1](userreg1) module"]
 pub type USERREG1 = crate::Reg<u32, _USERREG1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -330,7 +330,7 @@ impl crate::Readable for USERREG1 {}
 impl crate::Writable for USERREG1 {}
 #[doc = "User Register 1"]
 pub mod userreg1;
-#[doc = "User Register 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [userreg2](userreg2) module"]
+#[doc = "User Register 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [userreg2](userreg2) module"]
 pub type USERREG2 = crate::Reg<u32, _USERREG2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -341,7 +341,7 @@ impl crate::Readable for USERREG2 {}
 impl crate::Writable for USERREG2 {}
 #[doc = "User Register 2"]
 pub mod userreg2;
-#[doc = "User Register 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [userreg3](userreg3) module"]
+#[doc = "User Register 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [userreg3](userreg3) module"]
 pub type USERREG3 = crate::Reg<u32, _USERREG3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -352,7 +352,7 @@ impl crate::Readable for USERREG3 {}
 impl crate::Writable for USERREG3 {}
 #[doc = "User Register 3"]
 pub mod userreg3;
-#[doc = "Flash Memory Protection Read Enable 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre0](fmpre0) module"]
+#[doc = "Flash Memory Protection Read Enable 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre0](fmpre0) module"]
 pub type FMPRE0 = crate::Reg<u32, _FMPRE0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -363,7 +363,7 @@ impl crate::Readable for FMPRE0 {}
 impl crate::Writable for FMPRE0 {}
 #[doc = "Flash Memory Protection Read Enable 0"]
 pub mod fmpre0;
-#[doc = "Flash Memory Protection Read Enable 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre1](fmpre1) module"]
+#[doc = "Flash Memory Protection Read Enable 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre1](fmpre1) module"]
 pub type FMPRE1 = crate::Reg<u32, _FMPRE1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -374,7 +374,7 @@ impl crate::Readable for FMPRE1 {}
 impl crate::Writable for FMPRE1 {}
 #[doc = "Flash Memory Protection Read Enable 1"]
 pub mod fmpre1;
-#[doc = "Flash Memory Protection Read Enable 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre2](fmpre2) module"]
+#[doc = "Flash Memory Protection Read Enable 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre2](fmpre2) module"]
 pub type FMPRE2 = crate::Reg<u32, _FMPRE2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -385,7 +385,7 @@ impl crate::Readable for FMPRE2 {}
 impl crate::Writable for FMPRE2 {}
 #[doc = "Flash Memory Protection Read Enable 2"]
 pub mod fmpre2;
-#[doc = "Flash Memory Protection Read Enable 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre3](fmpre3) module"]
+#[doc = "Flash Memory Protection Read Enable 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre3](fmpre3) module"]
 pub type FMPRE3 = crate::Reg<u32, _FMPRE3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -396,7 +396,7 @@ impl crate::Readable for FMPRE3 {}
 impl crate::Writable for FMPRE3 {}
 #[doc = "Flash Memory Protection Read Enable 3"]
 pub mod fmpre3;
-#[doc = "Flash Memory Protection Read Enable 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre4](fmpre4) module"]
+#[doc = "Flash Memory Protection Read Enable 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre4](fmpre4) module"]
 pub type FMPRE4 = crate::Reg<u32, _FMPRE4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -407,7 +407,7 @@ impl crate::Readable for FMPRE4 {}
 impl crate::Writable for FMPRE4 {}
 #[doc = "Flash Memory Protection Read Enable 4"]
 pub mod fmpre4;
-#[doc = "Flash Memory Protection Read Enable 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre5](fmpre5) module"]
+#[doc = "Flash Memory Protection Read Enable 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre5](fmpre5) module"]
 pub type FMPRE5 = crate::Reg<u32, _FMPRE5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -418,7 +418,7 @@ impl crate::Readable for FMPRE5 {}
 impl crate::Writable for FMPRE5 {}
 #[doc = "Flash Memory Protection Read Enable 5"]
 pub mod fmpre5;
-#[doc = "Flash Memory Protection Read Enable 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre6](fmpre6) module"]
+#[doc = "Flash Memory Protection Read Enable 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre6](fmpre6) module"]
 pub type FMPRE6 = crate::Reg<u32, _FMPRE6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -429,7 +429,7 @@ impl crate::Readable for FMPRE6 {}
 impl crate::Writable for FMPRE6 {}
 #[doc = "Flash Memory Protection Read Enable 6"]
 pub mod fmpre6;
-#[doc = "Flash Memory Protection Read Enable 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre7](fmpre7) module"]
+#[doc = "Flash Memory Protection Read Enable 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre7](fmpre7) module"]
 pub type FMPRE7 = crate::Reg<u32, _FMPRE7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -440,7 +440,7 @@ impl crate::Readable for FMPRE7 {}
 impl crate::Writable for FMPRE7 {}
 #[doc = "Flash Memory Protection Read Enable 7"]
 pub mod fmpre7;
-#[doc = "Flash Memory Protection Read Enable 8\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre8](fmpre8) module"]
+#[doc = "Flash Memory Protection Read Enable 8\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre8](fmpre8) module"]
 pub type FMPRE8 = crate::Reg<u32, _FMPRE8>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -451,7 +451,7 @@ impl crate::Readable for FMPRE8 {}
 impl crate::Writable for FMPRE8 {}
 #[doc = "Flash Memory Protection Read Enable 8"]
 pub mod fmpre8;
-#[doc = "Flash Memory Protection Read Enable 9\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre9](fmpre9) module"]
+#[doc = "Flash Memory Protection Read Enable 9\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre9](fmpre9) module"]
 pub type FMPRE9 = crate::Reg<u32, _FMPRE9>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -462,7 +462,7 @@ impl crate::Readable for FMPRE9 {}
 impl crate::Writable for FMPRE9 {}
 #[doc = "Flash Memory Protection Read Enable 9"]
 pub mod fmpre9;
-#[doc = "Flash Memory Protection Read Enable 10\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre10](fmpre10) module"]
+#[doc = "Flash Memory Protection Read Enable 10\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre10](fmpre10) module"]
 pub type FMPRE10 = crate::Reg<u32, _FMPRE10>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -473,7 +473,7 @@ impl crate::Readable for FMPRE10 {}
 impl crate::Writable for FMPRE10 {}
 #[doc = "Flash Memory Protection Read Enable 10"]
 pub mod fmpre10;
-#[doc = "Flash Memory Protection Read Enable 11\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre11](fmpre11) module"]
+#[doc = "Flash Memory Protection Read Enable 11\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre11](fmpre11) module"]
 pub type FMPRE11 = crate::Reg<u32, _FMPRE11>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -484,7 +484,7 @@ impl crate::Readable for FMPRE11 {}
 impl crate::Writable for FMPRE11 {}
 #[doc = "Flash Memory Protection Read Enable 11"]
 pub mod fmpre11;
-#[doc = "Flash Memory Protection Read Enable 12\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre12](fmpre12) module"]
+#[doc = "Flash Memory Protection Read Enable 12\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre12](fmpre12) module"]
 pub type FMPRE12 = crate::Reg<u32, _FMPRE12>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -495,7 +495,7 @@ impl crate::Readable for FMPRE12 {}
 impl crate::Writable for FMPRE12 {}
 #[doc = "Flash Memory Protection Read Enable 12"]
 pub mod fmpre12;
-#[doc = "Flash Memory Protection Read Enable 13\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre13](fmpre13) module"]
+#[doc = "Flash Memory Protection Read Enable 13\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre13](fmpre13) module"]
 pub type FMPRE13 = crate::Reg<u32, _FMPRE13>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -506,7 +506,7 @@ impl crate::Readable for FMPRE13 {}
 impl crate::Writable for FMPRE13 {}
 #[doc = "Flash Memory Protection Read Enable 13"]
 pub mod fmpre13;
-#[doc = "Flash Memory Protection Read Enable 14\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre14](fmpre14) module"]
+#[doc = "Flash Memory Protection Read Enable 14\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre14](fmpre14) module"]
 pub type FMPRE14 = crate::Reg<u32, _FMPRE14>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -517,7 +517,7 @@ impl crate::Readable for FMPRE14 {}
 impl crate::Writable for FMPRE14 {}
 #[doc = "Flash Memory Protection Read Enable 14"]
 pub mod fmpre14;
-#[doc = "Flash Memory Protection Read Enable 15\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmpre15](fmpre15) module"]
+#[doc = "Flash Memory Protection Read Enable 15\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmpre15](fmpre15) module"]
 pub type FMPRE15 = crate::Reg<u32, _FMPRE15>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -528,7 +528,7 @@ impl crate::Readable for FMPRE15 {}
 impl crate::Writable for FMPRE15 {}
 #[doc = "Flash Memory Protection Read Enable 15"]
 pub mod fmpre15;
-#[doc = "Flash Memory Protection Program Enable 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe0](fmppe0) module"]
+#[doc = "Flash Memory Protection Program Enable 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe0](fmppe0) module"]
 pub type FMPPE0 = crate::Reg<u32, _FMPPE0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -539,7 +539,7 @@ impl crate::Readable for FMPPE0 {}
 impl crate::Writable for FMPPE0 {}
 #[doc = "Flash Memory Protection Program Enable 0"]
 pub mod fmppe0;
-#[doc = "Flash Memory Protection Program Enable 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe1](fmppe1) module"]
+#[doc = "Flash Memory Protection Program Enable 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe1](fmppe1) module"]
 pub type FMPPE1 = crate::Reg<u32, _FMPPE1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -550,7 +550,7 @@ impl crate::Readable for FMPPE1 {}
 impl crate::Writable for FMPPE1 {}
 #[doc = "Flash Memory Protection Program Enable 1"]
 pub mod fmppe1;
-#[doc = "Flash Memory Protection Program Enable 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe2](fmppe2) module"]
+#[doc = "Flash Memory Protection Program Enable 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe2](fmppe2) module"]
 pub type FMPPE2 = crate::Reg<u32, _FMPPE2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -561,7 +561,7 @@ impl crate::Readable for FMPPE2 {}
 impl crate::Writable for FMPPE2 {}
 #[doc = "Flash Memory Protection Program Enable 2"]
 pub mod fmppe2;
-#[doc = "Flash Memory Protection Program Enable 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe3](fmppe3) module"]
+#[doc = "Flash Memory Protection Program Enable 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe3](fmppe3) module"]
 pub type FMPPE3 = crate::Reg<u32, _FMPPE3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -572,7 +572,7 @@ impl crate::Readable for FMPPE3 {}
 impl crate::Writable for FMPPE3 {}
 #[doc = "Flash Memory Protection Program Enable 3"]
 pub mod fmppe3;
-#[doc = "Flash Memory Protection Program Enable 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe4](fmppe4) module"]
+#[doc = "Flash Memory Protection Program Enable 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe4](fmppe4) module"]
 pub type FMPPE4 = crate::Reg<u32, _FMPPE4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -583,7 +583,7 @@ impl crate::Readable for FMPPE4 {}
 impl crate::Writable for FMPPE4 {}
 #[doc = "Flash Memory Protection Program Enable 4"]
 pub mod fmppe4;
-#[doc = "Flash Memory Protection Program Enable 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe5](fmppe5) module"]
+#[doc = "Flash Memory Protection Program Enable 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe5](fmppe5) module"]
 pub type FMPPE5 = crate::Reg<u32, _FMPPE5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -594,7 +594,7 @@ impl crate::Readable for FMPPE5 {}
 impl crate::Writable for FMPPE5 {}
 #[doc = "Flash Memory Protection Program Enable 5"]
 pub mod fmppe5;
-#[doc = "Flash Memory Protection Program Enable 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe6](fmppe6) module"]
+#[doc = "Flash Memory Protection Program Enable 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe6](fmppe6) module"]
 pub type FMPPE6 = crate::Reg<u32, _FMPPE6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -605,7 +605,7 @@ impl crate::Readable for FMPPE6 {}
 impl crate::Writable for FMPPE6 {}
 #[doc = "Flash Memory Protection Program Enable 6"]
 pub mod fmppe6;
-#[doc = "Flash Memory Protection Program Enable 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe7](fmppe7) module"]
+#[doc = "Flash Memory Protection Program Enable 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe7](fmppe7) module"]
 pub type FMPPE7 = crate::Reg<u32, _FMPPE7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -616,7 +616,7 @@ impl crate::Readable for FMPPE7 {}
 impl crate::Writable for FMPPE7 {}
 #[doc = "Flash Memory Protection Program Enable 7"]
 pub mod fmppe7;
-#[doc = "Flash Memory Protection Program Enable 8\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe8](fmppe8) module"]
+#[doc = "Flash Memory Protection Program Enable 8\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe8](fmppe8) module"]
 pub type FMPPE8 = crate::Reg<u32, _FMPPE8>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -627,7 +627,7 @@ impl crate::Readable for FMPPE8 {}
 impl crate::Writable for FMPPE8 {}
 #[doc = "Flash Memory Protection Program Enable 8"]
 pub mod fmppe8;
-#[doc = "Flash Memory Protection Program Enable 9\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe9](fmppe9) module"]
+#[doc = "Flash Memory Protection Program Enable 9\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe9](fmppe9) module"]
 pub type FMPPE9 = crate::Reg<u32, _FMPPE9>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -638,7 +638,7 @@ impl crate::Readable for FMPPE9 {}
 impl crate::Writable for FMPPE9 {}
 #[doc = "Flash Memory Protection Program Enable 9"]
 pub mod fmppe9;
-#[doc = "Flash Memory Protection Program Enable 10\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe10](fmppe10) module"]
+#[doc = "Flash Memory Protection Program Enable 10\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe10](fmppe10) module"]
 pub type FMPPE10 = crate::Reg<u32, _FMPPE10>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -649,7 +649,7 @@ impl crate::Readable for FMPPE10 {}
 impl crate::Writable for FMPPE10 {}
 #[doc = "Flash Memory Protection Program Enable 10"]
 pub mod fmppe10;
-#[doc = "Flash Memory Protection Program Enable 11\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe11](fmppe11) module"]
+#[doc = "Flash Memory Protection Program Enable 11\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe11](fmppe11) module"]
 pub type FMPPE11 = crate::Reg<u32, _FMPPE11>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -660,7 +660,7 @@ impl crate::Readable for FMPPE11 {}
 impl crate::Writable for FMPPE11 {}
 #[doc = "Flash Memory Protection Program Enable 11"]
 pub mod fmppe11;
-#[doc = "Flash Memory Protection Program Enable 12\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe12](fmppe12) module"]
+#[doc = "Flash Memory Protection Program Enable 12\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe12](fmppe12) module"]
 pub type FMPPE12 = crate::Reg<u32, _FMPPE12>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -671,7 +671,7 @@ impl crate::Readable for FMPPE12 {}
 impl crate::Writable for FMPPE12 {}
 #[doc = "Flash Memory Protection Program Enable 12"]
 pub mod fmppe12;
-#[doc = "Flash Memory Protection Program Enable 13\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe13](fmppe13) module"]
+#[doc = "Flash Memory Protection Program Enable 13\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe13](fmppe13) module"]
 pub type FMPPE13 = crate::Reg<u32, _FMPPE13>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -682,7 +682,7 @@ impl crate::Readable for FMPPE13 {}
 impl crate::Writable for FMPPE13 {}
 #[doc = "Flash Memory Protection Program Enable 13"]
 pub mod fmppe13;
-#[doc = "Flash Memory Protection Program Enable 14\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe14](fmppe14) module"]
+#[doc = "Flash Memory Protection Program Enable 14\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe14](fmppe14) module"]
 pub type FMPPE14 = crate::Reg<u32, _FMPPE14>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -693,7 +693,7 @@ impl crate::Readable for FMPPE14 {}
 impl crate::Writable for FMPPE14 {}
 #[doc = "Flash Memory Protection Program Enable 14"]
 pub mod fmppe14;
-#[doc = "Flash Memory Protection Program Enable 15\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fmppe15](fmppe15) module"]
+#[doc = "Flash Memory Protection Program Enable 15\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fmppe15](fmppe15) module"]
 pub type FMPPE15 = crate::Reg<u32, _FMPPE15>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/flash_ctrl/bootcfg.rs
+++ b/crates/tm4c129x/src/flash_ctrl/bootcfg.rs
@@ -12,37 +12,29 @@ pub type EN_R = crate::R<bool, bool>;
 pub type POL_R = crate::R<bool, bool>;
 #[doc = "Boot GPIO Pin\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PIN_A {
     #[doc = "0: Pin 0"]
-    _0,
+    _0 = 0,
     #[doc = "1: Pin 1"]
-    _1,
+    _1 = 1,
     #[doc = "2: Pin 2"]
-    _2,
+    _2 = 2,
     #[doc = "3: Pin 3"]
-    _3,
+    _3 = 3,
     #[doc = "4: Pin 4"]
-    _4,
+    _4 = 4,
     #[doc = "5: Pin 5"]
-    _5,
+    _5 = 5,
     #[doc = "6: Pin 6"]
-    _6,
+    _6 = 6,
     #[doc = "7: Pin 7"]
-    _7,
+    _7 = 7,
 }
 impl From<PIN_A> for u8 {
     #[inline(always)]
     fn from(variant: PIN_A) -> Self {
-        match variant {
-            PIN_A::_0 => 0,
-            PIN_A::_1 => 1,
-            PIN_A::_2 => 2,
-            PIN_A::_3 => 3,
-            PIN_A::_4 => 4,
-            PIN_A::_5 => 5,
-            PIN_A::_6 => 6,
-            PIN_A::_7 => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PIN`"]
@@ -106,37 +98,29 @@ impl PIN_R {
 }
 #[doc = "Boot GPIO Port\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PORT_A {
     #[doc = "0: Port A"]
-    A,
+    A = 0,
     #[doc = "1: Port B"]
-    B,
+    B = 1,
     #[doc = "2: Port C"]
-    C,
+    C = 2,
     #[doc = "3: Port D"]
-    D,
+    D = 3,
     #[doc = "4: Port E"]
-    E,
+    E = 4,
     #[doc = "5: Port F"]
-    F,
+    F = 5,
     #[doc = "6: Port G"]
-    G,
+    G = 6,
     #[doc = "7: Port H"]
-    H,
+    H = 7,
 }
 impl From<PORT_A> for u8 {
     #[inline(always)]
     fn from(variant: PORT_A) -> Self {
-        match variant {
-            PORT_A::A => 0,
-            PORT_A::B => 1,
-            PORT_A::C => 2,
-            PORT_A::D => 3,
-            PORT_A::E => 4,
-            PORT_A::F => 5,
-            PORT_A::G => 6,
-            PORT_A::H => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PORT`"]

--- a/crates/tm4c129x/src/flash_ctrl/pp.rs
+++ b/crates/tm4c129x/src/flash_ctrl/pp.rs
@@ -2,16 +2,15 @@
 pub type R = crate::R<u32, super::PP>;
 #[doc = "Flash Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u16)]
 pub enum SIZE_A {
     #[doc = "511: 1024 KB of Flash"]
-    _1MB,
+    _1MB = 511,
 }
 impl From<SIZE_A> for u16 {
     #[inline(always)]
     fn from(variant: SIZE_A) -> Self {
-        match variant {
-            SIZE_A::_1MB => 511,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SIZE`"]
@@ -34,28 +33,23 @@ impl SIZE_R {
 }
 #[doc = "Flash Sector Size of the physical bank\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MAINSS_A {
     #[doc = "0: 1 KB"]
-    _1KB,
+    _1KB = 0,
     #[doc = "1: 2 KB"]
-    _2KB,
+    _2KB = 1,
     #[doc = "2: 4 KB"]
-    _4KB,
+    _4KB = 2,
     #[doc = "3: 8 KB"]
-    _8KB,
+    _8KB = 3,
     #[doc = "4: 16 KB"]
-    _16KB,
+    _16KB = 4,
 }
 impl From<MAINSS_A> for u8 {
     #[inline(always)]
     fn from(variant: MAINSS_A) -> Self {
-        match variant {
-            MAINSS_A::_1KB => 0,
-            MAINSS_A::_2KB => 1,
-            MAINSS_A::_4KB => 2,
-            MAINSS_A::_8KB => 3,
-            MAINSS_A::_16KB => 4,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MAINSS`"]
@@ -102,25 +96,21 @@ impl MAINSS_R {
 }
 #[doc = "EEPROM Sector Size of the physical bank\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum EESS_A {
     #[doc = "0: 1 KB"]
-    _1KB,
+    _1KB = 0,
     #[doc = "1: 2 KB"]
-    _2KB,
+    _2KB = 1,
     #[doc = "2: 4 KB"]
-    _4KB,
+    _4KB = 2,
     #[doc = "3: 8 KB"]
-    _8KB,
+    _8KB = 3,
 }
 impl From<EESS_A> for u8 {
     #[inline(always)]
     fn from(variant: EESS_A) -> Self {
-        match variant {
-            EESS_A::_1KB => 0,
-            EESS_A::_2KB => 1,
-            EESS_A::_4KB => 2,
-            EESS_A::_8KB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `EESS`"]

--- a/crates/tm4c129x/src/flash_ctrl/romswmap.rs
+++ b/crates/tm4c129x/src/flash_ctrl/romswmap.rs
@@ -2,19 +2,17 @@
 pub type R = crate::R<u32, super::ROMSWMAP>;
 #[doc = "ROM SW Region 0 Availability\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SW0EN_A {
     #[doc = "0: Software region not available to the core"]
-    NOTVIS,
+    NOTVIS = 0,
     #[doc = "1: Region available to core"]
-    CORE,
+    CORE = 1,
 }
 impl From<SW0EN_A> for u8 {
     #[inline(always)]
     fn from(variant: SW0EN_A) -> Self {
-        match variant {
-            SW0EN_A::NOTVIS => 0,
-            SW0EN_A::CORE => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SW0EN`"]
@@ -43,19 +41,17 @@ impl SW0EN_R {
 }
 #[doc = "ROM SW Region 1 Availability\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SW1EN_A {
     #[doc = "0: Software region not available to the core"]
-    NOTVIS,
+    NOTVIS = 0,
     #[doc = "1: Region available to core"]
-    CORE,
+    CORE = 1,
 }
 impl From<SW1EN_A> for u8 {
     #[inline(always)]
     fn from(variant: SW1EN_A) -> Self {
-        match variant {
-            SW1EN_A::NOTVIS => 0,
-            SW1EN_A::CORE => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SW1EN`"]
@@ -84,19 +80,17 @@ impl SW1EN_R {
 }
 #[doc = "ROM SW Region 2 Availability\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SW2EN_A {
     #[doc = "0: Software region not available to the core"]
-    NOTVIS,
+    NOTVIS = 0,
     #[doc = "1: Region available to core"]
-    CORE,
+    CORE = 1,
 }
 impl From<SW2EN_A> for u8 {
     #[inline(always)]
     fn from(variant: SW2EN_A) -> Self {
-        match variant {
-            SW2EN_A::NOTVIS => 0,
-            SW2EN_A::CORE => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SW2EN`"]
@@ -125,19 +119,17 @@ impl SW2EN_R {
 }
 #[doc = "ROM SW Region 3 Availability\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SW3EN_A {
     #[doc = "0: Software region not available to the core"]
-    NOTVIS,
+    NOTVIS = 0,
     #[doc = "1: Region available to core"]
-    CORE,
+    CORE = 1,
 }
 impl From<SW3EN_A> for u8 {
     #[inline(always)]
     fn from(variant: SW3EN_A) -> Self {
-        match variant {
-            SW3EN_A::NOTVIS => 0,
-            SW3EN_A::CORE => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SW3EN`"]
@@ -166,19 +158,17 @@ impl SW3EN_R {
 }
 #[doc = "ROM SW Region 4 Availability\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SW4EN_A {
     #[doc = "0: Software region not available to the core"]
-    NOTVIS,
+    NOTVIS = 0,
     #[doc = "1: Region available to core"]
-    CORE,
+    CORE = 1,
 }
 impl From<SW4EN_A> for u8 {
     #[inline(always)]
     fn from(variant: SW4EN_A) -> Self {
-        match variant {
-            SW4EN_A::NOTVIS => 0,
-            SW4EN_A::CORE => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SW4EN`"]
@@ -207,19 +197,17 @@ impl SW4EN_R {
 }
 #[doc = "ROM SW Region 5 Availability\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SW5EN_A {
     #[doc = "0: Software region not available to the core"]
-    NOTVIS,
+    NOTVIS = 0,
     #[doc = "1: Region available to core"]
-    CORE,
+    CORE = 1,
 }
 impl From<SW5EN_A> for u8 {
     #[inline(always)]
     fn from(variant: SW5EN_A) -> Self {
-        match variant {
-            SW5EN_A::NOTVIS => 0,
-            SW5EN_A::CORE => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SW5EN`"]
@@ -248,19 +236,17 @@ impl SW5EN_R {
 }
 #[doc = "ROM SW Region 6 Availability\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SW6EN_A {
     #[doc = "0: Software region not available to the core"]
-    NOTVIS,
+    NOTVIS = 0,
     #[doc = "1: Region available to core"]
-    CORE,
+    CORE = 1,
 }
 impl From<SW6EN_A> for u8 {
     #[inline(always)]
     fn from(variant: SW6EN_A) -> Self {
-        match variant {
-            SW6EN_A::NOTVIS => 0,
-            SW6EN_A::CORE => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SW6EN`"]
@@ -289,19 +275,17 @@ impl SW6EN_R {
 }
 #[doc = "ROM SW Region 7 Availability\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SW7EN_A {
     #[doc = "0: Software region not available to the core"]
-    NOTVIS,
+    NOTVIS = 0,
     #[doc = "1: Region available to core"]
-    CORE,
+    CORE = 1,
 }
 impl From<SW7EN_A> for u8 {
     #[inline(always)]
     fn from(variant: SW7EN_A) -> Self {
-        match variant {
-            SW7EN_A::NOTVIS => 0,
-            SW7EN_A::CORE => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SW7EN`"]

--- a/crates/tm4c129x/src/flash_ctrl/ssize.rs
+++ b/crates/tm4c129x/src/flash_ctrl/ssize.rs
@@ -2,16 +2,15 @@
 pub type R = crate::R<u32, super::SSIZE>;
 #[doc = "SRAM Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u16)]
 pub enum SIZE_A {
     #[doc = "1023: 256 KB of SRAM"]
-    _256KB,
+    _256KB = 1023,
 }
 impl From<SIZE_A> for u16 {
     #[inline(always)]
     fn from(variant: SIZE_A) -> Self {
-        match variant {
-            SIZE_A::_256KB => 1023,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SIZE`"]

--- a/crates/tm4c129x/src/gpio_porta_ahb.rs
+++ b/crates/tm4c129x/src/gpio_porta_ahb.rs
@@ -67,7 +67,7 @@ pub struct RegisterBlock {
     #[doc = "0xfc4 - GPIO Peripheral Configuration"]
     pub pc: PC,
 }
-#[doc = "GPIO Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [data](data) module"]
+#[doc = "GPIO Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [data](data) module"]
 pub type DATA = crate::Reg<u32, _DATA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -78,7 +78,7 @@ impl crate::Readable for DATA {}
 impl crate::Writable for DATA {}
 #[doc = "GPIO Data"]
 pub mod data;
-#[doc = "GPIO Direction\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dir](dir) module"]
+#[doc = "GPIO Direction\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dir](dir) module"]
 pub type DIR = crate::Reg<u32, _DIR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -89,7 +89,7 @@ impl crate::Readable for DIR {}
 impl crate::Writable for DIR {}
 #[doc = "GPIO Direction"]
 pub mod dir;
-#[doc = "GPIO Interrupt Sense\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [is](is) module"]
+#[doc = "GPIO Interrupt Sense\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [is](is) module"]
 pub type IS = crate::Reg<u32, _IS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -100,7 +100,7 @@ impl crate::Readable for IS {}
 impl crate::Writable for IS {}
 #[doc = "GPIO Interrupt Sense"]
 pub mod is;
-#[doc = "GPIO Interrupt Both Edges\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ibe](ibe) module"]
+#[doc = "GPIO Interrupt Both Edges\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ibe](ibe) module"]
 pub type IBE = crate::Reg<u32, _IBE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -111,7 +111,7 @@ impl crate::Readable for IBE {}
 impl crate::Writable for IBE {}
 #[doc = "GPIO Interrupt Both Edges"]
 pub mod ibe;
-#[doc = "GPIO Interrupt Event\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [iev](iev) module"]
+#[doc = "GPIO Interrupt Event\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [iev](iev) module"]
 pub type IEV = crate::Reg<u32, _IEV>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -122,7 +122,7 @@ impl crate::Readable for IEV {}
 impl crate::Writable for IEV {}
 #[doc = "GPIO Interrupt Event"]
 pub mod iev;
-#[doc = "GPIO Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [im](im) module"]
+#[doc = "GPIO Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [im](im) module"]
 pub type IM = crate::Reg<u32, _IM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -133,7 +133,7 @@ impl crate::Readable for IM {}
 impl crate::Writable for IM {}
 #[doc = "GPIO Interrupt Mask"]
 pub mod im;
-#[doc = "GPIO Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "GPIO Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -142,7 +142,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "GPIO Raw Interrupt Status"]
 pub mod ris;
-#[doc = "GPIO Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mis](mis) module"]
+#[doc = "GPIO Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mis](mis) module"]
 pub type MIS = crate::Reg<u32, _MIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -151,7 +151,7 @@ pub struct _MIS;
 impl crate::Readable for MIS {}
 #[doc = "GPIO Masked Interrupt Status"]
 pub mod mis;
-#[doc = "GPIO Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [icr](icr) module"]
+#[doc = "GPIO Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [icr](icr) module"]
 pub type ICR = crate::Reg<u32, _ICR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -160,7 +160,7 @@ pub struct _ICR;
 impl crate::Writable for ICR {}
 #[doc = "GPIO Interrupt Clear"]
 pub mod icr;
-#[doc = "GPIO Alternate Function Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [afsel](afsel) module"]
+#[doc = "GPIO Alternate Function Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [afsel](afsel) module"]
 pub type AFSEL = crate::Reg<u32, _AFSEL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -171,7 +171,7 @@ impl crate::Readable for AFSEL {}
 impl crate::Writable for AFSEL {}
 #[doc = "GPIO Alternate Function Select"]
 pub mod afsel;
-#[doc = "GPIO 2-mA Drive Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dr2r](dr2r) module"]
+#[doc = "GPIO 2-mA Drive Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dr2r](dr2r) module"]
 pub type DR2R = crate::Reg<u32, _DR2R>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -182,7 +182,7 @@ impl crate::Readable for DR2R {}
 impl crate::Writable for DR2R {}
 #[doc = "GPIO 2-mA Drive Select"]
 pub mod dr2r;
-#[doc = "GPIO 4-mA Drive Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dr4r](dr4r) module"]
+#[doc = "GPIO 4-mA Drive Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dr4r](dr4r) module"]
 pub type DR4R = crate::Reg<u32, _DR4R>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -193,7 +193,7 @@ impl crate::Readable for DR4R {}
 impl crate::Writable for DR4R {}
 #[doc = "GPIO 4-mA Drive Select"]
 pub mod dr4r;
-#[doc = "GPIO 8-mA Drive Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dr8r](dr8r) module"]
+#[doc = "GPIO 8-mA Drive Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dr8r](dr8r) module"]
 pub type DR8R = crate::Reg<u32, _DR8R>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -204,7 +204,7 @@ impl crate::Readable for DR8R {}
 impl crate::Writable for DR8R {}
 #[doc = "GPIO 8-mA Drive Select"]
 pub mod dr8r;
-#[doc = "GPIO Open Drain Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [odr](odr) module"]
+#[doc = "GPIO Open Drain Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [odr](odr) module"]
 pub type ODR = crate::Reg<u32, _ODR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -215,7 +215,7 @@ impl crate::Readable for ODR {}
 impl crate::Writable for ODR {}
 #[doc = "GPIO Open Drain Select"]
 pub mod odr;
-#[doc = "GPIO Pull-Up Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pur](pur) module"]
+#[doc = "GPIO Pull-Up Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pur](pur) module"]
 pub type PUR = crate::Reg<u32, _PUR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -226,7 +226,7 @@ impl crate::Readable for PUR {}
 impl crate::Writable for PUR {}
 #[doc = "GPIO Pull-Up Select"]
 pub mod pur;
-#[doc = "GPIO Pull-Down Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pdr](pdr) module"]
+#[doc = "GPIO Pull-Down Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pdr](pdr) module"]
 pub type PDR = crate::Reg<u32, _PDR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -237,7 +237,7 @@ impl crate::Readable for PDR {}
 impl crate::Writable for PDR {}
 #[doc = "GPIO Pull-Down Select"]
 pub mod pdr;
-#[doc = "GPIO Slew Rate Control Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [slr](slr) module"]
+#[doc = "GPIO Slew Rate Control Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [slr](slr) module"]
 pub type SLR = crate::Reg<u32, _SLR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -248,7 +248,7 @@ impl crate::Readable for SLR {}
 impl crate::Writable for SLR {}
 #[doc = "GPIO Slew Rate Control Select"]
 pub mod slr;
-#[doc = "GPIO Digital Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [den](den) module"]
+#[doc = "GPIO Digital Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [den](den) module"]
 pub type DEN = crate::Reg<u32, _DEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -259,7 +259,7 @@ impl crate::Readable for DEN {}
 impl crate::Writable for DEN {}
 #[doc = "GPIO Digital Enable"]
 pub mod den;
-#[doc = "GPIO Lock\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [lock](lock) module"]
+#[doc = "GPIO Lock\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [lock](lock) module"]
 pub type LOCK = crate::Reg<u32, _LOCK>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -270,7 +270,7 @@ impl crate::Readable for LOCK {}
 impl crate::Writable for LOCK {}
 #[doc = "GPIO Lock"]
 pub mod lock;
-#[doc = "GPIO Commit\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cr](cr) module"]
+#[doc = "GPIO Commit\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cr](cr) module"]
 pub type CR = crate::Reg<u32, _CR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -281,7 +281,7 @@ impl crate::Readable for CR {}
 impl crate::Writable for CR {}
 #[doc = "GPIO Commit"]
 pub mod cr;
-#[doc = "GPIO Analog Mode Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [amsel](amsel) module"]
+#[doc = "GPIO Analog Mode Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [amsel](amsel) module"]
 pub type AMSEL = crate::Reg<u32, _AMSEL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -292,7 +292,7 @@ impl crate::Readable for AMSEL {}
 impl crate::Writable for AMSEL {}
 #[doc = "GPIO Analog Mode Select"]
 pub mod amsel;
-#[doc = "GPIO Port Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pctl](pctl) module"]
+#[doc = "GPIO Port Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pctl](pctl) module"]
 pub type PCTL = crate::Reg<u32, _PCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -303,7 +303,7 @@ impl crate::Readable for PCTL {}
 impl crate::Writable for PCTL {}
 #[doc = "GPIO Port Control"]
 pub mod pctl;
-#[doc = "GPIO ADC Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [adcctl](adcctl) module"]
+#[doc = "GPIO ADC Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [adcctl](adcctl) module"]
 pub type ADCCTL = crate::Reg<u32, _ADCCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -314,7 +314,7 @@ impl crate::Readable for ADCCTL {}
 impl crate::Writable for ADCCTL {}
 #[doc = "GPIO ADC Control"]
 pub mod adcctl;
-#[doc = "GPIO DMA Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmactl](dmactl) module"]
+#[doc = "GPIO DMA Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmactl](dmactl) module"]
 pub type DMACTL = crate::Reg<u32, _DMACTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -325,7 +325,7 @@ impl crate::Readable for DMACTL {}
 impl crate::Writable for DMACTL {}
 #[doc = "GPIO DMA Control"]
 pub mod dmactl;
-#[doc = "GPIO Select Interrupt\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [si](si) module"]
+#[doc = "GPIO Select Interrupt\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [si](si) module"]
 pub type SI = crate::Reg<u32, _SI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -336,7 +336,7 @@ impl crate::Readable for SI {}
 impl crate::Writable for SI {}
 #[doc = "GPIO Select Interrupt"]
 pub mod si;
-#[doc = "GPIO 12-mA Drive Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dr12r](dr12r) module"]
+#[doc = "GPIO 12-mA Drive Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dr12r](dr12r) module"]
 pub type DR12R = crate::Reg<u32, _DR12R>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -347,7 +347,7 @@ impl crate::Readable for DR12R {}
 impl crate::Writable for DR12R {}
 #[doc = "GPIO 12-mA Drive Select"]
 pub mod dr12r;
-#[doc = "GPIO Wake Pin Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [wakepen](wakepen) module"]
+#[doc = "GPIO Wake Pin Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [wakepen](wakepen) module"]
 pub type WAKEPEN = crate::Reg<u32, _WAKEPEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -358,7 +358,7 @@ impl crate::Readable for WAKEPEN {}
 impl crate::Writable for WAKEPEN {}
 #[doc = "GPIO Wake Pin Enable"]
 pub mod wakepen;
-#[doc = "GPIO Wake Level\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [wakelvl](wakelvl) module"]
+#[doc = "GPIO Wake Level\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [wakelvl](wakelvl) module"]
 pub type WAKELVL = crate::Reg<u32, _WAKELVL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -369,7 +369,7 @@ impl crate::Readable for WAKELVL {}
 impl crate::Writable for WAKELVL {}
 #[doc = "GPIO Wake Level"]
 pub mod wakelvl;
-#[doc = "GPIO Wake Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [wakestat](wakestat) module"]
+#[doc = "GPIO Wake Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [wakestat](wakestat) module"]
 pub type WAKESTAT = crate::Reg<u32, _WAKESTAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -378,7 +378,7 @@ pub struct _WAKESTAT;
 impl crate::Readable for WAKESTAT {}
 #[doc = "GPIO Wake Status"]
 pub mod wakestat;
-#[doc = "GPIO Peripheral Property\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "GPIO Peripheral Property\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -387,7 +387,7 @@ pub struct _PP;
 impl crate::Readable for PP {}
 #[doc = "GPIO Peripheral Property"]
 pub mod pp;
-#[doc = "GPIO Peripheral Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pc](pc) module"]
+#[doc = "GPIO Peripheral Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pc](pc) module"]
 pub type PC = crate::Reg<u32, _PC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/gpio_porta_ahb/lock.rs
+++ b/crates/tm4c129x/src/gpio_porta_ahb/lock.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::LOCK {
 }
 #[doc = "GPIO Lock\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u32)]
 pub enum LOCK_A {
     #[doc = "0: The GPIOCR register is unlocked and may be modified"]
-    UNLOCKED,
+    UNLOCKED = 0,
     #[doc = "1: The GPIOCR register is locked and may not be modified"]
-    LOCKED,
+    LOCKED = 1,
     #[doc = "1280262987: Unlocks the GPIO_CR register"]
-    KEY,
+    KEY = 1280262987,
 }
 impl From<LOCK_A> for u32 {
     #[inline(always)]
     fn from(variant: LOCK_A) -> Self {
-        match variant {
-            LOCK_A::UNLOCKED => 0,
-            LOCK_A::LOCKED => 1,
-            LOCK_A::KEY => 1280262987,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `LOCK`"]

--- a/crates/tm4c129x/src/gpio_porta_ahb/pc.rs
+++ b/crates/tm4c129x/src/gpio_porta_ahb/pc.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::PC {
 }
 #[doc = "Extended Drive Mode Bit 0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum EDM0_A {
     #[doc = "0: Drive values of 2, 4 and 8 mA are maintained. GPIO n Drive Select (GPIODRnR) registers function as normal"]
-    DISABLE,
+    DISABLE = 0,
     #[doc = "1: An additional 6 mA option is provided"]
-    _6MA,
+    _6MA = 1,
     #[doc = "3: A 2 mA driver is always enabled; setting the corresponding GPIODR4R register bit adds 2 mA and setting the corresponding GPIODR8R of GPIODR12R register bit adds an additional 4 mA"]
-    PLUS2MA,
+    PLUS2MA = 3,
 }
 impl From<EDM0_A> for u8 {
     #[inline(always)]
     fn from(variant: EDM0_A) -> Self {
-        match variant {
-            EDM0_A::DISABLE => 0,
-            EDM0_A::_6MA => 1,
-            EDM0_A::PLUS2MA => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `EDM0`"]

--- a/crates/tm4c129x/src/gpio_porta_ahb/wakelvl.rs
+++ b/crates/tm4c129x/src/gpio_porta_ahb/wakelvl.rs
@@ -35,14 +35,16 @@ impl<'a> WAKELVL4_W<'a> {
     }
 }
 impl R {
-    #[doc = "Bit 4 - P\\[4\\] Wake Level"]
+    #[doc = "Bit 4 - P\\[4\\]
+Wake Level"]
     #[inline(always)]
     pub fn wakelvl4(&self) -> WAKELVL4_R {
         WAKELVL4_R::new(((self.bits >> 4) & 0x01) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 4 - P\\[4\\] Wake Level"]
+    #[doc = "Bit 4 - P\\[4\\]
+Wake Level"]
     #[inline(always)]
     pub fn wakelvl4(&mut self) -> WAKELVL4_W {
         WAKELVL4_W { w: self }

--- a/crates/tm4c129x/src/gpio_porta_ahb/wakepen.rs
+++ b/crates/tm4c129x/src/gpio_porta_ahb/wakepen.rs
@@ -35,14 +35,16 @@ impl<'a> WAKEP4_W<'a> {
     }
 }
 impl R {
-    #[doc = "Bit 4 - P\\[4\\] Wake Enable"]
+    #[doc = "Bit 4 - P\\[4\\]
+Wake Enable"]
     #[inline(always)]
     pub fn wakep4(&self) -> WAKEP4_R {
         WAKEP4_R::new(((self.bits >> 4) & 0x01) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 4 - P\\[4\\] Wake Enable"]
+    #[doc = "Bit 4 - P\\[4\\]
+Wake Enable"]
     #[inline(always)]
     pub fn wakep4(&mut self) -> WAKEP4_W {
         WAKEP4_W { w: self }

--- a/crates/tm4c129x/src/gpio_porta_ahb/wakestat.rs
+++ b/crates/tm4c129x/src/gpio_porta_ahb/wakestat.rs
@@ -3,7 +3,8 @@ pub type R = crate::R<u32, super::WAKESTAT>;
 #[doc = "Reader of field `STAT4`"]
 pub type STAT4_R = crate::R<bool, bool>;
 impl R {
-    #[doc = "Bit 4 - P\\[4\\] Wake Status"]
+    #[doc = "Bit 4 - P\\[4\\]
+Wake Status"]
     #[inline(always)]
     pub fn stat4(&self) -> STAT4_R {
         STAT4_R::new(((self.bits >> 4) & 0x01) != 0)

--- a/crates/tm4c129x/src/hib.rs
+++ b/crates/tm4c129x/src/hib.rs
@@ -79,7 +79,7 @@ pub struct RegisterBlock {
     #[doc = "0xfc8 - Hibernation Clock Control"]
     pub cc: CC,
 }
-#[doc = "Hibernation RTC Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rtcc](rtcc) module"]
+#[doc = "Hibernation RTC Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rtcc](rtcc) module"]
 pub type RTCC = crate::Reg<u32, _RTCC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -88,7 +88,7 @@ pub struct _RTCC;
 impl crate::Readable for RTCC {}
 #[doc = "Hibernation RTC Counter"]
 pub mod rtcc;
-#[doc = "Hibernation RTC Match 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rtcm0](rtcm0) module"]
+#[doc = "Hibernation RTC Match 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rtcm0](rtcm0) module"]
 pub type RTCM0 = crate::Reg<u32, _RTCM0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -99,7 +99,7 @@ impl crate::Readable for RTCM0 {}
 impl crate::Writable for RTCM0 {}
 #[doc = "Hibernation RTC Match 0"]
 pub mod rtcm0;
-#[doc = "Hibernation RTC Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rtcld](rtcld) module"]
+#[doc = "Hibernation RTC Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rtcld](rtcld) module"]
 pub type RTCLD = crate::Reg<u32, _RTCLD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -110,7 +110,7 @@ impl crate::Readable for RTCLD {}
 impl crate::Writable for RTCLD {}
 #[doc = "Hibernation RTC Load"]
 pub mod rtcld;
-#[doc = "Hibernation Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctl](ctl) module"]
+#[doc = "Hibernation Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctl](ctl) module"]
 pub type CTL = crate::Reg<u32, _CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -121,7 +121,7 @@ impl crate::Readable for CTL {}
 impl crate::Writable for CTL {}
 #[doc = "Hibernation Control"]
 pub mod ctl;
-#[doc = "Hibernation Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [im](im) module"]
+#[doc = "Hibernation Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [im](im) module"]
 pub type IM = crate::Reg<u32, _IM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -132,7 +132,7 @@ impl crate::Readable for IM {}
 impl crate::Writable for IM {}
 #[doc = "Hibernation Interrupt Mask"]
 pub mod im;
-#[doc = "Hibernation Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "Hibernation Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -141,7 +141,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "Hibernation Raw Interrupt Status"]
 pub mod ris;
-#[doc = "Hibernation Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mis](mis) module"]
+#[doc = "Hibernation Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mis](mis) module"]
 pub type MIS = crate::Reg<u32, _MIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -150,7 +150,7 @@ pub struct _MIS;
 impl crate::Readable for MIS {}
 #[doc = "Hibernation Masked Interrupt Status"]
 pub mod mis;
-#[doc = "Hibernation Interrupt Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ic](ic) module"]
+#[doc = "Hibernation Interrupt Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ic](ic) module"]
 pub type IC = crate::Reg<u32, _IC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -161,7 +161,7 @@ impl crate::Readable for IC {}
 impl crate::Writable for IC {}
 #[doc = "Hibernation Interrupt Clear"]
 pub mod ic;
-#[doc = "Hibernation RTC Trim\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rtct](rtct) module"]
+#[doc = "Hibernation RTC Trim\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rtct](rtct) module"]
 pub type RTCT = crate::Reg<u32, _RTCT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -172,7 +172,7 @@ impl crate::Readable for RTCT {}
 impl crate::Writable for RTCT {}
 #[doc = "Hibernation RTC Trim"]
 pub mod rtct;
-#[doc = "Hibernation RTC Sub Seconds\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rtcss](rtcss) module"]
+#[doc = "Hibernation RTC Sub Seconds\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rtcss](rtcss) module"]
 pub type RTCSS = crate::Reg<u32, _RTCSS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -183,7 +183,7 @@ impl crate::Readable for RTCSS {}
 impl crate::Writable for RTCSS {}
 #[doc = "Hibernation RTC Sub Seconds"]
 pub mod rtcss;
-#[doc = "Hibernation IO Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [io](io) module"]
+#[doc = "Hibernation IO Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [io](io) module"]
 pub type IO = crate::Reg<u32, _IO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -194,7 +194,7 @@ impl crate::Readable for IO {}
 impl crate::Writable for IO {}
 #[doc = "Hibernation IO Configuration"]
 pub mod io;
-#[doc = "Hibernation Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [data](data) module"]
+#[doc = "Hibernation Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [data](data) module"]
 pub type DATA = crate::Reg<u32, _DATA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -205,7 +205,7 @@ impl crate::Readable for DATA {}
 impl crate::Writable for DATA {}
 #[doc = "Hibernation Data"]
 pub mod data;
-#[doc = "Hibernation Calendar Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [calctl](calctl) module"]
+#[doc = "Hibernation Calendar Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [calctl](calctl) module"]
 pub type CALCTL = crate::Reg<u32, _CALCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -216,7 +216,7 @@ impl crate::Readable for CALCTL {}
 impl crate::Writable for CALCTL {}
 #[doc = "Hibernation Calendar Control"]
 pub mod calctl;
-#[doc = "Hibernation Calendar 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cal0](cal0) module"]
+#[doc = "Hibernation Calendar 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cal0](cal0) module"]
 pub type CAL0 = crate::Reg<u32, _CAL0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -225,7 +225,7 @@ pub struct _CAL0;
 impl crate::Readable for CAL0 {}
 #[doc = "Hibernation Calendar 0"]
 pub mod cal0;
-#[doc = "Hibernation Calendar 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cal1](cal1) module"]
+#[doc = "Hibernation Calendar 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cal1](cal1) module"]
 pub type CAL1 = crate::Reg<u32, _CAL1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -234,7 +234,7 @@ pub struct _CAL1;
 impl crate::Readable for CAL1 {}
 #[doc = "Hibernation Calendar 1"]
 pub mod cal1;
-#[doc = "Hibernation Calendar Load 0\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [calld0](calld0) module"]
+#[doc = "Hibernation Calendar Load 0\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [calld0](calld0) module"]
 pub type CALLD0 = crate::Reg<u32, _CALLD0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -243,7 +243,7 @@ pub struct _CALLD0;
 impl crate::Writable for CALLD0 {}
 #[doc = "Hibernation Calendar Load 0"]
 pub mod calld0;
-#[doc = "Hibernation Calendar Load\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [calld1](calld1) module"]
+#[doc = "Hibernation Calendar Load\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [calld1](calld1) module"]
 pub type CALLD1 = crate::Reg<u32, _CALLD1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -252,7 +252,7 @@ pub struct _CALLD1;
 impl crate::Writable for CALLD1 {}
 #[doc = "Hibernation Calendar Load"]
 pub mod calld1;
-#[doc = "Hibernation Calendar Match 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [calm0](calm0) module"]
+#[doc = "Hibernation Calendar Match 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [calm0](calm0) module"]
 pub type CALM0 = crate::Reg<u32, _CALM0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -263,7 +263,7 @@ impl crate::Readable for CALM0 {}
 impl crate::Writable for CALM0 {}
 #[doc = "Hibernation Calendar Match 0"]
 pub mod calm0;
-#[doc = "Hibernation Calendar Match 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [calm1](calm1) module"]
+#[doc = "Hibernation Calendar Match 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [calm1](calm1) module"]
 pub type CALM1 = crate::Reg<u32, _CALM1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -274,7 +274,7 @@ impl crate::Readable for CALM1 {}
 impl crate::Writable for CALM1 {}
 #[doc = "Hibernation Calendar Match 1"]
 pub mod calm1;
-#[doc = "Hibernation Lock\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [lock](lock) module"]
+#[doc = "Hibernation Lock\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [lock](lock) module"]
 pub type LOCK = crate::Reg<u32, _LOCK>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -285,7 +285,7 @@ impl crate::Readable for LOCK {}
 impl crate::Writable for LOCK {}
 #[doc = "Hibernation Lock"]
 pub mod lock;
-#[doc = "HIB Tamper Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tpctl](tpctl) module"]
+#[doc = "HIB Tamper Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tpctl](tpctl) module"]
 pub type TPCTL = crate::Reg<u32, _TPCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -296,7 +296,7 @@ impl crate::Readable for TPCTL {}
 impl crate::Writable for TPCTL {}
 #[doc = "HIB Tamper Control"]
 pub mod tpctl;
-#[doc = "HIB Tamper Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tpstat](tpstat) module"]
+#[doc = "HIB Tamper Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tpstat](tpstat) module"]
 pub type TPSTAT = crate::Reg<u32, _TPSTAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -307,7 +307,7 @@ impl crate::Readable for TPSTAT {}
 impl crate::Writable for TPSTAT {}
 #[doc = "HIB Tamper Status"]
 pub mod tpstat;
-#[doc = "HIB Tamper I/O Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tpio](tpio) module"]
+#[doc = "HIB Tamper I/O Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tpio](tpio) module"]
 pub type TPIO = crate::Reg<u32, _TPIO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -318,7 +318,7 @@ impl crate::Readable for TPIO {}
 impl crate::Writable for TPIO {}
 #[doc = "HIB Tamper I/O Control"]
 pub mod tpio;
-#[doc = "HIB Tamper Log 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tplog0](tplog0) module"]
+#[doc = "HIB Tamper Log 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tplog0](tplog0) module"]
 pub type TPLOG0 = crate::Reg<u32, _TPLOG0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -327,7 +327,7 @@ pub struct _TPLOG0;
 impl crate::Readable for TPLOG0 {}
 #[doc = "HIB Tamper Log 0"]
 pub mod tplog0;
-#[doc = "HIB Tamper Log 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tplog1](tplog1) module"]
+#[doc = "HIB Tamper Log 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tplog1](tplog1) module"]
 pub type TPLOG1 = crate::Reg<u32, _TPLOG1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -336,7 +336,7 @@ pub struct _TPLOG1;
 impl crate::Readable for TPLOG1 {}
 #[doc = "HIB Tamper Log 1"]
 pub mod tplog1;
-#[doc = "HIB Tamper Log 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tplog2](tplog2) module"]
+#[doc = "HIB Tamper Log 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tplog2](tplog2) module"]
 pub type TPLOG2 = crate::Reg<u32, _TPLOG2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -345,7 +345,7 @@ pub struct _TPLOG2;
 impl crate::Readable for TPLOG2 {}
 #[doc = "HIB Tamper Log 2"]
 pub mod tplog2;
-#[doc = "HIB Tamper Log 3\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tplog3](tplog3) module"]
+#[doc = "HIB Tamper Log 3\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tplog3](tplog3) module"]
 pub type TPLOG3 = crate::Reg<u32, _TPLOG3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -354,7 +354,7 @@ pub struct _TPLOG3;
 impl crate::Readable for TPLOG3 {}
 #[doc = "HIB Tamper Log 3"]
 pub mod tplog3;
-#[doc = "HIB Tamper Log 4\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tplog4](tplog4) module"]
+#[doc = "HIB Tamper Log 4\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tplog4](tplog4) module"]
 pub type TPLOG4 = crate::Reg<u32, _TPLOG4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -363,7 +363,7 @@ pub struct _TPLOG4;
 impl crate::Readable for TPLOG4 {}
 #[doc = "HIB Tamper Log 4"]
 pub mod tplog4;
-#[doc = "HIB Tamper Log 5\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tplog5](tplog5) module"]
+#[doc = "HIB Tamper Log 5\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tplog5](tplog5) module"]
 pub type TPLOG5 = crate::Reg<u32, _TPLOG5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -372,7 +372,7 @@ pub struct _TPLOG5;
 impl crate::Readable for TPLOG5 {}
 #[doc = "HIB Tamper Log 5"]
 pub mod tplog5;
-#[doc = "HIB Tamper Log 6\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tplog6](tplog6) module"]
+#[doc = "HIB Tamper Log 6\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tplog6](tplog6) module"]
 pub type TPLOG6 = crate::Reg<u32, _TPLOG6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -381,7 +381,7 @@ pub struct _TPLOG6;
 impl crate::Readable for TPLOG6 {}
 #[doc = "HIB Tamper Log 6"]
 pub mod tplog6;
-#[doc = "HIB Tamper Log 7\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tplog7](tplog7) module"]
+#[doc = "HIB Tamper Log 7\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tplog7](tplog7) module"]
 pub type TPLOG7 = crate::Reg<u32, _TPLOG7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -390,7 +390,7 @@ pub struct _TPLOG7;
 impl crate::Readable for TPLOG7 {}
 #[doc = "HIB Tamper Log 7"]
 pub mod tplog7;
-#[doc = "Hibernation Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "Hibernation Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -399,7 +399,7 @@ pub struct _PP;
 impl crate::Readable for PP {}
 #[doc = "Hibernation Peripheral Properties"]
 pub mod pp;
-#[doc = "Hibernation Clock Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc](cc) module"]
+#[doc = "Hibernation Clock Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cc](cc) module"]
 pub type CC = crate::Reg<u32, _CC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/hib/ctl.rs
+++ b/crates/tm4c129x/src/hib/ctl.rs
@@ -228,25 +228,21 @@ impl<'a> BATCHK_W<'a> {
 }
 #[doc = "Select for Low-Battery Comparator\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum VBATSEL_A {
     #[doc = "0: 1.9 Volts"]
-    _1_9V,
+    _1_9V = 0,
     #[doc = "1: 2.1 Volts (default)"]
-    _2_1V,
+    _2_1V = 1,
     #[doc = "2: 2.3 Volts"]
-    _2_3V,
+    _2_3V = 2,
     #[doc = "3: 2.5 Volts"]
-    _2_5V,
+    _2_5V = 3,
 }
 impl From<VBATSEL_A> for u8 {
     #[inline(always)]
     fn from(variant: VBATSEL_A) -> Self {
-        match variant {
-            VBATSEL_A::_1_9V => 0,
-            VBATSEL_A::_2_1V => 1,
-            VBATSEL_A::_2_3V => 2,
-            VBATSEL_A::_2_5V => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `VBATSEL`"]

--- a/crates/tm4c129x/src/hib/tpctl.rs
+++ b/crates/tm4c129x/src/hib/tpctl.rs
@@ -60,25 +60,21 @@ impl<'a> TPCLR_W<'a> {
 }
 #[doc = "HIB Memory Clear on Tamper Event\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MEMCLR_A {
     #[doc = "0: Do not Clear HIB memory on tamper event"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Clear Lower 32 Bytes of HIB memory on tamper event"]
-    LOW32,
+    LOW32 = 1,
     #[doc = "2: Clear upper 32 Bytes of HIB memory on tamper event"]
-    HIGH32,
+    HIGH32 = 2,
     #[doc = "3: Clear all HIB memory on tamper event"]
-    ALL,
+    ALL = 3,
 }
 impl From<MEMCLR_A> for u8 {
     #[inline(always)]
     fn from(variant: MEMCLR_A) -> Self {
-        match variant {
-            MEMCLR_A::NONE => 0,
-            MEMCLR_A::LOW32 => 1,
-            MEMCLR_A::HIGH32 => 2,
-            MEMCLR_A::ALL => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MEMCLR`"]

--- a/crates/tm4c129x/src/hib/tplog1.rs
+++ b/crates/tm4c129x/src/hib/tplog1.rs
@@ -11,22 +11,26 @@ pub type TRIG3_R = crate::R<bool, bool>;
 #[doc = "Reader of field `XOSC`"]
 pub type XOSC_R = crate::R<bool, bool>;
 impl R {
-    #[doc = "Bit 0 - Status of TMPR\\[0\\] Trigger"]
+    #[doc = "Bit 0 - Status of TMPR\\[0\\]
+Trigger"]
     #[inline(always)]
     pub fn trig0(&self) -> TRIG0_R {
         TRIG0_R::new((self.bits & 0x01) != 0)
     }
-    #[doc = "Bit 1 - Status of TMPR\\[1\\] Trigger"]
+    #[doc = "Bit 1 - Status of TMPR\\[1\\]
+Trigger"]
     #[inline(always)]
     pub fn trig1(&self) -> TRIG1_R {
         TRIG1_R::new(((self.bits >> 1) & 0x01) != 0)
     }
-    #[doc = "Bit 2 - Status of TMPR\\[2\\] Trigger"]
+    #[doc = "Bit 2 - Status of TMPR\\[2\\]
+Trigger"]
     #[inline(always)]
     pub fn trig2(&self) -> TRIG2_R {
         TRIG2_R::new(((self.bits >> 2) & 0x01) != 0)
     }
-    #[doc = "Bit 3 - Status of TMPR\\[3\\] Trigger"]
+    #[doc = "Bit 3 - Status of TMPR\\[3\\]
+Trigger"]
     #[inline(always)]
     pub fn trig3(&self) -> TRIG3_R {
         TRIG3_R::new(((self.bits >> 3) & 0x01) != 0)

--- a/crates/tm4c129x/src/hib/tplog3.rs
+++ b/crates/tm4c129x/src/hib/tplog3.rs
@@ -11,22 +11,26 @@ pub type TRIG3_R = crate::R<bool, bool>;
 #[doc = "Reader of field `XOSC`"]
 pub type XOSC_R = crate::R<bool, bool>;
 impl R {
-    #[doc = "Bit 0 - Status of TMPR\\[0\\] Trigger"]
+    #[doc = "Bit 0 - Status of TMPR\\[0\\]
+Trigger"]
     #[inline(always)]
     pub fn trig0(&self) -> TRIG0_R {
         TRIG0_R::new((self.bits & 0x01) != 0)
     }
-    #[doc = "Bit 1 - Status of TMPR\\[1\\] Trigger"]
+    #[doc = "Bit 1 - Status of TMPR\\[1\\]
+Trigger"]
     #[inline(always)]
     pub fn trig1(&self) -> TRIG1_R {
         TRIG1_R::new(((self.bits >> 1) & 0x01) != 0)
     }
-    #[doc = "Bit 2 - Status of TMPR\\[2\\] Trigger"]
+    #[doc = "Bit 2 - Status of TMPR\\[2\\]
+Trigger"]
     #[inline(always)]
     pub fn trig2(&self) -> TRIG2_R {
         TRIG2_R::new(((self.bits >> 2) & 0x01) != 0)
     }
-    #[doc = "Bit 3 - Status of TMPR\\[3\\] Trigger"]
+    #[doc = "Bit 3 - Status of TMPR\\[3\\]
+Trigger"]
     #[inline(always)]
     pub fn trig3(&self) -> TRIG3_R {
         TRIG3_R::new(((self.bits >> 3) & 0x01) != 0)

--- a/crates/tm4c129x/src/hib/tplog5.rs
+++ b/crates/tm4c129x/src/hib/tplog5.rs
@@ -11,22 +11,26 @@ pub type TRIG3_R = crate::R<bool, bool>;
 #[doc = "Reader of field `XOSC`"]
 pub type XOSC_R = crate::R<bool, bool>;
 impl R {
-    #[doc = "Bit 0 - Status of TMPR\\[0\\] Trigger"]
+    #[doc = "Bit 0 - Status of TMPR\\[0\\]
+Trigger"]
     #[inline(always)]
     pub fn trig0(&self) -> TRIG0_R {
         TRIG0_R::new((self.bits & 0x01) != 0)
     }
-    #[doc = "Bit 1 - Status of TMPR\\[1\\] Trigger"]
+    #[doc = "Bit 1 - Status of TMPR\\[1\\]
+Trigger"]
     #[inline(always)]
     pub fn trig1(&self) -> TRIG1_R {
         TRIG1_R::new(((self.bits >> 1) & 0x01) != 0)
     }
-    #[doc = "Bit 2 - Status of TMPR\\[2\\] Trigger"]
+    #[doc = "Bit 2 - Status of TMPR\\[2\\]
+Trigger"]
     #[inline(always)]
     pub fn trig2(&self) -> TRIG2_R {
         TRIG2_R::new(((self.bits >> 2) & 0x01) != 0)
     }
-    #[doc = "Bit 3 - Status of TMPR\\[3\\] Trigger"]
+    #[doc = "Bit 3 - Status of TMPR\\[3\\]
+Trigger"]
     #[inline(always)]
     pub fn trig3(&self) -> TRIG3_R {
         TRIG3_R::new(((self.bits >> 3) & 0x01) != 0)

--- a/crates/tm4c129x/src/hib/tplog7.rs
+++ b/crates/tm4c129x/src/hib/tplog7.rs
@@ -11,22 +11,26 @@ pub type TRIG3_R = crate::R<bool, bool>;
 #[doc = "Reader of field `XOSC`"]
 pub type XOSC_R = crate::R<bool, bool>;
 impl R {
-    #[doc = "Bit 0 - Status of TMPR\\[0\\] Trigger"]
+    #[doc = "Bit 0 - Status of TMPR\\[0\\]
+Trigger"]
     #[inline(always)]
     pub fn trig0(&self) -> TRIG0_R {
         TRIG0_R::new((self.bits & 0x01) != 0)
     }
-    #[doc = "Bit 1 - Status of TMPR\\[1\\] Trigger"]
+    #[doc = "Bit 1 - Status of TMPR\\[1\\]
+Trigger"]
     #[inline(always)]
     pub fn trig1(&self) -> TRIG1_R {
         TRIG1_R::new(((self.bits >> 1) & 0x01) != 0)
     }
-    #[doc = "Bit 2 - Status of TMPR\\[2\\] Trigger"]
+    #[doc = "Bit 2 - Status of TMPR\\[2\\]
+Trigger"]
     #[inline(always)]
     pub fn trig2(&self) -> TRIG2_R {
         TRIG2_R::new(((self.bits >> 2) & 0x01) != 0)
     }
-    #[doc = "Bit 3 - Status of TMPR\\[3\\] Trigger"]
+    #[doc = "Bit 3 - Status of TMPR\\[3\\]
+Trigger"]
     #[inline(always)]
     pub fn trig3(&self) -> TRIG3_R {
         TRIG3_R::new(((self.bits >> 3) & 0x01) != 0)

--- a/crates/tm4c129x/src/hib/tpstat.rs
+++ b/crates/tm4c129x/src/hib/tpstat.rs
@@ -60,22 +60,19 @@ impl<'a> XOSCST_W<'a> {
 }
 #[doc = "Tamper Module Status\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum STATE_A {
     #[doc = "0: Tamper disabled"]
-    DISABLED,
+    DISABLED = 0,
     #[doc = "1: Tamper configured"]
-    CONFIGED,
+    CONFIGED = 1,
     #[doc = "2: Tamper pin event occurred"]
-    ERROR,
+    ERROR = 2,
 }
 impl From<STATE_A> for u8 {
     #[inline(always)]
     fn from(variant: STATE_A) -> Self {
-        match variant {
-            STATE_A::DISABLED => 0,
-            STATE_A::CONFIGED => 1,
-            STATE_A::ERROR => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `STATE`"]

--- a/crates/tm4c129x/src/i2c0.rs
+++ b/crates/tm4c129x/src/i2c0.rs
@@ -60,7 +60,7 @@ pub struct RegisterBlock {
     #[doc = "0xfc4 - I2C Peripheral Configuration"]
     pub pc: PC,
 }
-#[doc = "I2C Master Slave Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [msa](msa) module"]
+#[doc = "I2C Master Slave Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [msa](msa) module"]
 pub type MSA = crate::Reg<u32, _MSA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -71,7 +71,7 @@ impl crate::Readable for MSA {}
 impl crate::Writable for MSA {}
 #[doc = "I2C Master Slave Address"]
 pub mod msa;
-#[doc = "I2C Master Control/Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mcs](mcs) module"]
+#[doc = "I2C Master Control/Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mcs](mcs) module"]
 pub type MCS = crate::Reg<u32, _MCS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -82,7 +82,7 @@ impl crate::Readable for MCS {}
 impl crate::Writable for MCS {}
 #[doc = "I2C Master Control/Status"]
 pub mod mcs;
-#[doc = "I2C Master Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mdr](mdr) module"]
+#[doc = "I2C Master Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mdr](mdr) module"]
 pub type MDR = crate::Reg<u32, _MDR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -93,7 +93,7 @@ impl crate::Readable for MDR {}
 impl crate::Writable for MDR {}
 #[doc = "I2C Master Data"]
 pub mod mdr;
-#[doc = "I2C Master Timer Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mtpr](mtpr) module"]
+#[doc = "I2C Master Timer Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mtpr](mtpr) module"]
 pub type MTPR = crate::Reg<u32, _MTPR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -104,7 +104,7 @@ impl crate::Readable for MTPR {}
 impl crate::Writable for MTPR {}
 #[doc = "I2C Master Timer Period"]
 pub mod mtpr;
-#[doc = "I2C Master Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mimr](mimr) module"]
+#[doc = "I2C Master Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mimr](mimr) module"]
 pub type MIMR = crate::Reg<u32, _MIMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -115,7 +115,7 @@ impl crate::Readable for MIMR {}
 impl crate::Writable for MIMR {}
 #[doc = "I2C Master Interrupt Mask"]
 pub mod mimr;
-#[doc = "I2C Master Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mris](mris) module"]
+#[doc = "I2C Master Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mris](mris) module"]
 pub type MRIS = crate::Reg<u32, _MRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -124,7 +124,7 @@ pub struct _MRIS;
 impl crate::Readable for MRIS {}
 #[doc = "I2C Master Raw Interrupt Status"]
 pub mod mris;
-#[doc = "I2C Master Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mmis](mmis) module"]
+#[doc = "I2C Master Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mmis](mmis) module"]
 pub type MMIS = crate::Reg<u32, _MMIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -133,7 +133,7 @@ pub struct _MMIS;
 impl crate::Readable for MMIS {}
 #[doc = "I2C Master Masked Interrupt Status"]
 pub mod mmis;
-#[doc = "I2C Master Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [micr](micr) module"]
+#[doc = "I2C Master Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [micr](micr) module"]
 pub type MICR = crate::Reg<u32, _MICR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -142,7 +142,7 @@ pub struct _MICR;
 impl crate::Writable for MICR {}
 #[doc = "I2C Master Interrupt Clear"]
 pub mod micr;
-#[doc = "I2C Master Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mcr](mcr) module"]
+#[doc = "I2C Master Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mcr](mcr) module"]
 pub type MCR = crate::Reg<u32, _MCR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -153,7 +153,7 @@ impl crate::Readable for MCR {}
 impl crate::Writable for MCR {}
 #[doc = "I2C Master Configuration"]
 pub mod mcr;
-#[doc = "I2C Master Clock Low Timeout Count\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mclkocnt](mclkocnt) module"]
+#[doc = "I2C Master Clock Low Timeout Count\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mclkocnt](mclkocnt) module"]
 pub type MCLKOCNT = crate::Reg<u32, _MCLKOCNT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -164,7 +164,7 @@ impl crate::Readable for MCLKOCNT {}
 impl crate::Writable for MCLKOCNT {}
 #[doc = "I2C Master Clock Low Timeout Count"]
 pub mod mclkocnt;
-#[doc = "I2C Master Bus Monitor\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mbmon](mbmon) module"]
+#[doc = "I2C Master Bus Monitor\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mbmon](mbmon) module"]
 pub type MBMON = crate::Reg<u32, _MBMON>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -173,7 +173,7 @@ pub struct _MBMON;
 impl crate::Readable for MBMON {}
 #[doc = "I2C Master Bus Monitor"]
 pub mod mbmon;
-#[doc = "I2C Master Burst Length\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mblen](mblen) module"]
+#[doc = "I2C Master Burst Length\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mblen](mblen) module"]
 pub type MBLEN = crate::Reg<u32, _MBLEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -184,7 +184,7 @@ impl crate::Readable for MBLEN {}
 impl crate::Writable for MBLEN {}
 #[doc = "I2C Master Burst Length"]
 pub mod mblen;
-#[doc = "I2C Master Burst Count\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mbcnt](mbcnt) module"]
+#[doc = "I2C Master Burst Count\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mbcnt](mbcnt) module"]
 pub type MBCNT = crate::Reg<u32, _MBCNT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -193,7 +193,7 @@ pub struct _MBCNT;
 impl crate::Readable for MBCNT {}
 #[doc = "I2C Master Burst Count"]
 pub mod mbcnt;
-#[doc = "I2C Slave Own Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [soar](soar) module"]
+#[doc = "I2C Slave Own Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [soar](soar) module"]
 pub type SOAR = crate::Reg<u32, _SOAR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -204,7 +204,7 @@ impl crate::Readable for SOAR {}
 impl crate::Writable for SOAR {}
 #[doc = "I2C Slave Own Address"]
 pub mod soar;
-#[doc = "I2C Slave Control/Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scsr](scsr) module"]
+#[doc = "I2C Slave Control/Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scsr](scsr) module"]
 pub type SCSR = crate::Reg<u32, _SCSR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -213,7 +213,7 @@ pub struct _SCSR;
 impl crate::Readable for SCSR {}
 #[doc = "I2C Slave Control/Status"]
 pub mod scsr;
-#[doc = "I2C Slave Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sdr](sdr) module"]
+#[doc = "I2C Slave Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sdr](sdr) module"]
 pub type SDR = crate::Reg<u32, _SDR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -224,7 +224,7 @@ impl crate::Readable for SDR {}
 impl crate::Writable for SDR {}
 #[doc = "I2C Slave Data"]
 pub mod sdr;
-#[doc = "I2C Slave Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [simr](simr) module"]
+#[doc = "I2C Slave Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [simr](simr) module"]
 pub type SIMR = crate::Reg<u32, _SIMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -235,7 +235,7 @@ impl crate::Readable for SIMR {}
 impl crate::Writable for SIMR {}
 #[doc = "I2C Slave Interrupt Mask"]
 pub mod simr;
-#[doc = "I2C Slave Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sris](sris) module"]
+#[doc = "I2C Slave Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sris](sris) module"]
 pub type SRIS = crate::Reg<u32, _SRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -244,7 +244,7 @@ pub struct _SRIS;
 impl crate::Readable for SRIS {}
 #[doc = "I2C Slave Raw Interrupt Status"]
 pub mod sris;
-#[doc = "I2C Slave Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [smis](smis) module"]
+#[doc = "I2C Slave Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [smis](smis) module"]
 pub type SMIS = crate::Reg<u32, _SMIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -253,7 +253,7 @@ pub struct _SMIS;
 impl crate::Readable for SMIS {}
 #[doc = "I2C Slave Masked Interrupt Status"]
 pub mod smis;
-#[doc = "I2C Slave Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sicr](sicr) module"]
+#[doc = "I2C Slave Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sicr](sicr) module"]
 pub type SICR = crate::Reg<u32, _SICR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -262,7 +262,7 @@ pub struct _SICR;
 impl crate::Writable for SICR {}
 #[doc = "I2C Slave Interrupt Clear"]
 pub mod sicr;
-#[doc = "I2C Slave Own Address 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [soar2](soar2) module"]
+#[doc = "I2C Slave Own Address 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [soar2](soar2) module"]
 pub type SOAR2 = crate::Reg<u32, _SOAR2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -273,7 +273,7 @@ impl crate::Readable for SOAR2 {}
 impl crate::Writable for SOAR2 {}
 #[doc = "I2C Slave Own Address 2"]
 pub mod soar2;
-#[doc = "I2C Slave ACK Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sackctl](sackctl) module"]
+#[doc = "I2C Slave ACK Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sackctl](sackctl) module"]
 pub type SACKCTL = crate::Reg<u32, _SACKCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -284,7 +284,7 @@ impl crate::Readable for SACKCTL {}
 impl crate::Writable for SACKCTL {}
 #[doc = "I2C Slave ACK Control"]
 pub mod sackctl;
-#[doc = "I2C FIFO Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifodata](fifodata) module"]
+#[doc = "I2C FIFO Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifodata](fifodata) module"]
 pub type FIFODATA = crate::Reg<u32, _FIFODATA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -295,7 +295,7 @@ impl crate::Readable for FIFODATA {}
 impl crate::Writable for FIFODATA {}
 #[doc = "I2C FIFO Data"]
 pub mod fifodata;
-#[doc = "I2C FIFO Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifoctl](fifoctl) module"]
+#[doc = "I2C FIFO Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifoctl](fifoctl) module"]
 pub type FIFOCTL = crate::Reg<u32, _FIFOCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -306,7 +306,7 @@ impl crate::Readable for FIFOCTL {}
 impl crate::Writable for FIFOCTL {}
 #[doc = "I2C FIFO Control"]
 pub mod fifoctl;
-#[doc = "I2C FIFO Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifostatus](fifostatus) module"]
+#[doc = "I2C FIFO Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifostatus](fifostatus) module"]
 pub type FIFOSTATUS = crate::Reg<u32, _FIFOSTATUS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -315,7 +315,7 @@ pub struct _FIFOSTATUS;
 impl crate::Readable for FIFOSTATUS {}
 #[doc = "I2C FIFO Status"]
 pub mod fifostatus;
-#[doc = "I2C Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "I2C Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -324,7 +324,7 @@ pub struct _PP;
 impl crate::Readable for PP {}
 #[doc = "I2C Peripheral Properties"]
 pub mod pp;
-#[doc = "I2C Peripheral Configuration\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pc](pc) module"]
+#[doc = "I2C Peripheral Configuration\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pc](pc) module"]
 pub type PC = crate::Reg<u32, _PC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/i2c0/mtpr.rs
+++ b/crates/tm4c129x/src/i2c0/mtpr.rs
@@ -50,37 +50,29 @@ impl<'a> HS_W<'a> {
 }
 #[doc = "Glitch Suppression Pulse Width\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PULSEL_A {
     #[doc = "0: Bypass"]
-    BYPASS,
+    BYPASS = 0,
     #[doc = "1: 1 clock"]
-    _1,
+    _1 = 1,
     #[doc = "2: 2 clocks"]
-    _2,
+    _2 = 2,
     #[doc = "3: 3 clocks"]
-    _3,
+    _3 = 3,
     #[doc = "4: 4 clocks"]
-    _4,
+    _4 = 4,
     #[doc = "5: 8 clocks"]
-    _8,
+    _8 = 5,
     #[doc = "6: 16 clocks"]
-    _16,
+    _16 = 6,
     #[doc = "7: 31 clocks"]
-    _31,
+    _31 = 7,
 }
 impl From<PULSEL_A> for u8 {
     #[inline(always)]
     fn from(variant: PULSEL_A) -> Self {
-        match variant {
-            PULSEL_A::BYPASS => 0,
-            PULSEL_A::_1 => 1,
-            PULSEL_A::_2 => 2,
-            PULSEL_A::_3 => 3,
-            PULSEL_A::_4 => 4,
-            PULSEL_A::_8 => 5,
-            PULSEL_A::_16 => 6,
-            PULSEL_A::_31 => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PULSEL`"]

--- a/crates/tm4c129x/src/lib.rs
+++ b/crates/tm4c129x/src/lib.rs
@@ -1,7 +1,25 @@
-#![doc = "Peripheral access API for TM4C129X microcontrollers (generated using svd2rust v0.16.1)\n\nYou can find an overview of the API [here].\n\n[here]: https://docs.rs/svd2rust/0.16.1/svd2rust/#peripheral-api"]
+#![doc = "Peripheral access API for TM4C129X microcontrollers (generated using svd2rust v0.17.0)\n\nYou can find an overview of the API [here].\n\n[here]: https://docs.rs/svd2rust/0.17.0/svd2rust/#peripheral-api"]
+#![deny(const_err)]
+#![deny(dead_code)]
+#![deny(improper_ctypes)]
+#![deny(legacy_directory_ownership)]
 #![deny(missing_docs)]
-#![deny(warnings)]
+#![deny(no_mangle_generic_items)]
+#![deny(non_shorthand_field_patterns)]
+#![deny(overflowing_literals)]
+#![deny(path_statements)]
+#![deny(patterns_in_fns_without_body)]
+#![deny(plugin_as_library)]
+#![deny(private_in_public)]
+#![deny(safe_extern_statics)]
+#![deny(unconditional_recursion)]
+#![deny(unions_with_drop_fields)]
+#![deny(unused_allocation)]
+#![deny(unused_comparisons)]
+#![deny(unused_parens)]
+#![deny(while_true)]
 #![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
 #![no_std]
 extern crate bare_metal;
 extern crate cortex_m;
@@ -10,6 +28,8 @@ extern crate cortex_m_rt;
 extern crate vcell;
 use core::marker::PhantomData;
 use core::ops::Deref;
+#[doc = r"Number available in the NVIC for configuring priority"]
+pub const NVIC_PRIO_BITS: u8 = 3;
 #[cfg(feature = "rt")]
 extern "C" {
     fn GPIOA();
@@ -243,328 +263,223 @@ pub static __INTERRUPTS: [Vector; 112] = [
 ];
 #[doc = r"Enumeration of all the interrupts"]
 #[derive(Copy, Clone, Debug)]
+#[repr(u8)]
 pub enum Interrupt {
     #[doc = "0 - GPIO Port A"]
-    GPIOA,
+    GPIOA = 0,
     #[doc = "1 - GPIO Port B"]
-    GPIOB,
+    GPIOB = 1,
     #[doc = "2 - GPIO Port C"]
-    GPIOC,
+    GPIOC = 2,
     #[doc = "3 - GPIO Port D"]
-    GPIOD,
+    GPIOD = 3,
     #[doc = "4 - GPIO Port E"]
-    GPIOE,
+    GPIOE = 4,
     #[doc = "5 - UART0"]
-    UART0,
+    UART0 = 5,
     #[doc = "6 - UART1"]
-    UART1,
+    UART1 = 6,
     #[doc = "7 - SSI0"]
-    SSI0,
+    SSI0 = 7,
     #[doc = "8 - I2C0"]
-    I2C0,
+    I2C0 = 8,
     #[doc = "9 - PWM Fault"]
-    PWM0_FAULT,
+    PWM0_FAULT = 9,
     #[doc = "10 - PWM Generator 0"]
-    PWM0_0,
+    PWM0_0 = 10,
     #[doc = "11 - PWM Generator 1"]
-    PWM0_1,
+    PWM0_1 = 11,
     #[doc = "12 - PWM Generator 2"]
-    PWM0_2,
+    PWM0_2 = 12,
     #[doc = "13 - QEI0"]
-    QEI0,
+    QEI0 = 13,
     #[doc = "14 - ADC0 Sequence 0"]
-    ADC0SS0,
+    ADC0SS0 = 14,
     #[doc = "15 - ADC0 Sequence 1"]
-    ADC0SS1,
+    ADC0SS1 = 15,
     #[doc = "16 - ADC0 Sequence 2"]
-    ADC0SS2,
+    ADC0SS2 = 16,
     #[doc = "17 - ADC0 Sequence 3"]
-    ADC0SS3,
+    ADC0SS3 = 17,
     #[doc = "18 - Watchdog Timers 0 and 1"]
-    WATCHDOG,
+    WATCHDOG = 18,
     #[doc = "19 - 16/32-Bit Timer 0A"]
-    TIMER0A,
+    TIMER0A = 19,
     #[doc = "20 - 16/32-Bit Timer 0B"]
-    TIMER0B,
+    TIMER0B = 20,
     #[doc = "21 - 16/32-Bit Timer 1A"]
-    TIMER1A,
+    TIMER1A = 21,
     #[doc = "22 - 16/32-Bit Timer 1B"]
-    TIMER1B,
+    TIMER1B = 22,
     #[doc = "23 - 16/32-Bit Timer 2A"]
-    TIMER2A,
+    TIMER2A = 23,
     #[doc = "24 - 16/32-Bit Timer 2B"]
-    TIMER2B,
+    TIMER2B = 24,
     #[doc = "25 - Analog Comparator 0"]
-    COMP0,
+    COMP0 = 25,
     #[doc = "26 - Analog Comparator 1"]
-    COMP1,
+    COMP1 = 26,
     #[doc = "27 - Analog Comparator 2"]
-    COMP2,
+    COMP2 = 27,
     #[doc = "28 - System Control"]
-    SYSCTL,
+    SYSCTL = 28,
     #[doc = "29 - Flash Memory Control"]
-    FLASH,
+    FLASH = 29,
     #[doc = "30 - GPIO Port F"]
-    GPIOF,
+    GPIOF = 30,
     #[doc = "31 - GPIO Port G"]
-    GPIOG,
+    GPIOG = 31,
     #[doc = "32 - GPIO Port H"]
-    GPIOH,
+    GPIOH = 32,
     #[doc = "33 - UART2"]
-    UART2,
+    UART2 = 33,
     #[doc = "34 - SSI1"]
-    SSI1,
+    SSI1 = 34,
     #[doc = "35 - 16/32-Bit Timer 3A"]
-    TIMER3A,
+    TIMER3A = 35,
     #[doc = "36 - 16/32-Bit Timer 3B"]
-    TIMER3B,
+    TIMER3B = 36,
     #[doc = "37 - I2C1"]
-    I2C1,
+    I2C1 = 37,
     #[doc = "38 - CAN 0"]
-    CAN0,
+    CAN0 = 38,
     #[doc = "39 - CAN1"]
-    CAN1,
+    CAN1 = 39,
     #[doc = "40 - Ethernet MAC"]
-    EMAC0,
+    EMAC0 = 40,
     #[doc = "41 - HIB (Power Island)"]
-    HIBERNATE,
+    HIBERNATE = 41,
     #[doc = "42 - USB MAC"]
-    USB0,
+    USB0 = 42,
     #[doc = "43 - PWM Generator 3"]
-    PWM0_3,
+    PWM0_3 = 43,
     #[doc = "44 - uDMA 0 Software"]
-    UDMA,
+    UDMA = 44,
     #[doc = "45 - uDMA 0 Error"]
-    UDMAERR,
+    UDMAERR = 45,
     #[doc = "46 - ADC1 Sequence 0"]
-    ADC1SS0,
+    ADC1SS0 = 46,
     #[doc = "47 - ADC1 Sequence 1"]
-    ADC1SS1,
+    ADC1SS1 = 47,
     #[doc = "48 - ADC1 Sequence 2"]
-    ADC1SS2,
+    ADC1SS2 = 48,
     #[doc = "49 - ADC1 Sequence 3"]
-    ADC1SS3,
+    ADC1SS3 = 49,
     #[doc = "50 - EPI 0"]
-    EPI0,
+    EPI0 = 50,
     #[doc = "51 - GPIO Port J"]
-    GPIOJ,
+    GPIOJ = 51,
     #[doc = "52 - GPIO Port K"]
-    GPIOK,
+    GPIOK = 52,
     #[doc = "53 - GPIO Port L"]
-    GPIOL,
+    GPIOL = 53,
     #[doc = "54 - SSI 2"]
-    SSI2,
+    SSI2 = 54,
     #[doc = "55 - SSI 3"]
-    SSI3,
+    SSI3 = 55,
     #[doc = "56 - UART 3"]
-    UART3,
+    UART3 = 56,
     #[doc = "57 - UART 4"]
-    UART4,
+    UART4 = 57,
     #[doc = "58 - UART 5"]
-    UART5,
+    UART5 = 58,
     #[doc = "59 - UART 6"]
-    UART6,
+    UART6 = 59,
     #[doc = "60 - UART 7"]
-    UART7,
+    UART7 = 60,
     #[doc = "61 - I2C 2"]
-    I2C2,
+    I2C2 = 61,
     #[doc = "62 - I2C 3"]
-    I2C3,
+    I2C3 = 62,
     #[doc = "63 - Timer 4A"]
-    TIMER4A,
+    TIMER4A = 63,
     #[doc = "64 - Timer 4B"]
-    TIMER4B,
+    TIMER4B = 64,
     #[doc = "65 - Timer 5A"]
-    TIMER5A,
+    TIMER5A = 65,
     #[doc = "66 - Timer 5B"]
-    TIMER5B,
+    TIMER5B = 66,
     #[doc = "67 - Floating-Point Exception (imprecise)"]
-    SYSEXC,
+    SYSEXC = 67,
     #[doc = "70 - I2C 4"]
-    I2C4,
+    I2C4 = 70,
     #[doc = "71 - I2C 5"]
-    I2C5,
+    I2C5 = 71,
     #[doc = "72 - GPIO Port M"]
-    GPIOM,
+    GPIOM = 72,
     #[doc = "73 - GPIO Port N"]
-    GPION,
+    GPION = 73,
     #[doc = "75 - Tamper"]
-    TAMPER0,
+    TAMPER0 = 75,
     #[doc = "76 - GPIO Port P (Summary or P0)"]
-    GPIOP0,
+    GPIOP0 = 76,
     #[doc = "77 - GPIO Port P1"]
-    GPIOP1,
+    GPIOP1 = 77,
     #[doc = "78 - GPIO Port P2"]
-    GPIOP2,
+    GPIOP2 = 78,
     #[doc = "79 - GPIO Port P3"]
-    GPIOP3,
+    GPIOP3 = 79,
     #[doc = "80 - GPIO Port P4"]
-    GPIOP4,
+    GPIOP4 = 80,
     #[doc = "81 - GPIO Port P5"]
-    GPIOP5,
+    GPIOP5 = 81,
     #[doc = "82 - GPIO Port P6"]
-    GPIOP6,
+    GPIOP6 = 82,
     #[doc = "83 - GPIO Port P7"]
-    GPIOP7,
+    GPIOP7 = 83,
     #[doc = "84 - GPIO Port Q (Summary or Q0)"]
-    GPIOQ0,
+    GPIOQ0 = 84,
     #[doc = "85 - GPIO Port Q1"]
-    GPIOQ1,
+    GPIOQ1 = 85,
     #[doc = "86 - GPIO Port Q2"]
-    GPIOQ2,
+    GPIOQ2 = 86,
     #[doc = "87 - GPIO Port Q3"]
-    GPIOQ3,
+    GPIOQ3 = 87,
     #[doc = "88 - GPIO Port Q4"]
-    GPIOQ4,
+    GPIOQ4 = 88,
     #[doc = "89 - GPIO Port Q5"]
-    GPIOQ5,
+    GPIOQ5 = 89,
     #[doc = "90 - GPIO Port Q6"]
-    GPIOQ6,
+    GPIOQ6 = 90,
     #[doc = "91 - GPIO Port Q7"]
-    GPIOQ7,
+    GPIOQ7 = 91,
     #[doc = "92 - GPIO Port R"]
-    GPIOR,
+    GPIOR = 92,
     #[doc = "93 - GPIO Port S"]
-    GPIOS,
+    GPIOS = 93,
     #[doc = "94 - SHA/MD5"]
-    SHA0,
+    SHA0 = 94,
     #[doc = "95 - AES"]
-    AES0,
+    AES0 = 95,
     #[doc = "96 - DES"]
-    DES0,
+    DES0 = 96,
     #[doc = "97 - LCD"]
-    LCD0,
+    LCD0 = 97,
     #[doc = "98 - 16/32-Bit Timer 6A"]
-    TIMER6A,
+    TIMER6A = 98,
     #[doc = "99 - 16/32-Bit Timer 6B"]
-    TIMER6B,
+    TIMER6B = 99,
     #[doc = "100 - 16/32-Bit Timer 7A"]
-    TIMER7A,
+    TIMER7A = 100,
     #[doc = "101 - 16/32-Bit Timer 7B"]
-    TIMER7B,
+    TIMER7B = 101,
     #[doc = "102 - I2C 6"]
-    I2C6,
+    I2C6 = 102,
     #[doc = "103 - I2C 7"]
-    I2C7,
+    I2C7 = 103,
     #[doc = "105 - 1-Wire"]
-    ONEWIRE0,
+    ONEWIRE0 = 105,
     #[doc = "109 - I2C 8"]
-    I2C8,
+    I2C8 = 109,
     #[doc = "110 - I2C 9"]
-    I2C9,
+    I2C9 = 110,
     #[doc = "111 - GPIO T"]
-    GPIOT,
+    GPIOT = 111,
 }
 unsafe impl bare_metal::Nr for Interrupt {
-    #[inline]
+    #[inline(always)]
     fn nr(&self) -> u8 {
-        match *self {
-            Interrupt::GPIOA => 0,
-            Interrupt::GPIOB => 1,
-            Interrupt::GPIOC => 2,
-            Interrupt::GPIOD => 3,
-            Interrupt::GPIOE => 4,
-            Interrupt::UART0 => 5,
-            Interrupt::UART1 => 6,
-            Interrupt::SSI0 => 7,
-            Interrupt::I2C0 => 8,
-            Interrupt::PWM0_FAULT => 9,
-            Interrupt::PWM0_0 => 10,
-            Interrupt::PWM0_1 => 11,
-            Interrupt::PWM0_2 => 12,
-            Interrupt::QEI0 => 13,
-            Interrupt::ADC0SS0 => 14,
-            Interrupt::ADC0SS1 => 15,
-            Interrupt::ADC0SS2 => 16,
-            Interrupt::ADC0SS3 => 17,
-            Interrupt::WATCHDOG => 18,
-            Interrupt::TIMER0A => 19,
-            Interrupt::TIMER0B => 20,
-            Interrupt::TIMER1A => 21,
-            Interrupt::TIMER1B => 22,
-            Interrupt::TIMER2A => 23,
-            Interrupt::TIMER2B => 24,
-            Interrupt::COMP0 => 25,
-            Interrupt::COMP1 => 26,
-            Interrupt::COMP2 => 27,
-            Interrupt::SYSCTL => 28,
-            Interrupt::FLASH => 29,
-            Interrupt::GPIOF => 30,
-            Interrupt::GPIOG => 31,
-            Interrupt::GPIOH => 32,
-            Interrupt::UART2 => 33,
-            Interrupt::SSI1 => 34,
-            Interrupt::TIMER3A => 35,
-            Interrupt::TIMER3B => 36,
-            Interrupt::I2C1 => 37,
-            Interrupt::CAN0 => 38,
-            Interrupt::CAN1 => 39,
-            Interrupt::EMAC0 => 40,
-            Interrupt::HIBERNATE => 41,
-            Interrupt::USB0 => 42,
-            Interrupt::PWM0_3 => 43,
-            Interrupt::UDMA => 44,
-            Interrupt::UDMAERR => 45,
-            Interrupt::ADC1SS0 => 46,
-            Interrupt::ADC1SS1 => 47,
-            Interrupt::ADC1SS2 => 48,
-            Interrupt::ADC1SS3 => 49,
-            Interrupt::EPI0 => 50,
-            Interrupt::GPIOJ => 51,
-            Interrupt::GPIOK => 52,
-            Interrupt::GPIOL => 53,
-            Interrupt::SSI2 => 54,
-            Interrupt::SSI3 => 55,
-            Interrupt::UART3 => 56,
-            Interrupt::UART4 => 57,
-            Interrupt::UART5 => 58,
-            Interrupt::UART6 => 59,
-            Interrupt::UART7 => 60,
-            Interrupt::I2C2 => 61,
-            Interrupt::I2C3 => 62,
-            Interrupt::TIMER4A => 63,
-            Interrupt::TIMER4B => 64,
-            Interrupt::TIMER5A => 65,
-            Interrupt::TIMER5B => 66,
-            Interrupt::SYSEXC => 67,
-            Interrupt::I2C4 => 70,
-            Interrupt::I2C5 => 71,
-            Interrupt::GPIOM => 72,
-            Interrupt::GPION => 73,
-            Interrupt::TAMPER0 => 75,
-            Interrupt::GPIOP0 => 76,
-            Interrupt::GPIOP1 => 77,
-            Interrupt::GPIOP2 => 78,
-            Interrupt::GPIOP3 => 79,
-            Interrupt::GPIOP4 => 80,
-            Interrupt::GPIOP5 => 81,
-            Interrupt::GPIOP6 => 82,
-            Interrupt::GPIOP7 => 83,
-            Interrupt::GPIOQ0 => 84,
-            Interrupt::GPIOQ1 => 85,
-            Interrupt::GPIOQ2 => 86,
-            Interrupt::GPIOQ3 => 87,
-            Interrupt::GPIOQ4 => 88,
-            Interrupt::GPIOQ5 => 89,
-            Interrupt::GPIOQ6 => 90,
-            Interrupt::GPIOQ7 => 91,
-            Interrupt::GPIOR => 92,
-            Interrupt::GPIOS => 93,
-            Interrupt::SHA0 => 94,
-            Interrupt::AES0 => 95,
-            Interrupt::DES0 => 96,
-            Interrupt::LCD0 => 97,
-            Interrupt::TIMER6A => 98,
-            Interrupt::TIMER6B => 99,
-            Interrupt::TIMER7A => 100,
-            Interrupt::TIMER7B => 101,
-            Interrupt::I2C6 => 102,
-            Interrupt::I2C7 => 103,
-            Interrupt::ONEWIRE0 => 105,
-            Interrupt::I2C8 => 109,
-            Interrupt::I2C9 => 110,
-            Interrupt::GPIOT => 111,
-        }
+        *self as u8
     }
 }
 #[cfg(feature = "rt")]
@@ -591,6 +506,7 @@ impl WATCHDOG0 {
 }
 impl Deref for WATCHDOG0 {
     type Target = watchdog0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*WATCHDOG0::ptr() }
     }
@@ -611,6 +527,7 @@ impl WATCHDOG1 {
 }
 impl Deref for WATCHDOG1 {
     type Target = watchdog0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*WATCHDOG1::ptr() }
     }
@@ -629,6 +546,7 @@ impl SSI0 {
 }
 impl Deref for SSI0 {
     type Target = ssi0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*SSI0::ptr() }
     }
@@ -649,6 +567,7 @@ impl SSI1 {
 }
 impl Deref for SSI1 {
     type Target = ssi0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*SSI1::ptr() }
     }
@@ -667,6 +586,7 @@ impl SSI2 {
 }
 impl Deref for SSI2 {
     type Target = ssi0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*SSI2::ptr() }
     }
@@ -685,6 +605,7 @@ impl SSI3 {
 }
 impl Deref for SSI3 {
     type Target = ssi0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*SSI3::ptr() }
     }
@@ -703,6 +624,7 @@ impl UART0 {
 }
 impl Deref for UART0 {
     type Target = uart0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UART0::ptr() }
     }
@@ -723,6 +645,7 @@ impl UART1 {
 }
 impl Deref for UART1 {
     type Target = uart0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UART1::ptr() }
     }
@@ -741,6 +664,7 @@ impl UART2 {
 }
 impl Deref for UART2 {
     type Target = uart0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UART2::ptr() }
     }
@@ -759,6 +683,7 @@ impl UART3 {
 }
 impl Deref for UART3 {
     type Target = uart0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UART3::ptr() }
     }
@@ -777,6 +702,7 @@ impl UART4 {
 }
 impl Deref for UART4 {
     type Target = uart0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UART4::ptr() }
     }
@@ -795,6 +721,7 @@ impl UART5 {
 }
 impl Deref for UART5 {
     type Target = uart0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UART5::ptr() }
     }
@@ -813,6 +740,7 @@ impl UART6 {
 }
 impl Deref for UART6 {
     type Target = uart0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UART6::ptr() }
     }
@@ -831,6 +759,7 @@ impl UART7 {
 }
 impl Deref for UART7 {
     type Target = uart0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UART7::ptr() }
     }
@@ -849,6 +778,7 @@ impl I2C0 {
 }
 impl Deref for I2C0 {
     type Target = i2c0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*I2C0::ptr() }
     }
@@ -869,6 +799,7 @@ impl I2C1 {
 }
 impl Deref for I2C1 {
     type Target = i2c0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*I2C1::ptr() }
     }
@@ -887,6 +818,7 @@ impl I2C2 {
 }
 impl Deref for I2C2 {
     type Target = i2c0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*I2C2::ptr() }
     }
@@ -905,6 +837,7 @@ impl I2C3 {
 }
 impl Deref for I2C3 {
     type Target = i2c0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*I2C3::ptr() }
     }
@@ -923,6 +856,7 @@ impl PWM0 {
 }
 impl Deref for PWM0 {
     type Target = pwm0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*PWM0::ptr() }
     }
@@ -943,6 +877,7 @@ impl QEI0 {
 }
 impl Deref for QEI0 {
     type Target = qei0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*QEI0::ptr() }
     }
@@ -963,6 +898,7 @@ impl TIMER0 {
 }
 impl Deref for TIMER0 {
     type Target = timer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*TIMER0::ptr() }
     }
@@ -983,6 +919,7 @@ impl TIMER1 {
 }
 impl Deref for TIMER1 {
     type Target = timer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*TIMER1::ptr() }
     }
@@ -1001,6 +938,7 @@ impl TIMER2 {
 }
 impl Deref for TIMER2 {
     type Target = timer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*TIMER2::ptr() }
     }
@@ -1019,6 +957,7 @@ impl TIMER3 {
 }
 impl Deref for TIMER3 {
     type Target = timer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*TIMER3::ptr() }
     }
@@ -1037,6 +976,7 @@ impl TIMER4 {
 }
 impl Deref for TIMER4 {
     type Target = timer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*TIMER4::ptr() }
     }
@@ -1055,6 +995,7 @@ impl TIMER5 {
 }
 impl Deref for TIMER5 {
     type Target = timer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*TIMER5::ptr() }
     }
@@ -1073,6 +1014,7 @@ impl ADC0 {
 }
 impl Deref for ADC0 {
     type Target = adc0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*ADC0::ptr() }
     }
@@ -1093,6 +1035,7 @@ impl ADC1 {
 }
 impl Deref for ADC1 {
     type Target = adc0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*ADC1::ptr() }
     }
@@ -1111,6 +1054,7 @@ impl COMP {
 }
 impl Deref for COMP {
     type Target = comp::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*COMP::ptr() }
     }
@@ -1131,6 +1075,7 @@ impl CAN0 {
 }
 impl Deref for CAN0 {
     type Target = can0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*CAN0::ptr() }
     }
@@ -1151,6 +1096,7 @@ impl CAN1 {
 }
 impl Deref for CAN1 {
     type Target = can0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*CAN1::ptr() }
     }
@@ -1169,6 +1115,7 @@ impl USB0 {
 }
 impl Deref for USB0 {
     type Target = usb0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*USB0::ptr() }
     }
@@ -1189,6 +1136,7 @@ impl GPIO_PORTA_AHB {
 }
 impl Deref for GPIO_PORTA_AHB {
     type Target = gpio_porta_ahb::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTA_AHB::ptr() }
     }
@@ -1209,6 +1157,7 @@ impl GPIO_PORTB_AHB {
 }
 impl Deref for GPIO_PORTB_AHB {
     type Target = gpio_porta_ahb::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTB_AHB::ptr() }
     }
@@ -1227,6 +1176,7 @@ impl GPIO_PORTC_AHB {
 }
 impl Deref for GPIO_PORTC_AHB {
     type Target = gpio_porta_ahb::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTC_AHB::ptr() }
     }
@@ -1245,6 +1195,7 @@ impl GPIO_PORTD_AHB {
 }
 impl Deref for GPIO_PORTD_AHB {
     type Target = gpio_porta_ahb::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTD_AHB::ptr() }
     }
@@ -1263,6 +1214,7 @@ impl GPIO_PORTE_AHB {
 }
 impl Deref for GPIO_PORTE_AHB {
     type Target = gpio_porta_ahb::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTE_AHB::ptr() }
     }
@@ -1281,6 +1233,7 @@ impl GPIO_PORTF_AHB {
 }
 impl Deref for GPIO_PORTF_AHB {
     type Target = gpio_porta_ahb::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTF_AHB::ptr() }
     }
@@ -1299,6 +1252,7 @@ impl GPIO_PORTG_AHB {
 }
 impl Deref for GPIO_PORTG_AHB {
     type Target = gpio_porta_ahb::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTG_AHB::ptr() }
     }
@@ -1317,6 +1271,7 @@ impl GPIO_PORTH_AHB {
 }
 impl Deref for GPIO_PORTH_AHB {
     type Target = gpio_porta_ahb::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTH_AHB::ptr() }
     }
@@ -1335,6 +1290,7 @@ impl GPIO_PORTJ_AHB {
 }
 impl Deref for GPIO_PORTJ_AHB {
     type Target = gpio_porta_ahb::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTJ_AHB::ptr() }
     }
@@ -1353,6 +1309,7 @@ impl GPIO_PORTK {
 }
 impl Deref for GPIO_PORTK {
     type Target = gpio_porta_ahb::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTK::ptr() }
     }
@@ -1371,6 +1328,7 @@ impl GPIO_PORTL {
 }
 impl Deref for GPIO_PORTL {
     type Target = gpio_porta_ahb::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTL::ptr() }
     }
@@ -1389,6 +1347,7 @@ impl GPIO_PORTM {
 }
 impl Deref for GPIO_PORTM {
     type Target = gpio_porta_ahb::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTM::ptr() }
     }
@@ -1407,6 +1366,7 @@ impl GPIO_PORTN {
 }
 impl Deref for GPIO_PORTN {
     type Target = gpio_porta_ahb::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTN::ptr() }
     }
@@ -1425,6 +1385,7 @@ impl GPIO_PORTP {
 }
 impl Deref for GPIO_PORTP {
     type Target = gpio_porta_ahb::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTP::ptr() }
     }
@@ -1443,6 +1404,7 @@ impl GPIO_PORTQ {
 }
 impl Deref for GPIO_PORTQ {
     type Target = gpio_porta_ahb::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*GPIO_PORTQ::ptr() }
     }
@@ -1461,6 +1423,7 @@ impl EEPROM {
 }
 impl Deref for EEPROM {
     type Target = eeprom::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*EEPROM::ptr() }
     }
@@ -1481,6 +1444,7 @@ impl I2C8 {
 }
 impl Deref for I2C8 {
     type Target = i2c0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*I2C8::ptr() }
     }
@@ -1499,6 +1463,7 @@ impl I2C9 {
 }
 impl Deref for I2C9 {
     type Target = i2c0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*I2C9::ptr() }
     }
@@ -1517,6 +1482,7 @@ impl I2C4 {
 }
 impl Deref for I2C4 {
     type Target = i2c0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*I2C4::ptr() }
     }
@@ -1535,6 +1501,7 @@ impl I2C5 {
 }
 impl Deref for I2C5 {
     type Target = i2c0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*I2C5::ptr() }
     }
@@ -1553,6 +1520,7 @@ impl I2C6 {
 }
 impl Deref for I2C6 {
     type Target = i2c0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*I2C6::ptr() }
     }
@@ -1571,6 +1539,7 @@ impl I2C7 {
 }
 impl Deref for I2C7 {
     type Target = i2c0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*I2C7::ptr() }
     }
@@ -1589,6 +1558,7 @@ impl EPI0 {
 }
 impl Deref for EPI0 {
     type Target = epi0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*EPI0::ptr() }
     }
@@ -1609,6 +1579,7 @@ impl TIMER6 {
 }
 impl Deref for TIMER6 {
     type Target = timer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*TIMER6::ptr() }
     }
@@ -1627,6 +1598,7 @@ impl TIMER7 {
 }
 impl Deref for TIMER7 {
     type Target = timer0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*TIMER7::ptr() }
     }
@@ -1645,6 +1617,7 @@ impl EMAC0 {
 }
 impl Deref for EMAC0 {
     type Target = emac0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*EMAC0::ptr() }
     }
@@ -1665,6 +1638,7 @@ impl SYSEXC {
 }
 impl Deref for SYSEXC {
     type Target = sysexc::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*SYSEXC::ptr() }
     }
@@ -1685,6 +1659,7 @@ impl HIB {
 }
 impl Deref for HIB {
     type Target = hib::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*HIB::ptr() }
     }
@@ -1705,6 +1680,7 @@ impl FLASH_CTRL {
 }
 impl Deref for FLASH_CTRL {
     type Target = flash_ctrl::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*FLASH_CTRL::ptr() }
     }
@@ -1725,6 +1701,7 @@ impl SYSCTL {
 }
 impl Deref for SYSCTL {
     type Target = sysctl::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*SYSCTL::ptr() }
     }
@@ -1745,6 +1722,7 @@ impl UDMA {
 }
 impl Deref for UDMA {
     type Target = udma::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*UDMA::ptr() }
     }
@@ -1765,6 +1743,7 @@ impl CCM0 {
 }
 impl Deref for CCM0 {
     type Target = ccm0::RegisterBlock;
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*CCM0::ptr() }
     }
@@ -1912,6 +1891,7 @@ impl Peripherals {
         cortex_m::interrupt::free(|_| if unsafe { DEVICE_PERIPHERALS } { None } else { Some(unsafe { Peripherals::steal() }) })
     }
     #[doc = r"Unchecked version of `Peripherals::take`"]
+    #[inline]
     pub unsafe fn steal() -> Self {
         DEVICE_PERIPHERALS = true;
         Peripherals {

--- a/crates/tm4c129x/src/pwm0.rs
+++ b/crates/tm4c129x/src/pwm0.rs
@@ -187,7 +187,7 @@ pub struct RegisterBlock {
     #[doc = "0xfc8 - PWM Clock Configuration"]
     pub cc: CC,
 }
-#[doc = "PWM Master Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctl](ctl) module"]
+#[doc = "PWM Master Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctl](ctl) module"]
 pub type CTL = crate::Reg<u32, _CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -198,7 +198,7 @@ impl crate::Readable for CTL {}
 impl crate::Writable for CTL {}
 #[doc = "PWM Master Control"]
 pub mod ctl;
-#[doc = "PWM Time Base Sync\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sync](sync) module"]
+#[doc = "PWM Time Base Sync\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sync](sync) module"]
 pub type SYNC = crate::Reg<u32, _SYNC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -209,7 +209,7 @@ impl crate::Readable for SYNC {}
 impl crate::Writable for SYNC {}
 #[doc = "PWM Time Base Sync"]
 pub mod sync;
-#[doc = "PWM Output Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [enable](enable) module"]
+#[doc = "PWM Output Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [enable](enable) module"]
 pub type ENABLE = crate::Reg<u32, _ENABLE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -220,7 +220,7 @@ impl crate::Readable for ENABLE {}
 impl crate::Writable for ENABLE {}
 #[doc = "PWM Output Enable"]
 pub mod enable;
-#[doc = "PWM Output Inversion\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [invert](invert) module"]
+#[doc = "PWM Output Inversion\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [invert](invert) module"]
 pub type INVERT = crate::Reg<u32, _INVERT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -231,7 +231,7 @@ impl crate::Readable for INVERT {}
 impl crate::Writable for INVERT {}
 #[doc = "PWM Output Inversion"]
 pub mod invert;
-#[doc = "PWM Output Fault\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fault](fault) module"]
+#[doc = "PWM Output Fault\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fault](fault) module"]
 pub type FAULT = crate::Reg<u32, _FAULT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -242,7 +242,7 @@ impl crate::Readable for FAULT {}
 impl crate::Writable for FAULT {}
 #[doc = "PWM Output Fault"]
 pub mod fault;
-#[doc = "PWM Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [inten](inten) module"]
+#[doc = "PWM Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [inten](inten) module"]
 pub type INTEN = crate::Reg<u32, _INTEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -253,7 +253,7 @@ impl crate::Readable for INTEN {}
 impl crate::Writable for INTEN {}
 #[doc = "PWM Interrupt Enable"]
 pub mod inten;
-#[doc = "PWM Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "PWM Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -262,7 +262,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "PWM Raw Interrupt Status"]
 pub mod ris;
-#[doc = "PWM Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [isc](isc) module"]
+#[doc = "PWM Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [isc](isc) module"]
 pub type ISC = crate::Reg<u32, _ISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -273,7 +273,7 @@ impl crate::Readable for ISC {}
 impl crate::Writable for ISC {}
 #[doc = "PWM Interrupt Status and Clear"]
 pub mod isc;
-#[doc = "PWM Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+#[doc = "PWM Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [status](status) module"]
 pub type STATUS = crate::Reg<u32, _STATUS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -282,7 +282,7 @@ pub struct _STATUS;
 impl crate::Readable for STATUS {}
 #[doc = "PWM Status"]
 pub mod status;
-#[doc = "PWM Fault Condition Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [faultval](faultval) module"]
+#[doc = "PWM Fault Condition Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [faultval](faultval) module"]
 pub type FAULTVAL = crate::Reg<u32, _FAULTVAL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -293,7 +293,7 @@ impl crate::Readable for FAULTVAL {}
 impl crate::Writable for FAULTVAL {}
 #[doc = "PWM Fault Condition Value"]
 pub mod faultval;
-#[doc = "PWM Enable Update\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [enupd](enupd) module"]
+#[doc = "PWM Enable Update\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [enupd](enupd) module"]
 pub type ENUPD = crate::Reg<u32, _ENUPD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -304,7 +304,7 @@ impl crate::Readable for ENUPD {}
 impl crate::Writable for ENUPD {}
 #[doc = "PWM Enable Update"]
 pub mod enupd;
-#[doc = "PWM0 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_ctl](_0_ctl) module"]
+#[doc = "PWM0 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_ctl](_0_ctl) module"]
 pub type _0_CTL = crate::Reg<u32, __0_CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -315,7 +315,7 @@ impl crate::Readable for _0_CTL {}
 impl crate::Writable for _0_CTL {}
 #[doc = "PWM0 Control"]
 pub mod _0_ctl;
-#[doc = "PWM0 Interrupt and Trigger Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_inten](_0_inten) module"]
+#[doc = "PWM0 Interrupt and Trigger Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_inten](_0_inten) module"]
 pub type _0_INTEN = crate::Reg<u32, __0_INTEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -326,7 +326,7 @@ impl crate::Readable for _0_INTEN {}
 impl crate::Writable for _0_INTEN {}
 #[doc = "PWM0 Interrupt and Trigger Enable"]
 pub mod _0_inten;
-#[doc = "PWM0 Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_ris](_0_ris) module"]
+#[doc = "PWM0 Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_ris](_0_ris) module"]
 pub type _0_RIS = crate::Reg<u32, __0_RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -335,7 +335,7 @@ pub struct __0_RIS;
 impl crate::Readable for _0_RIS {}
 #[doc = "PWM0 Raw Interrupt Status"]
 pub mod _0_ris;
-#[doc = "PWM0 Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_isc](_0_isc) module"]
+#[doc = "PWM0 Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_isc](_0_isc) module"]
 pub type _0_ISC = crate::Reg<u32, __0_ISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -346,7 +346,7 @@ impl crate::Readable for _0_ISC {}
 impl crate::Writable for _0_ISC {}
 #[doc = "PWM0 Interrupt Status and Clear"]
 pub mod _0_isc;
-#[doc = "PWM0 Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_load](_0_load) module"]
+#[doc = "PWM0 Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_load](_0_load) module"]
 pub type _0_LOAD = crate::Reg<u32, __0_LOAD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -357,7 +357,7 @@ impl crate::Readable for _0_LOAD {}
 impl crate::Writable for _0_LOAD {}
 #[doc = "PWM0 Load"]
 pub mod _0_load;
-#[doc = "PWM0 Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_count](_0_count) module"]
+#[doc = "PWM0 Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_count](_0_count) module"]
 pub type _0_COUNT = crate::Reg<u32, __0_COUNT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -366,7 +366,7 @@ pub struct __0_COUNT;
 impl crate::Readable for _0_COUNT {}
 #[doc = "PWM0 Counter"]
 pub mod _0_count;
-#[doc = "PWM0 Compare A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_cmpa](_0_cmpa) module"]
+#[doc = "PWM0 Compare A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_cmpa](_0_cmpa) module"]
 pub type _0_CMPA = crate::Reg<u32, __0_CMPA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -377,7 +377,7 @@ impl crate::Readable for _0_CMPA {}
 impl crate::Writable for _0_CMPA {}
 #[doc = "PWM0 Compare A"]
 pub mod _0_cmpa;
-#[doc = "PWM0 Compare B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_cmpb](_0_cmpb) module"]
+#[doc = "PWM0 Compare B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_cmpb](_0_cmpb) module"]
 pub type _0_CMPB = crate::Reg<u32, __0_CMPB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -388,7 +388,7 @@ impl crate::Readable for _0_CMPB {}
 impl crate::Writable for _0_CMPB {}
 #[doc = "PWM0 Compare B"]
 pub mod _0_cmpb;
-#[doc = "PWM0 Generator A Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_gena](_0_gena) module"]
+#[doc = "PWM0 Generator A Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_gena](_0_gena) module"]
 pub type _0_GENA = crate::Reg<u32, __0_GENA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -399,7 +399,7 @@ impl crate::Readable for _0_GENA {}
 impl crate::Writable for _0_GENA {}
 #[doc = "PWM0 Generator A Control"]
 pub mod _0_gena;
-#[doc = "PWM0 Generator B Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_genb](_0_genb) module"]
+#[doc = "PWM0 Generator B Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_genb](_0_genb) module"]
 pub type _0_GENB = crate::Reg<u32, __0_GENB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -410,7 +410,7 @@ impl crate::Readable for _0_GENB {}
 impl crate::Writable for _0_GENB {}
 #[doc = "PWM0 Generator B Control"]
 pub mod _0_genb;
-#[doc = "PWM0 Dead-Band Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_dbctl](_0_dbctl) module"]
+#[doc = "PWM0 Dead-Band Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_dbctl](_0_dbctl) module"]
 pub type _0_DBCTL = crate::Reg<u32, __0_DBCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -421,7 +421,7 @@ impl crate::Readable for _0_DBCTL {}
 impl crate::Writable for _0_DBCTL {}
 #[doc = "PWM0 Dead-Band Control"]
 pub mod _0_dbctl;
-#[doc = "PWM0 Dead-Band Rising-Edge Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_dbrise](_0_dbrise) module"]
+#[doc = "PWM0 Dead-Band Rising-Edge Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_dbrise](_0_dbrise) module"]
 pub type _0_DBRISE = crate::Reg<u32, __0_DBRISE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -432,7 +432,7 @@ impl crate::Readable for _0_DBRISE {}
 impl crate::Writable for _0_DBRISE {}
 #[doc = "PWM0 Dead-Band Rising-Edge Delay"]
 pub mod _0_dbrise;
-#[doc = "PWM0 Dead-Band Falling-Edge-Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_dbfall](_0_dbfall) module"]
+#[doc = "PWM0 Dead-Band Falling-Edge-Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_dbfall](_0_dbfall) module"]
 pub type _0_DBFALL = crate::Reg<u32, __0_DBFALL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -443,7 +443,7 @@ impl crate::Readable for _0_DBFALL {}
 impl crate::Writable for _0_DBFALL {}
 #[doc = "PWM0 Dead-Band Falling-Edge-Delay"]
 pub mod _0_dbfall;
-#[doc = "PWM0 Fault Source 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_fltsrc0](_0_fltsrc0) module"]
+#[doc = "PWM0 Fault Source 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_fltsrc0](_0_fltsrc0) module"]
 pub type _0_FLTSRC0 = crate::Reg<u32, __0_FLTSRC0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -454,7 +454,7 @@ impl crate::Readable for _0_FLTSRC0 {}
 impl crate::Writable for _0_FLTSRC0 {}
 #[doc = "PWM0 Fault Source 0"]
 pub mod _0_fltsrc0;
-#[doc = "PWM0 Fault Source 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_fltsrc1](_0_fltsrc1) module"]
+#[doc = "PWM0 Fault Source 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_fltsrc1](_0_fltsrc1) module"]
 pub type _0_FLTSRC1 = crate::Reg<u32, __0_FLTSRC1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -465,7 +465,7 @@ impl crate::Readable for _0_FLTSRC1 {}
 impl crate::Writable for _0_FLTSRC1 {}
 #[doc = "PWM0 Fault Source 1"]
 pub mod _0_fltsrc1;
-#[doc = "PWM0 Minimum Fault Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_minfltper](_0_minfltper) module"]
+#[doc = "PWM0 Minimum Fault Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_minfltper](_0_minfltper) module"]
 pub type _0_MINFLTPER = crate::Reg<u32, __0_MINFLTPER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -476,7 +476,7 @@ impl crate::Readable for _0_MINFLTPER {}
 impl crate::Writable for _0_MINFLTPER {}
 #[doc = "PWM0 Minimum Fault Period"]
 pub mod _0_minfltper;
-#[doc = "PWM1 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_ctl](_1_ctl) module"]
+#[doc = "PWM1 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_ctl](_1_ctl) module"]
 pub type _1_CTL = crate::Reg<u32, __1_CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -487,7 +487,7 @@ impl crate::Readable for _1_CTL {}
 impl crate::Writable for _1_CTL {}
 #[doc = "PWM1 Control"]
 pub mod _1_ctl;
-#[doc = "PWM1 Interrupt and Trigger Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_inten](_1_inten) module"]
+#[doc = "PWM1 Interrupt and Trigger Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_inten](_1_inten) module"]
 pub type _1_INTEN = crate::Reg<u32, __1_INTEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -498,7 +498,7 @@ impl crate::Readable for _1_INTEN {}
 impl crate::Writable for _1_INTEN {}
 #[doc = "PWM1 Interrupt and Trigger Enable"]
 pub mod _1_inten;
-#[doc = "PWM1 Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_ris](_1_ris) module"]
+#[doc = "PWM1 Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_ris](_1_ris) module"]
 pub type _1_RIS = crate::Reg<u32, __1_RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -507,7 +507,7 @@ pub struct __1_RIS;
 impl crate::Readable for _1_RIS {}
 #[doc = "PWM1 Raw Interrupt Status"]
 pub mod _1_ris;
-#[doc = "PWM1 Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_isc](_1_isc) module"]
+#[doc = "PWM1 Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_isc](_1_isc) module"]
 pub type _1_ISC = crate::Reg<u32, __1_ISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -518,7 +518,7 @@ impl crate::Readable for _1_ISC {}
 impl crate::Writable for _1_ISC {}
 #[doc = "PWM1 Interrupt Status and Clear"]
 pub mod _1_isc;
-#[doc = "PWM1 Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_load](_1_load) module"]
+#[doc = "PWM1 Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_load](_1_load) module"]
 pub type _1_LOAD = crate::Reg<u32, __1_LOAD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -529,7 +529,7 @@ impl crate::Readable for _1_LOAD {}
 impl crate::Writable for _1_LOAD {}
 #[doc = "PWM1 Load"]
 pub mod _1_load;
-#[doc = "PWM1 Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_count](_1_count) module"]
+#[doc = "PWM1 Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_count](_1_count) module"]
 pub type _1_COUNT = crate::Reg<u32, __1_COUNT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -538,7 +538,7 @@ pub struct __1_COUNT;
 impl crate::Readable for _1_COUNT {}
 #[doc = "PWM1 Counter"]
 pub mod _1_count;
-#[doc = "PWM1 Compare A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_cmpa](_1_cmpa) module"]
+#[doc = "PWM1 Compare A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_cmpa](_1_cmpa) module"]
 pub type _1_CMPA = crate::Reg<u32, __1_CMPA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -549,7 +549,7 @@ impl crate::Readable for _1_CMPA {}
 impl crate::Writable for _1_CMPA {}
 #[doc = "PWM1 Compare A"]
 pub mod _1_cmpa;
-#[doc = "PWM1 Compare B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_cmpb](_1_cmpb) module"]
+#[doc = "PWM1 Compare B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_cmpb](_1_cmpb) module"]
 pub type _1_CMPB = crate::Reg<u32, __1_CMPB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -560,7 +560,7 @@ impl crate::Readable for _1_CMPB {}
 impl crate::Writable for _1_CMPB {}
 #[doc = "PWM1 Compare B"]
 pub mod _1_cmpb;
-#[doc = "PWM1 Generator A Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_gena](_1_gena) module"]
+#[doc = "PWM1 Generator A Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_gena](_1_gena) module"]
 pub type _1_GENA = crate::Reg<u32, __1_GENA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -571,7 +571,7 @@ impl crate::Readable for _1_GENA {}
 impl crate::Writable for _1_GENA {}
 #[doc = "PWM1 Generator A Control"]
 pub mod _1_gena;
-#[doc = "PWM1 Generator B Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_genb](_1_genb) module"]
+#[doc = "PWM1 Generator B Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_genb](_1_genb) module"]
 pub type _1_GENB = crate::Reg<u32, __1_GENB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -582,7 +582,7 @@ impl crate::Readable for _1_GENB {}
 impl crate::Writable for _1_GENB {}
 #[doc = "PWM1 Generator B Control"]
 pub mod _1_genb;
-#[doc = "PWM1 Dead-Band Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_dbctl](_1_dbctl) module"]
+#[doc = "PWM1 Dead-Band Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_dbctl](_1_dbctl) module"]
 pub type _1_DBCTL = crate::Reg<u32, __1_DBCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -593,7 +593,7 @@ impl crate::Readable for _1_DBCTL {}
 impl crate::Writable for _1_DBCTL {}
 #[doc = "PWM1 Dead-Band Control"]
 pub mod _1_dbctl;
-#[doc = "PWM1 Dead-Band Rising-Edge Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_dbrise](_1_dbrise) module"]
+#[doc = "PWM1 Dead-Band Rising-Edge Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_dbrise](_1_dbrise) module"]
 pub type _1_DBRISE = crate::Reg<u32, __1_DBRISE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -604,7 +604,7 @@ impl crate::Readable for _1_DBRISE {}
 impl crate::Writable for _1_DBRISE {}
 #[doc = "PWM1 Dead-Band Rising-Edge Delay"]
 pub mod _1_dbrise;
-#[doc = "PWM1 Dead-Band Falling-Edge-Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_dbfall](_1_dbfall) module"]
+#[doc = "PWM1 Dead-Band Falling-Edge-Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_dbfall](_1_dbfall) module"]
 pub type _1_DBFALL = crate::Reg<u32, __1_DBFALL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -615,7 +615,7 @@ impl crate::Readable for _1_DBFALL {}
 impl crate::Writable for _1_DBFALL {}
 #[doc = "PWM1 Dead-Band Falling-Edge-Delay"]
 pub mod _1_dbfall;
-#[doc = "PWM1 Fault Source 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_fltsrc0](_1_fltsrc0) module"]
+#[doc = "PWM1 Fault Source 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_fltsrc0](_1_fltsrc0) module"]
 pub type _1_FLTSRC0 = crate::Reg<u32, __1_FLTSRC0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -626,7 +626,7 @@ impl crate::Readable for _1_FLTSRC0 {}
 impl crate::Writable for _1_FLTSRC0 {}
 #[doc = "PWM1 Fault Source 0"]
 pub mod _1_fltsrc0;
-#[doc = "PWM1 Fault Source 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_fltsrc1](_1_fltsrc1) module"]
+#[doc = "PWM1 Fault Source 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_fltsrc1](_1_fltsrc1) module"]
 pub type _1_FLTSRC1 = crate::Reg<u32, __1_FLTSRC1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -637,7 +637,7 @@ impl crate::Readable for _1_FLTSRC1 {}
 impl crate::Writable for _1_FLTSRC1 {}
 #[doc = "PWM1 Fault Source 1"]
 pub mod _1_fltsrc1;
-#[doc = "PWM1 Minimum Fault Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_minfltper](_1_minfltper) module"]
+#[doc = "PWM1 Minimum Fault Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_minfltper](_1_minfltper) module"]
 pub type _1_MINFLTPER = crate::Reg<u32, __1_MINFLTPER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -648,7 +648,7 @@ impl crate::Readable for _1_MINFLTPER {}
 impl crate::Writable for _1_MINFLTPER {}
 #[doc = "PWM1 Minimum Fault Period"]
 pub mod _1_minfltper;
-#[doc = "PWM2 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_ctl](_2_ctl) module"]
+#[doc = "PWM2 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_ctl](_2_ctl) module"]
 pub type _2_CTL = crate::Reg<u32, __2_CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -659,7 +659,7 @@ impl crate::Readable for _2_CTL {}
 impl crate::Writable for _2_CTL {}
 #[doc = "PWM2 Control"]
 pub mod _2_ctl;
-#[doc = "PWM2 Interrupt and Trigger Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_inten](_2_inten) module"]
+#[doc = "PWM2 Interrupt and Trigger Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_inten](_2_inten) module"]
 pub type _2_INTEN = crate::Reg<u32, __2_INTEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -670,7 +670,7 @@ impl crate::Readable for _2_INTEN {}
 impl crate::Writable for _2_INTEN {}
 #[doc = "PWM2 Interrupt and Trigger Enable"]
 pub mod _2_inten;
-#[doc = "PWM2 Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_ris](_2_ris) module"]
+#[doc = "PWM2 Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_ris](_2_ris) module"]
 pub type _2_RIS = crate::Reg<u32, __2_RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -679,7 +679,7 @@ pub struct __2_RIS;
 impl crate::Readable for _2_RIS {}
 #[doc = "PWM2 Raw Interrupt Status"]
 pub mod _2_ris;
-#[doc = "PWM2 Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_isc](_2_isc) module"]
+#[doc = "PWM2 Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_isc](_2_isc) module"]
 pub type _2_ISC = crate::Reg<u32, __2_ISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -690,7 +690,7 @@ impl crate::Readable for _2_ISC {}
 impl crate::Writable for _2_ISC {}
 #[doc = "PWM2 Interrupt Status and Clear"]
 pub mod _2_isc;
-#[doc = "PWM2 Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_load](_2_load) module"]
+#[doc = "PWM2 Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_load](_2_load) module"]
 pub type _2_LOAD = crate::Reg<u32, __2_LOAD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -701,7 +701,7 @@ impl crate::Readable for _2_LOAD {}
 impl crate::Writable for _2_LOAD {}
 #[doc = "PWM2 Load"]
 pub mod _2_load;
-#[doc = "PWM2 Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_count](_2_count) module"]
+#[doc = "PWM2 Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_count](_2_count) module"]
 pub type _2_COUNT = crate::Reg<u32, __2_COUNT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -710,7 +710,7 @@ pub struct __2_COUNT;
 impl crate::Readable for _2_COUNT {}
 #[doc = "PWM2 Counter"]
 pub mod _2_count;
-#[doc = "PWM2 Compare A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_cmpa](_2_cmpa) module"]
+#[doc = "PWM2 Compare A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_cmpa](_2_cmpa) module"]
 pub type _2_CMPA = crate::Reg<u32, __2_CMPA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -721,7 +721,7 @@ impl crate::Readable for _2_CMPA {}
 impl crate::Writable for _2_CMPA {}
 #[doc = "PWM2 Compare A"]
 pub mod _2_cmpa;
-#[doc = "PWM2 Compare B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_cmpb](_2_cmpb) module"]
+#[doc = "PWM2 Compare B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_cmpb](_2_cmpb) module"]
 pub type _2_CMPB = crate::Reg<u32, __2_CMPB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -732,7 +732,7 @@ impl crate::Readable for _2_CMPB {}
 impl crate::Writable for _2_CMPB {}
 #[doc = "PWM2 Compare B"]
 pub mod _2_cmpb;
-#[doc = "PWM2 Generator A Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_gena](_2_gena) module"]
+#[doc = "PWM2 Generator A Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_gena](_2_gena) module"]
 pub type _2_GENA = crate::Reg<u32, __2_GENA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -743,7 +743,7 @@ impl crate::Readable for _2_GENA {}
 impl crate::Writable for _2_GENA {}
 #[doc = "PWM2 Generator A Control"]
 pub mod _2_gena;
-#[doc = "PWM2 Generator B Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_genb](_2_genb) module"]
+#[doc = "PWM2 Generator B Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_genb](_2_genb) module"]
 pub type _2_GENB = crate::Reg<u32, __2_GENB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -754,7 +754,7 @@ impl crate::Readable for _2_GENB {}
 impl crate::Writable for _2_GENB {}
 #[doc = "PWM2 Generator B Control"]
 pub mod _2_genb;
-#[doc = "PWM2 Dead-Band Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_dbctl](_2_dbctl) module"]
+#[doc = "PWM2 Dead-Band Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_dbctl](_2_dbctl) module"]
 pub type _2_DBCTL = crate::Reg<u32, __2_DBCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -765,7 +765,7 @@ impl crate::Readable for _2_DBCTL {}
 impl crate::Writable for _2_DBCTL {}
 #[doc = "PWM2 Dead-Band Control"]
 pub mod _2_dbctl;
-#[doc = "PWM2 Dead-Band Rising-Edge Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_dbrise](_2_dbrise) module"]
+#[doc = "PWM2 Dead-Band Rising-Edge Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_dbrise](_2_dbrise) module"]
 pub type _2_DBRISE = crate::Reg<u32, __2_DBRISE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -776,7 +776,7 @@ impl crate::Readable for _2_DBRISE {}
 impl crate::Writable for _2_DBRISE {}
 #[doc = "PWM2 Dead-Band Rising-Edge Delay"]
 pub mod _2_dbrise;
-#[doc = "PWM2 Dead-Band Falling-Edge-Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_dbfall](_2_dbfall) module"]
+#[doc = "PWM2 Dead-Band Falling-Edge-Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_dbfall](_2_dbfall) module"]
 pub type _2_DBFALL = crate::Reg<u32, __2_DBFALL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -787,7 +787,7 @@ impl crate::Readable for _2_DBFALL {}
 impl crate::Writable for _2_DBFALL {}
 #[doc = "PWM2 Dead-Band Falling-Edge-Delay"]
 pub mod _2_dbfall;
-#[doc = "PWM2 Fault Source 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_fltsrc0](_2_fltsrc0) module"]
+#[doc = "PWM2 Fault Source 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_fltsrc0](_2_fltsrc0) module"]
 pub type _2_FLTSRC0 = crate::Reg<u32, __2_FLTSRC0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -798,7 +798,7 @@ impl crate::Readable for _2_FLTSRC0 {}
 impl crate::Writable for _2_FLTSRC0 {}
 #[doc = "PWM2 Fault Source 0"]
 pub mod _2_fltsrc0;
-#[doc = "PWM2 Fault Source 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_fltsrc1](_2_fltsrc1) module"]
+#[doc = "PWM2 Fault Source 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_fltsrc1](_2_fltsrc1) module"]
 pub type _2_FLTSRC1 = crate::Reg<u32, __2_FLTSRC1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -809,7 +809,7 @@ impl crate::Readable for _2_FLTSRC1 {}
 impl crate::Writable for _2_FLTSRC1 {}
 #[doc = "PWM2 Fault Source 1"]
 pub mod _2_fltsrc1;
-#[doc = "PWM2 Minimum Fault Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_minfltper](_2_minfltper) module"]
+#[doc = "PWM2 Minimum Fault Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_minfltper](_2_minfltper) module"]
 pub type _2_MINFLTPER = crate::Reg<u32, __2_MINFLTPER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -820,7 +820,7 @@ impl crate::Readable for _2_MINFLTPER {}
 impl crate::Writable for _2_MINFLTPER {}
 #[doc = "PWM2 Minimum Fault Period"]
 pub mod _2_minfltper;
-#[doc = "PWM3 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_ctl](_3_ctl) module"]
+#[doc = "PWM3 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_ctl](_3_ctl) module"]
 pub type _3_CTL = crate::Reg<u32, __3_CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -831,7 +831,7 @@ impl crate::Readable for _3_CTL {}
 impl crate::Writable for _3_CTL {}
 #[doc = "PWM3 Control"]
 pub mod _3_ctl;
-#[doc = "PWM3 Interrupt and Trigger Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_inten](_3_inten) module"]
+#[doc = "PWM3 Interrupt and Trigger Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_inten](_3_inten) module"]
 pub type _3_INTEN = crate::Reg<u32, __3_INTEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -842,7 +842,7 @@ impl crate::Readable for _3_INTEN {}
 impl crate::Writable for _3_INTEN {}
 #[doc = "PWM3 Interrupt and Trigger Enable"]
 pub mod _3_inten;
-#[doc = "PWM3 Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_ris](_3_ris) module"]
+#[doc = "PWM3 Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_ris](_3_ris) module"]
 pub type _3_RIS = crate::Reg<u32, __3_RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -851,7 +851,7 @@ pub struct __3_RIS;
 impl crate::Readable for _3_RIS {}
 #[doc = "PWM3 Raw Interrupt Status"]
 pub mod _3_ris;
-#[doc = "PWM3 Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_isc](_3_isc) module"]
+#[doc = "PWM3 Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_isc](_3_isc) module"]
 pub type _3_ISC = crate::Reg<u32, __3_ISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -862,7 +862,7 @@ impl crate::Readable for _3_ISC {}
 impl crate::Writable for _3_ISC {}
 #[doc = "PWM3 Interrupt Status and Clear"]
 pub mod _3_isc;
-#[doc = "PWM3 Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_load](_3_load) module"]
+#[doc = "PWM3 Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_load](_3_load) module"]
 pub type _3_LOAD = crate::Reg<u32, __3_LOAD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -873,7 +873,7 @@ impl crate::Readable for _3_LOAD {}
 impl crate::Writable for _3_LOAD {}
 #[doc = "PWM3 Load"]
 pub mod _3_load;
-#[doc = "PWM3 Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_count](_3_count) module"]
+#[doc = "PWM3 Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_count](_3_count) module"]
 pub type _3_COUNT = crate::Reg<u32, __3_COUNT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -882,7 +882,7 @@ pub struct __3_COUNT;
 impl crate::Readable for _3_COUNT {}
 #[doc = "PWM3 Counter"]
 pub mod _3_count;
-#[doc = "PWM3 Compare A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_cmpa](_3_cmpa) module"]
+#[doc = "PWM3 Compare A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_cmpa](_3_cmpa) module"]
 pub type _3_CMPA = crate::Reg<u32, __3_CMPA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -893,7 +893,7 @@ impl crate::Readable for _3_CMPA {}
 impl crate::Writable for _3_CMPA {}
 #[doc = "PWM3 Compare A"]
 pub mod _3_cmpa;
-#[doc = "PWM3 Compare B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_cmpb](_3_cmpb) module"]
+#[doc = "PWM3 Compare B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_cmpb](_3_cmpb) module"]
 pub type _3_CMPB = crate::Reg<u32, __3_CMPB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -904,7 +904,7 @@ impl crate::Readable for _3_CMPB {}
 impl crate::Writable for _3_CMPB {}
 #[doc = "PWM3 Compare B"]
 pub mod _3_cmpb;
-#[doc = "PWM3 Generator A Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_gena](_3_gena) module"]
+#[doc = "PWM3 Generator A Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_gena](_3_gena) module"]
 pub type _3_GENA = crate::Reg<u32, __3_GENA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -915,7 +915,7 @@ impl crate::Readable for _3_GENA {}
 impl crate::Writable for _3_GENA {}
 #[doc = "PWM3 Generator A Control"]
 pub mod _3_gena;
-#[doc = "PWM3 Generator B Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_genb](_3_genb) module"]
+#[doc = "PWM3 Generator B Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_genb](_3_genb) module"]
 pub type _3_GENB = crate::Reg<u32, __3_GENB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -926,7 +926,7 @@ impl crate::Readable for _3_GENB {}
 impl crate::Writable for _3_GENB {}
 #[doc = "PWM3 Generator B Control"]
 pub mod _3_genb;
-#[doc = "PWM3 Dead-Band Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_dbctl](_3_dbctl) module"]
+#[doc = "PWM3 Dead-Band Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_dbctl](_3_dbctl) module"]
 pub type _3_DBCTL = crate::Reg<u32, __3_DBCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -937,7 +937,7 @@ impl crate::Readable for _3_DBCTL {}
 impl crate::Writable for _3_DBCTL {}
 #[doc = "PWM3 Dead-Band Control"]
 pub mod _3_dbctl;
-#[doc = "PWM3 Dead-Band Rising-Edge Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_dbrise](_3_dbrise) module"]
+#[doc = "PWM3 Dead-Band Rising-Edge Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_dbrise](_3_dbrise) module"]
 pub type _3_DBRISE = crate::Reg<u32, __3_DBRISE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -948,7 +948,7 @@ impl crate::Readable for _3_DBRISE {}
 impl crate::Writable for _3_DBRISE {}
 #[doc = "PWM3 Dead-Band Rising-Edge Delay"]
 pub mod _3_dbrise;
-#[doc = "PWM3 Dead-Band Falling-Edge-Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_dbfall](_3_dbfall) module"]
+#[doc = "PWM3 Dead-Band Falling-Edge-Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_dbfall](_3_dbfall) module"]
 pub type _3_DBFALL = crate::Reg<u32, __3_DBFALL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -959,7 +959,7 @@ impl crate::Readable for _3_DBFALL {}
 impl crate::Writable for _3_DBFALL {}
 #[doc = "PWM3 Dead-Band Falling-Edge-Delay"]
 pub mod _3_dbfall;
-#[doc = "PWM3 Fault Source 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_fltsrc0](_3_fltsrc0) module"]
+#[doc = "PWM3 Fault Source 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_fltsrc0](_3_fltsrc0) module"]
 pub type _3_FLTSRC0 = crate::Reg<u32, __3_FLTSRC0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -970,7 +970,7 @@ impl crate::Readable for _3_FLTSRC0 {}
 impl crate::Writable for _3_FLTSRC0 {}
 #[doc = "PWM3 Fault Source 0"]
 pub mod _3_fltsrc0;
-#[doc = "PWM3 Fault Source 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_fltsrc1](_3_fltsrc1) module"]
+#[doc = "PWM3 Fault Source 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_fltsrc1](_3_fltsrc1) module"]
 pub type _3_FLTSRC1 = crate::Reg<u32, __3_FLTSRC1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -981,7 +981,7 @@ impl crate::Readable for _3_FLTSRC1 {}
 impl crate::Writable for _3_FLTSRC1 {}
 #[doc = "PWM3 Fault Source 1"]
 pub mod _3_fltsrc1;
-#[doc = "PWM3 Minimum Fault Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_minfltper](_3_minfltper) module"]
+#[doc = "PWM3 Minimum Fault Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_minfltper](_3_minfltper) module"]
 pub type _3_MINFLTPER = crate::Reg<u32, __3_MINFLTPER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -992,7 +992,7 @@ impl crate::Readable for _3_MINFLTPER {}
 impl crate::Writable for _3_MINFLTPER {}
 #[doc = "PWM3 Minimum Fault Period"]
 pub mod _3_minfltper;
-#[doc = "PWM0 Fault Pin Logic Sense\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_fltsen](_0_fltsen) module"]
+#[doc = "PWM0 Fault Pin Logic Sense\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_fltsen](_0_fltsen) module"]
 pub type _0_FLTSEN = crate::Reg<u32, __0_FLTSEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1003,7 +1003,7 @@ impl crate::Readable for _0_FLTSEN {}
 impl crate::Writable for _0_FLTSEN {}
 #[doc = "PWM0 Fault Pin Logic Sense"]
 pub mod _0_fltsen;
-#[doc = "PWM0 Fault Status 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_fltstat0](_0_fltstat0) module"]
+#[doc = "PWM0 Fault Status 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_fltstat0](_0_fltstat0) module"]
 pub type _0_FLTSTAT0 = crate::Reg<u32, __0_FLTSTAT0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1014,7 +1014,7 @@ impl crate::Readable for _0_FLTSTAT0 {}
 impl crate::Writable for _0_FLTSTAT0 {}
 #[doc = "PWM0 Fault Status 0"]
 pub mod _0_fltstat0;
-#[doc = "PWM0 Fault Status 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_0_fltstat1](_0_fltstat1) module"]
+#[doc = "PWM0 Fault Status 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_0_fltstat1](_0_fltstat1) module"]
 pub type _0_FLTSTAT1 = crate::Reg<u32, __0_FLTSTAT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1025,7 +1025,7 @@ impl crate::Readable for _0_FLTSTAT1 {}
 impl crate::Writable for _0_FLTSTAT1 {}
 #[doc = "PWM0 Fault Status 1"]
 pub mod _0_fltstat1;
-#[doc = "PWM1 Fault Pin Logic Sense\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_fltsen](_1_fltsen) module"]
+#[doc = "PWM1 Fault Pin Logic Sense\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_fltsen](_1_fltsen) module"]
 pub type _1_FLTSEN = crate::Reg<u32, __1_FLTSEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1036,7 +1036,7 @@ impl crate::Readable for _1_FLTSEN {}
 impl crate::Writable for _1_FLTSEN {}
 #[doc = "PWM1 Fault Pin Logic Sense"]
 pub mod _1_fltsen;
-#[doc = "PWM1 Fault Status 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_fltstat0](_1_fltstat0) module"]
+#[doc = "PWM1 Fault Status 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_fltstat0](_1_fltstat0) module"]
 pub type _1_FLTSTAT0 = crate::Reg<u32, __1_FLTSTAT0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1047,7 +1047,7 @@ impl crate::Readable for _1_FLTSTAT0 {}
 impl crate::Writable for _1_FLTSTAT0 {}
 #[doc = "PWM1 Fault Status 0"]
 pub mod _1_fltstat0;
-#[doc = "PWM1 Fault Status 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_1_fltstat1](_1_fltstat1) module"]
+#[doc = "PWM1 Fault Status 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_1_fltstat1](_1_fltstat1) module"]
 pub type _1_FLTSTAT1 = crate::Reg<u32, __1_FLTSTAT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1058,7 +1058,7 @@ impl crate::Readable for _1_FLTSTAT1 {}
 impl crate::Writable for _1_FLTSTAT1 {}
 #[doc = "PWM1 Fault Status 1"]
 pub mod _1_fltstat1;
-#[doc = "PWM2 Fault Pin Logic Sense\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_fltsen](_2_fltsen) module"]
+#[doc = "PWM2 Fault Pin Logic Sense\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_fltsen](_2_fltsen) module"]
 pub type _2_FLTSEN = crate::Reg<u32, __2_FLTSEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1069,7 +1069,7 @@ impl crate::Readable for _2_FLTSEN {}
 impl crate::Writable for _2_FLTSEN {}
 #[doc = "PWM2 Fault Pin Logic Sense"]
 pub mod _2_fltsen;
-#[doc = "PWM2 Fault Status 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_fltstat0](_2_fltstat0) module"]
+#[doc = "PWM2 Fault Status 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_fltstat0](_2_fltstat0) module"]
 pub type _2_FLTSTAT0 = crate::Reg<u32, __2_FLTSTAT0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1080,7 +1080,7 @@ impl crate::Readable for _2_FLTSTAT0 {}
 impl crate::Writable for _2_FLTSTAT0 {}
 #[doc = "PWM2 Fault Status 0"]
 pub mod _2_fltstat0;
-#[doc = "PWM2 Fault Status 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_2_fltstat1](_2_fltstat1) module"]
+#[doc = "PWM2 Fault Status 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_2_fltstat1](_2_fltstat1) module"]
 pub type _2_FLTSTAT1 = crate::Reg<u32, __2_FLTSTAT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1091,7 +1091,7 @@ impl crate::Readable for _2_FLTSTAT1 {}
 impl crate::Writable for _2_FLTSTAT1 {}
 #[doc = "PWM2 Fault Status 1"]
 pub mod _2_fltstat1;
-#[doc = "PWM3 Fault Pin Logic Sense\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_fltsen](_3_fltsen) module"]
+#[doc = "PWM3 Fault Pin Logic Sense\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_fltsen](_3_fltsen) module"]
 pub type _3_FLTSEN = crate::Reg<u32, __3_FLTSEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1102,7 +1102,7 @@ impl crate::Readable for _3_FLTSEN {}
 impl crate::Writable for _3_FLTSEN {}
 #[doc = "PWM3 Fault Pin Logic Sense"]
 pub mod _3_fltsen;
-#[doc = "PWM3 Fault Status 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_fltstat0](_3_fltstat0) module"]
+#[doc = "PWM3 Fault Status 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_fltstat0](_3_fltstat0) module"]
 pub type _3_FLTSTAT0 = crate::Reg<u32, __3_FLTSTAT0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1113,7 +1113,7 @@ impl crate::Readable for _3_FLTSTAT0 {}
 impl crate::Writable for _3_FLTSTAT0 {}
 #[doc = "PWM3 Fault Status 0"]
 pub mod _3_fltstat0;
-#[doc = "PWM3 Fault Status 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_3_fltstat1](_3_fltstat1) module"]
+#[doc = "PWM3 Fault Status 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_3_fltstat1](_3_fltstat1) module"]
 pub type _3_FLTSTAT1 = crate::Reg<u32, __3_FLTSTAT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1124,7 +1124,7 @@ impl crate::Readable for _3_FLTSTAT1 {}
 impl crate::Writable for _3_FLTSTAT1 {}
 #[doc = "PWM3 Fault Status 1"]
 pub mod _3_fltstat1;
-#[doc = "PWM Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "PWM Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1133,7 +1133,7 @@ pub struct _PP;
 impl crate::Readable for PP {}
 #[doc = "PWM Peripheral Properties"]
 pub mod pp;
-#[doc = "PWM Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc](cc) module"]
+#[doc = "PWM Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cc](cc) module"]
 pub type CC = crate::Reg<u32, _CC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/pwm0/_0_ctl.rs
+++ b/crates/tm4c129x/src/pwm0/_0_ctl.rs
@@ -156,22 +156,19 @@ impl<'a> CMPBUPD_W<'a> {
 }
 #[doc = "PWMnGENA Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum GENAUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<GENAUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: GENAUPD_A) -> Self {
-        match variant {
-            GENAUPD_A::I => 0,
-            GENAUPD_A::LS => 2,
-            GENAUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `GENAUPD`"]
@@ -238,22 +235,19 @@ impl<'a> GENAUPD_W<'a> {
 }
 #[doc = "PWMnGENB Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum GENBUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<GENBUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: GENBUPD_A) -> Self {
-        match variant {
-            GENBUPD_A::I => 0,
-            GENBUPD_A::LS => 2,
-            GENBUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `GENBUPD`"]
@@ -320,22 +314,19 @@ impl<'a> GENBUPD_W<'a> {
 }
 #[doc = "PWMnDBCTL Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBCTLUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBCTLUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBCTLUPD_A) -> Self {
-        match variant {
-            DBCTLUPD_A::I => 0,
-            DBCTLUPD_A::LS => 2,
-            DBCTLUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBCTLUPD`"]
@@ -402,22 +393,19 @@ impl<'a> DBCTLUPD_W<'a> {
 }
 #[doc = "PWMnDBRISE Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBRISEUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBRISEUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBRISEUPD_A) -> Self {
-        match variant {
-            DBRISEUPD_A::I => 0,
-            DBRISEUPD_A::LS => 2,
-            DBRISEUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBRISEUPD`"]
@@ -484,22 +472,19 @@ impl<'a> DBRISEUPD_W<'a> {
 }
 #[doc = "PWMnDBFALL Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBFALLUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBFALLUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBFALLUPD_A) -> Self {
-        match variant {
-            DBFALLUPD_A::I => 0,
-            DBFALLUPD_A::LS => 2,
-            DBFALLUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBFALLUPD`"]

--- a/crates/tm4c129x/src/pwm0/_0_gena.rs
+++ b/crates/tm4c129x/src/pwm0/_0_gena.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::_0_GENA {
 }
 #[doc = "Action for Counter=0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTZERO_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTZERO_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTZERO_A) -> Self {
-        match variant {
-            ACTZERO_A::NONE => 0,
-            ACTZERO_A::INV => 1,
-            ACTZERO_A::ZERO => 2,
-            ACTZERO_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTZERO`"]
@@ -109,25 +105,21 @@ impl<'a> ACTZERO_W<'a> {
 }
 #[doc = "Action for Counter=LOAD\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTLOAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTLOAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTLOAD_A) -> Self {
-        match variant {
-            ACTLOAD_A::NONE => 0,
-            ACTLOAD_A::INV => 1,
-            ACTLOAD_A::ZERO => 2,
-            ACTLOAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTLOAD`"]
@@ -206,25 +198,21 @@ impl<'a> ACTLOAD_W<'a> {
 }
 #[doc = "Action for Comparator A Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAU_A) -> Self {
-        match variant {
-            ACTCMPAU_A::NONE => 0,
-            ACTCMPAU_A::INV => 1,
-            ACTCMPAU_A::ZERO => 2,
-            ACTCMPAU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAU`"]
@@ -303,25 +291,21 @@ impl<'a> ACTCMPAU_W<'a> {
 }
 #[doc = "Action for Comparator A Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAD_A) -> Self {
-        match variant {
-            ACTCMPAD_A::NONE => 0,
-            ACTCMPAD_A::INV => 1,
-            ACTCMPAD_A::ZERO => 2,
-            ACTCMPAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAD`"]
@@ -400,25 +384,21 @@ impl<'a> ACTCMPAD_W<'a> {
 }
 #[doc = "Action for Comparator B Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBU_A) -> Self {
-        match variant {
-            ACTCMPBU_A::NONE => 0,
-            ACTCMPBU_A::INV => 1,
-            ACTCMPBU_A::ZERO => 2,
-            ACTCMPBU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBU`"]
@@ -497,25 +477,21 @@ impl<'a> ACTCMPBU_W<'a> {
 }
 #[doc = "Action for Comparator B Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBD_A) -> Self {
-        match variant {
-            ACTCMPBD_A::NONE => 0,
-            ACTCMPBD_A::INV => 1,
-            ACTCMPBD_A::ZERO => 2,
-            ACTCMPBD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBD`"]

--- a/crates/tm4c129x/src/pwm0/_0_genb.rs
+++ b/crates/tm4c129x/src/pwm0/_0_genb.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::_0_GENB {
 }
 #[doc = "Action for Counter=0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTZERO_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTZERO_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTZERO_A) -> Self {
-        match variant {
-            ACTZERO_A::NONE => 0,
-            ACTZERO_A::INV => 1,
-            ACTZERO_A::ZERO => 2,
-            ACTZERO_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTZERO`"]
@@ -109,25 +105,21 @@ impl<'a> ACTZERO_W<'a> {
 }
 #[doc = "Action for Counter=LOAD\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTLOAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTLOAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTLOAD_A) -> Self {
-        match variant {
-            ACTLOAD_A::NONE => 0,
-            ACTLOAD_A::INV => 1,
-            ACTLOAD_A::ZERO => 2,
-            ACTLOAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTLOAD`"]
@@ -206,25 +198,21 @@ impl<'a> ACTLOAD_W<'a> {
 }
 #[doc = "Action for Comparator A Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAU_A) -> Self {
-        match variant {
-            ACTCMPAU_A::NONE => 0,
-            ACTCMPAU_A::INV => 1,
-            ACTCMPAU_A::ZERO => 2,
-            ACTCMPAU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAU`"]
@@ -303,25 +291,21 @@ impl<'a> ACTCMPAU_W<'a> {
 }
 #[doc = "Action for Comparator A Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAD_A) -> Self {
-        match variant {
-            ACTCMPAD_A::NONE => 0,
-            ACTCMPAD_A::INV => 1,
-            ACTCMPAD_A::ZERO => 2,
-            ACTCMPAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAD`"]
@@ -400,25 +384,21 @@ impl<'a> ACTCMPAD_W<'a> {
 }
 #[doc = "Action for Comparator B Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBU_A) -> Self {
-        match variant {
-            ACTCMPBU_A::NONE => 0,
-            ACTCMPBU_A::INV => 1,
-            ACTCMPBU_A::ZERO => 2,
-            ACTCMPBU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBU`"]
@@ -497,25 +477,21 @@ impl<'a> ACTCMPBU_W<'a> {
 }
 #[doc = "Action for Comparator B Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBD_A) -> Self {
-        match variant {
-            ACTCMPBD_A::NONE => 0,
-            ACTCMPBD_A::INV => 1,
-            ACTCMPBD_A::ZERO => 2,
-            ACTCMPBD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBD`"]

--- a/crates/tm4c129x/src/pwm0/_1_ctl.rs
+++ b/crates/tm4c129x/src/pwm0/_1_ctl.rs
@@ -156,22 +156,19 @@ impl<'a> CMPBUPD_W<'a> {
 }
 #[doc = "PWMnGENA Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum GENAUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<GENAUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: GENAUPD_A) -> Self {
-        match variant {
-            GENAUPD_A::I => 0,
-            GENAUPD_A::LS => 2,
-            GENAUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `GENAUPD`"]
@@ -238,22 +235,19 @@ impl<'a> GENAUPD_W<'a> {
 }
 #[doc = "PWMnGENB Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum GENBUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<GENBUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: GENBUPD_A) -> Self {
-        match variant {
-            GENBUPD_A::I => 0,
-            GENBUPD_A::LS => 2,
-            GENBUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `GENBUPD`"]
@@ -320,22 +314,19 @@ impl<'a> GENBUPD_W<'a> {
 }
 #[doc = "PWMnDBCTL Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBCTLUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBCTLUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBCTLUPD_A) -> Self {
-        match variant {
-            DBCTLUPD_A::I => 0,
-            DBCTLUPD_A::LS => 2,
-            DBCTLUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBCTLUPD`"]
@@ -402,22 +393,19 @@ impl<'a> DBCTLUPD_W<'a> {
 }
 #[doc = "PWMnDBRISE Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBRISEUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBRISEUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBRISEUPD_A) -> Self {
-        match variant {
-            DBRISEUPD_A::I => 0,
-            DBRISEUPD_A::LS => 2,
-            DBRISEUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBRISEUPD`"]
@@ -484,22 +472,19 @@ impl<'a> DBRISEUPD_W<'a> {
 }
 #[doc = "PWMnDBFALL Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBFALLUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBFALLUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBFALLUPD_A) -> Self {
-        match variant {
-            DBFALLUPD_A::I => 0,
-            DBFALLUPD_A::LS => 2,
-            DBFALLUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBFALLUPD`"]

--- a/crates/tm4c129x/src/pwm0/_1_gena.rs
+++ b/crates/tm4c129x/src/pwm0/_1_gena.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::_1_GENA {
 }
 #[doc = "Action for Counter=0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTZERO_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTZERO_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTZERO_A) -> Self {
-        match variant {
-            ACTZERO_A::NONE => 0,
-            ACTZERO_A::INV => 1,
-            ACTZERO_A::ZERO => 2,
-            ACTZERO_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTZERO`"]
@@ -109,25 +105,21 @@ impl<'a> ACTZERO_W<'a> {
 }
 #[doc = "Action for Counter=LOAD\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTLOAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTLOAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTLOAD_A) -> Self {
-        match variant {
-            ACTLOAD_A::NONE => 0,
-            ACTLOAD_A::INV => 1,
-            ACTLOAD_A::ZERO => 2,
-            ACTLOAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTLOAD`"]
@@ -206,25 +198,21 @@ impl<'a> ACTLOAD_W<'a> {
 }
 #[doc = "Action for Comparator A Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAU_A) -> Self {
-        match variant {
-            ACTCMPAU_A::NONE => 0,
-            ACTCMPAU_A::INV => 1,
-            ACTCMPAU_A::ZERO => 2,
-            ACTCMPAU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAU`"]
@@ -303,25 +291,21 @@ impl<'a> ACTCMPAU_W<'a> {
 }
 #[doc = "Action for Comparator A Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAD_A) -> Self {
-        match variant {
-            ACTCMPAD_A::NONE => 0,
-            ACTCMPAD_A::INV => 1,
-            ACTCMPAD_A::ZERO => 2,
-            ACTCMPAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAD`"]
@@ -400,25 +384,21 @@ impl<'a> ACTCMPAD_W<'a> {
 }
 #[doc = "Action for Comparator B Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBU_A) -> Self {
-        match variant {
-            ACTCMPBU_A::NONE => 0,
-            ACTCMPBU_A::INV => 1,
-            ACTCMPBU_A::ZERO => 2,
-            ACTCMPBU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBU`"]
@@ -497,25 +477,21 @@ impl<'a> ACTCMPBU_W<'a> {
 }
 #[doc = "Action for Comparator B Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBD_A) -> Self {
-        match variant {
-            ACTCMPBD_A::NONE => 0,
-            ACTCMPBD_A::INV => 1,
-            ACTCMPBD_A::ZERO => 2,
-            ACTCMPBD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBD`"]

--- a/crates/tm4c129x/src/pwm0/_1_genb.rs
+++ b/crates/tm4c129x/src/pwm0/_1_genb.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::_1_GENB {
 }
 #[doc = "Action for Counter=0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTZERO_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTZERO_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTZERO_A) -> Self {
-        match variant {
-            ACTZERO_A::NONE => 0,
-            ACTZERO_A::INV => 1,
-            ACTZERO_A::ZERO => 2,
-            ACTZERO_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTZERO`"]
@@ -109,25 +105,21 @@ impl<'a> ACTZERO_W<'a> {
 }
 #[doc = "Action for Counter=LOAD\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTLOAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTLOAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTLOAD_A) -> Self {
-        match variant {
-            ACTLOAD_A::NONE => 0,
-            ACTLOAD_A::INV => 1,
-            ACTLOAD_A::ZERO => 2,
-            ACTLOAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTLOAD`"]
@@ -206,25 +198,21 @@ impl<'a> ACTLOAD_W<'a> {
 }
 #[doc = "Action for Comparator A Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAU_A) -> Self {
-        match variant {
-            ACTCMPAU_A::NONE => 0,
-            ACTCMPAU_A::INV => 1,
-            ACTCMPAU_A::ZERO => 2,
-            ACTCMPAU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAU`"]
@@ -303,25 +291,21 @@ impl<'a> ACTCMPAU_W<'a> {
 }
 #[doc = "Action for Comparator A Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAD_A) -> Self {
-        match variant {
-            ACTCMPAD_A::NONE => 0,
-            ACTCMPAD_A::INV => 1,
-            ACTCMPAD_A::ZERO => 2,
-            ACTCMPAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAD`"]
@@ -400,25 +384,21 @@ impl<'a> ACTCMPAD_W<'a> {
 }
 #[doc = "Action for Comparator B Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBU_A) -> Self {
-        match variant {
-            ACTCMPBU_A::NONE => 0,
-            ACTCMPBU_A::INV => 1,
-            ACTCMPBU_A::ZERO => 2,
-            ACTCMPBU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBU`"]
@@ -497,25 +477,21 @@ impl<'a> ACTCMPBU_W<'a> {
 }
 #[doc = "Action for Comparator B Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBD_A) -> Self {
-        match variant {
-            ACTCMPBD_A::NONE => 0,
-            ACTCMPBD_A::INV => 1,
-            ACTCMPBD_A::ZERO => 2,
-            ACTCMPBD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBD`"]

--- a/crates/tm4c129x/src/pwm0/_2_ctl.rs
+++ b/crates/tm4c129x/src/pwm0/_2_ctl.rs
@@ -156,22 +156,19 @@ impl<'a> CMPBUPD_W<'a> {
 }
 #[doc = "PWMnGENA Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum GENAUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<GENAUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: GENAUPD_A) -> Self {
-        match variant {
-            GENAUPD_A::I => 0,
-            GENAUPD_A::LS => 2,
-            GENAUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `GENAUPD`"]
@@ -238,22 +235,19 @@ impl<'a> GENAUPD_W<'a> {
 }
 #[doc = "PWMnGENB Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum GENBUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<GENBUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: GENBUPD_A) -> Self {
-        match variant {
-            GENBUPD_A::I => 0,
-            GENBUPD_A::LS => 2,
-            GENBUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `GENBUPD`"]
@@ -320,22 +314,19 @@ impl<'a> GENBUPD_W<'a> {
 }
 #[doc = "PWMnDBCTL Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBCTLUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBCTLUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBCTLUPD_A) -> Self {
-        match variant {
-            DBCTLUPD_A::I => 0,
-            DBCTLUPD_A::LS => 2,
-            DBCTLUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBCTLUPD`"]
@@ -402,22 +393,19 @@ impl<'a> DBCTLUPD_W<'a> {
 }
 #[doc = "PWMnDBRISE Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBRISEUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBRISEUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBRISEUPD_A) -> Self {
-        match variant {
-            DBRISEUPD_A::I => 0,
-            DBRISEUPD_A::LS => 2,
-            DBRISEUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBRISEUPD`"]
@@ -484,22 +472,19 @@ impl<'a> DBRISEUPD_W<'a> {
 }
 #[doc = "PWMnDBFALL Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBFALLUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBFALLUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBFALLUPD_A) -> Self {
-        match variant {
-            DBFALLUPD_A::I => 0,
-            DBFALLUPD_A::LS => 2,
-            DBFALLUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBFALLUPD`"]

--- a/crates/tm4c129x/src/pwm0/_2_gena.rs
+++ b/crates/tm4c129x/src/pwm0/_2_gena.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::_2_GENA {
 }
 #[doc = "Action for Counter=0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTZERO_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTZERO_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTZERO_A) -> Self {
-        match variant {
-            ACTZERO_A::NONE => 0,
-            ACTZERO_A::INV => 1,
-            ACTZERO_A::ZERO => 2,
-            ACTZERO_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTZERO`"]
@@ -109,25 +105,21 @@ impl<'a> ACTZERO_W<'a> {
 }
 #[doc = "Action for Counter=LOAD\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTLOAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTLOAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTLOAD_A) -> Self {
-        match variant {
-            ACTLOAD_A::NONE => 0,
-            ACTLOAD_A::INV => 1,
-            ACTLOAD_A::ZERO => 2,
-            ACTLOAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTLOAD`"]
@@ -206,25 +198,21 @@ impl<'a> ACTLOAD_W<'a> {
 }
 #[doc = "Action for Comparator A Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAU_A) -> Self {
-        match variant {
-            ACTCMPAU_A::NONE => 0,
-            ACTCMPAU_A::INV => 1,
-            ACTCMPAU_A::ZERO => 2,
-            ACTCMPAU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAU`"]
@@ -303,25 +291,21 @@ impl<'a> ACTCMPAU_W<'a> {
 }
 #[doc = "Action for Comparator A Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAD_A) -> Self {
-        match variant {
-            ACTCMPAD_A::NONE => 0,
-            ACTCMPAD_A::INV => 1,
-            ACTCMPAD_A::ZERO => 2,
-            ACTCMPAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAD`"]
@@ -400,25 +384,21 @@ impl<'a> ACTCMPAD_W<'a> {
 }
 #[doc = "Action for Comparator B Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBU_A) -> Self {
-        match variant {
-            ACTCMPBU_A::NONE => 0,
-            ACTCMPBU_A::INV => 1,
-            ACTCMPBU_A::ZERO => 2,
-            ACTCMPBU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBU`"]
@@ -497,25 +477,21 @@ impl<'a> ACTCMPBU_W<'a> {
 }
 #[doc = "Action for Comparator B Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBD_A) -> Self {
-        match variant {
-            ACTCMPBD_A::NONE => 0,
-            ACTCMPBD_A::INV => 1,
-            ACTCMPBD_A::ZERO => 2,
-            ACTCMPBD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBD`"]

--- a/crates/tm4c129x/src/pwm0/_2_genb.rs
+++ b/crates/tm4c129x/src/pwm0/_2_genb.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::_2_GENB {
 }
 #[doc = "Action for Counter=0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTZERO_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTZERO_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTZERO_A) -> Self {
-        match variant {
-            ACTZERO_A::NONE => 0,
-            ACTZERO_A::INV => 1,
-            ACTZERO_A::ZERO => 2,
-            ACTZERO_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTZERO`"]
@@ -109,25 +105,21 @@ impl<'a> ACTZERO_W<'a> {
 }
 #[doc = "Action for Counter=LOAD\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTLOAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTLOAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTLOAD_A) -> Self {
-        match variant {
-            ACTLOAD_A::NONE => 0,
-            ACTLOAD_A::INV => 1,
-            ACTLOAD_A::ZERO => 2,
-            ACTLOAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTLOAD`"]
@@ -206,25 +198,21 @@ impl<'a> ACTLOAD_W<'a> {
 }
 #[doc = "Action for Comparator A Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAU_A) -> Self {
-        match variant {
-            ACTCMPAU_A::NONE => 0,
-            ACTCMPAU_A::INV => 1,
-            ACTCMPAU_A::ZERO => 2,
-            ACTCMPAU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAU`"]
@@ -303,25 +291,21 @@ impl<'a> ACTCMPAU_W<'a> {
 }
 #[doc = "Action for Comparator A Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAD_A) -> Self {
-        match variant {
-            ACTCMPAD_A::NONE => 0,
-            ACTCMPAD_A::INV => 1,
-            ACTCMPAD_A::ZERO => 2,
-            ACTCMPAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAD`"]
@@ -400,25 +384,21 @@ impl<'a> ACTCMPAD_W<'a> {
 }
 #[doc = "Action for Comparator B Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBU_A) -> Self {
-        match variant {
-            ACTCMPBU_A::NONE => 0,
-            ACTCMPBU_A::INV => 1,
-            ACTCMPBU_A::ZERO => 2,
-            ACTCMPBU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBU`"]
@@ -497,25 +477,21 @@ impl<'a> ACTCMPBU_W<'a> {
 }
 #[doc = "Action for Comparator B Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBD_A) -> Self {
-        match variant {
-            ACTCMPBD_A::NONE => 0,
-            ACTCMPBD_A::INV => 1,
-            ACTCMPBD_A::ZERO => 2,
-            ACTCMPBD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBD`"]

--- a/crates/tm4c129x/src/pwm0/_3_ctl.rs
+++ b/crates/tm4c129x/src/pwm0/_3_ctl.rs
@@ -156,22 +156,19 @@ impl<'a> CMPBUPD_W<'a> {
 }
 #[doc = "PWMnGENA Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum GENAUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<GENAUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: GENAUPD_A) -> Self {
-        match variant {
-            GENAUPD_A::I => 0,
-            GENAUPD_A::LS => 2,
-            GENAUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `GENAUPD`"]
@@ -238,22 +235,19 @@ impl<'a> GENAUPD_W<'a> {
 }
 #[doc = "PWMnGENB Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum GENBUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<GENBUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: GENBUPD_A) -> Self {
-        match variant {
-            GENBUPD_A::I => 0,
-            GENBUPD_A::LS => 2,
-            GENBUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `GENBUPD`"]
@@ -320,22 +314,19 @@ impl<'a> GENBUPD_W<'a> {
 }
 #[doc = "PWMnDBCTL Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBCTLUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBCTLUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBCTLUPD_A) -> Self {
-        match variant {
-            DBCTLUPD_A::I => 0,
-            DBCTLUPD_A::LS => 2,
-            DBCTLUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBCTLUPD`"]
@@ -402,22 +393,19 @@ impl<'a> DBCTLUPD_W<'a> {
 }
 #[doc = "PWMnDBRISE Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBRISEUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBRISEUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBRISEUPD_A) -> Self {
-        match variant {
-            DBRISEUPD_A::I => 0,
-            DBRISEUPD_A::LS => 2,
-            DBRISEUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBRISEUPD`"]
@@ -484,22 +472,19 @@ impl<'a> DBRISEUPD_W<'a> {
 }
 #[doc = "PWMnDBFALL Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DBFALLUPD_A {
     #[doc = "0: Immediate"]
-    I,
+    I = 0,
     #[doc = "2: Locally Synchronized"]
-    LS,
+    LS = 2,
     #[doc = "3: Globally Synchronized"]
-    GS,
+    GS = 3,
 }
 impl From<DBFALLUPD_A> for u8 {
     #[inline(always)]
     fn from(variant: DBFALLUPD_A) -> Self {
-        match variant {
-            DBFALLUPD_A::I => 0,
-            DBFALLUPD_A::LS => 2,
-            DBFALLUPD_A::GS => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DBFALLUPD`"]

--- a/crates/tm4c129x/src/pwm0/_3_gena.rs
+++ b/crates/tm4c129x/src/pwm0/_3_gena.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::_3_GENA {
 }
 #[doc = "Action for Counter=0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTZERO_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTZERO_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTZERO_A) -> Self {
-        match variant {
-            ACTZERO_A::NONE => 0,
-            ACTZERO_A::INV => 1,
-            ACTZERO_A::ZERO => 2,
-            ACTZERO_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTZERO`"]
@@ -109,25 +105,21 @@ impl<'a> ACTZERO_W<'a> {
 }
 #[doc = "Action for Counter=LOAD\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTLOAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTLOAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTLOAD_A) -> Self {
-        match variant {
-            ACTLOAD_A::NONE => 0,
-            ACTLOAD_A::INV => 1,
-            ACTLOAD_A::ZERO => 2,
-            ACTLOAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTLOAD`"]
@@ -206,25 +198,21 @@ impl<'a> ACTLOAD_W<'a> {
 }
 #[doc = "Action for Comparator A Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAU_A) -> Self {
-        match variant {
-            ACTCMPAU_A::NONE => 0,
-            ACTCMPAU_A::INV => 1,
-            ACTCMPAU_A::ZERO => 2,
-            ACTCMPAU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAU`"]
@@ -303,25 +291,21 @@ impl<'a> ACTCMPAU_W<'a> {
 }
 #[doc = "Action for Comparator A Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAD_A) -> Self {
-        match variant {
-            ACTCMPAD_A::NONE => 0,
-            ACTCMPAD_A::INV => 1,
-            ACTCMPAD_A::ZERO => 2,
-            ACTCMPAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAD`"]
@@ -400,25 +384,21 @@ impl<'a> ACTCMPAD_W<'a> {
 }
 #[doc = "Action for Comparator B Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBU_A) -> Self {
-        match variant {
-            ACTCMPBU_A::NONE => 0,
-            ACTCMPBU_A::INV => 1,
-            ACTCMPBU_A::ZERO => 2,
-            ACTCMPBU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBU`"]
@@ -497,25 +477,21 @@ impl<'a> ACTCMPBU_W<'a> {
 }
 #[doc = "Action for Comparator B Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmA"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmA Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmA High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBD_A) -> Self {
-        match variant {
-            ACTCMPBD_A::NONE => 0,
-            ACTCMPBD_A::INV => 1,
-            ACTCMPBD_A::ZERO => 2,
-            ACTCMPBD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBD`"]

--- a/crates/tm4c129x/src/pwm0/_3_genb.rs
+++ b/crates/tm4c129x/src/pwm0/_3_genb.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::_3_GENB {
 }
 #[doc = "Action for Counter=0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTZERO_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTZERO_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTZERO_A) -> Self {
-        match variant {
-            ACTZERO_A::NONE => 0,
-            ACTZERO_A::INV => 1,
-            ACTZERO_A::ZERO => 2,
-            ACTZERO_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTZERO`"]
@@ -109,25 +105,21 @@ impl<'a> ACTZERO_W<'a> {
 }
 #[doc = "Action for Counter=LOAD\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTLOAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTLOAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTLOAD_A) -> Self {
-        match variant {
-            ACTLOAD_A::NONE => 0,
-            ACTLOAD_A::INV => 1,
-            ACTLOAD_A::ZERO => 2,
-            ACTLOAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTLOAD`"]
@@ -206,25 +198,21 @@ impl<'a> ACTLOAD_W<'a> {
 }
 #[doc = "Action for Comparator A Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAU_A) -> Self {
-        match variant {
-            ACTCMPAU_A::NONE => 0,
-            ACTCMPAU_A::INV => 1,
-            ACTCMPAU_A::ZERO => 2,
-            ACTCMPAU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAU`"]
@@ -303,25 +291,21 @@ impl<'a> ACTCMPAU_W<'a> {
 }
 #[doc = "Action for Comparator A Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPAD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPAD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPAD_A) -> Self {
-        match variant {
-            ACTCMPAD_A::NONE => 0,
-            ACTCMPAD_A::INV => 1,
-            ACTCMPAD_A::ZERO => 2,
-            ACTCMPAD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPAD`"]
@@ -400,25 +384,21 @@ impl<'a> ACTCMPAD_W<'a> {
 }
 #[doc = "Action for Comparator B Up\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBU_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBU_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBU_A) -> Self {
-        match variant {
-            ACTCMPBU_A::NONE => 0,
-            ACTCMPBU_A::INV => 1,
-            ACTCMPBU_A::ZERO => 2,
-            ACTCMPBU_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBU`"]
@@ -497,25 +477,21 @@ impl<'a> ACTCMPBU_W<'a> {
 }
 #[doc = "Action for Comparator B Down\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ACTCMPBD_A {
     #[doc = "0: Do nothing"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Invert pwmB"]
-    INV,
+    INV = 1,
     #[doc = "2: Drive pwmB Low"]
-    ZERO,
+    ZERO = 2,
     #[doc = "3: Drive pwmB High"]
-    ONE,
+    ONE = 3,
 }
 impl From<ACTCMPBD_A> for u8 {
     #[inline(always)]
     fn from(variant: ACTCMPBD_A) -> Self {
-        match variant {
-            ACTCMPBD_A::NONE => 0,
-            ACTCMPBD_A::INV => 1,
-            ACTCMPBD_A::ZERO => 2,
-            ACTCMPBD_A::ONE => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ACTCMPBD`"]

--- a/crates/tm4c129x/src/pwm0/cc.rs
+++ b/crates/tm4c129x/src/pwm0/cc.rs
@@ -12,31 +12,25 @@ impl crate::ResetValue for super::CC {
 }
 #[doc = "PWM Clock Divider\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PWMDIV_A {
     #[doc = "0: /2"]
-    _2,
+    _2 = 0,
     #[doc = "1: /4"]
-    _4,
+    _4 = 1,
     #[doc = "2: /8"]
-    _8,
+    _8 = 2,
     #[doc = "3: /16"]
-    _16,
+    _16 = 3,
     #[doc = "4: /32"]
-    _32,
+    _32 = 4,
     #[doc = "5: /64"]
-    _64,
+    _64 = 5,
 }
 impl From<PWMDIV_A> for u8 {
     #[inline(always)]
     fn from(variant: PWMDIV_A) -> Self {
-        match variant {
-            PWMDIV_A::_2 => 0,
-            PWMDIV_A::_4 => 1,
-            PWMDIV_A::_8 => 2,
-            PWMDIV_A::_16 => 3,
-            PWMDIV_A::_32 => 4,
-            PWMDIV_A::_64 => 5,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PWMDIV`"]

--- a/crates/tm4c129x/src/pwm0/enupd.rs
+++ b/crates/tm4c129x/src/pwm0/enupd.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::ENUPD {
 }
 #[doc = "MnPWM0 Enable Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ENUPD0_A {
     #[doc = "0: Immediate"]
-    IMM,
+    IMM = 0,
     #[doc = "2: Locally Synchronized"]
-    LSYNC,
+    LSYNC = 2,
     #[doc = "3: Globally Synchronized"]
-    GSYNC,
+    GSYNC = 3,
 }
 impl From<ENUPD0_A> for u8 {
     #[inline(always)]
     fn from(variant: ENUPD0_A) -> Self {
-        match variant {
-            ENUPD0_A::IMM => 0,
-            ENUPD0_A::LSYNC => 2,
-            ENUPD0_A::GSYNC => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ENUPD0`"]
@@ -94,22 +91,19 @@ impl<'a> ENUPD0_W<'a> {
 }
 #[doc = "MnPWM1 Enable Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ENUPD1_A {
     #[doc = "0: Immediate"]
-    IMM,
+    IMM = 0,
     #[doc = "2: Locally Synchronized"]
-    LSYNC,
+    LSYNC = 2,
     #[doc = "3: Globally Synchronized"]
-    GSYNC,
+    GSYNC = 3,
 }
 impl From<ENUPD1_A> for u8 {
     #[inline(always)]
     fn from(variant: ENUPD1_A) -> Self {
-        match variant {
-            ENUPD1_A::IMM => 0,
-            ENUPD1_A::LSYNC => 2,
-            ENUPD1_A::GSYNC => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ENUPD1`"]
@@ -176,22 +170,19 @@ impl<'a> ENUPD1_W<'a> {
 }
 #[doc = "MnPWM2 Enable Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ENUPD2_A {
     #[doc = "0: Immediate"]
-    IMM,
+    IMM = 0,
     #[doc = "2: Locally Synchronized"]
-    LSYNC,
+    LSYNC = 2,
     #[doc = "3: Globally Synchronized"]
-    GSYNC,
+    GSYNC = 3,
 }
 impl From<ENUPD2_A> for u8 {
     #[inline(always)]
     fn from(variant: ENUPD2_A) -> Self {
-        match variant {
-            ENUPD2_A::IMM => 0,
-            ENUPD2_A::LSYNC => 2,
-            ENUPD2_A::GSYNC => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ENUPD2`"]
@@ -258,22 +249,19 @@ impl<'a> ENUPD2_W<'a> {
 }
 #[doc = "MnPWM3 Enable Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ENUPD3_A {
     #[doc = "0: Immediate"]
-    IMM,
+    IMM = 0,
     #[doc = "2: Locally Synchronized"]
-    LSYNC,
+    LSYNC = 2,
     #[doc = "3: Globally Synchronized"]
-    GSYNC,
+    GSYNC = 3,
 }
 impl From<ENUPD3_A> for u8 {
     #[inline(always)]
     fn from(variant: ENUPD3_A) -> Self {
-        match variant {
-            ENUPD3_A::IMM => 0,
-            ENUPD3_A::LSYNC => 2,
-            ENUPD3_A::GSYNC => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ENUPD3`"]
@@ -340,22 +328,19 @@ impl<'a> ENUPD3_W<'a> {
 }
 #[doc = "MnPWM4 Enable Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ENUPD4_A {
     #[doc = "0: Immediate"]
-    IMM,
+    IMM = 0,
     #[doc = "2: Locally Synchronized"]
-    LSYNC,
+    LSYNC = 2,
     #[doc = "3: Globally Synchronized"]
-    GSYNC,
+    GSYNC = 3,
 }
 impl From<ENUPD4_A> for u8 {
     #[inline(always)]
     fn from(variant: ENUPD4_A) -> Self {
-        match variant {
-            ENUPD4_A::IMM => 0,
-            ENUPD4_A::LSYNC => 2,
-            ENUPD4_A::GSYNC => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ENUPD4`"]
@@ -422,22 +407,19 @@ impl<'a> ENUPD4_W<'a> {
 }
 #[doc = "MnPWM5 Enable Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ENUPD5_A {
     #[doc = "0: Immediate"]
-    IMM,
+    IMM = 0,
     #[doc = "2: Locally Synchronized"]
-    LSYNC,
+    LSYNC = 2,
     #[doc = "3: Globally Synchronized"]
-    GSYNC,
+    GSYNC = 3,
 }
 impl From<ENUPD5_A> for u8 {
     #[inline(always)]
     fn from(variant: ENUPD5_A) -> Self {
-        match variant {
-            ENUPD5_A::IMM => 0,
-            ENUPD5_A::LSYNC => 2,
-            ENUPD5_A::GSYNC => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ENUPD5`"]
@@ -504,22 +486,19 @@ impl<'a> ENUPD5_W<'a> {
 }
 #[doc = "MnPWM6 Enable Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ENUPD6_A {
     #[doc = "0: Immediate"]
-    IMM,
+    IMM = 0,
     #[doc = "2: Locally Synchronized"]
-    LSYNC,
+    LSYNC = 2,
     #[doc = "3: Globally Synchronized"]
-    GSYNC,
+    GSYNC = 3,
 }
 impl From<ENUPD6_A> for u8 {
     #[inline(always)]
     fn from(variant: ENUPD6_A) -> Self {
-        match variant {
-            ENUPD6_A::IMM => 0,
-            ENUPD6_A::LSYNC => 2,
-            ENUPD6_A::GSYNC => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ENUPD6`"]
@@ -586,22 +565,19 @@ impl<'a> ENUPD6_W<'a> {
 }
 #[doc = "MnPWM7 Enable Update Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ENUPD7_A {
     #[doc = "0: Immediate"]
-    IMM,
+    IMM = 0,
     #[doc = "2: Locally Synchronized"]
-    LSYNC,
+    LSYNC = 2,
     #[doc = "3: Globally Synchronized"]
-    GSYNC,
+    GSYNC = 3,
 }
 impl From<ENUPD7_A> for u8 {
     #[inline(always)]
     fn from(variant: ENUPD7_A) -> Self {
-        match variant {
-            ENUPD7_A::IMM => 0,
-            ENUPD7_A::LSYNC => 2,
-            ENUPD7_A::GSYNC => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ENUPD7`"]

--- a/crates/tm4c129x/src/qei0.rs
+++ b/crates/tm4c129x/src/qei0.rs
@@ -24,7 +24,7 @@ pub struct RegisterBlock {
     #[doc = "0x28 - QEI Interrupt Status and Clear"]
     pub isc: ISC,
 }
-#[doc = "QEI Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctl](ctl) module"]
+#[doc = "QEI Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctl](ctl) module"]
 pub type CTL = crate::Reg<u32, _CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -35,7 +35,7 @@ impl crate::Readable for CTL {}
 impl crate::Writable for CTL {}
 #[doc = "QEI Control"]
 pub mod ctl;
-#[doc = "QEI Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [stat](stat) module"]
+#[doc = "QEI Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [stat](stat) module"]
 pub type STAT = crate::Reg<u32, _STAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -44,7 +44,7 @@ pub struct _STAT;
 impl crate::Readable for STAT {}
 #[doc = "QEI Status"]
 pub mod stat;
-#[doc = "QEI Position\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pos](pos) module"]
+#[doc = "QEI Position\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pos](pos) module"]
 pub type POS = crate::Reg<u32, _POS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -55,7 +55,7 @@ impl crate::Readable for POS {}
 impl crate::Writable for POS {}
 #[doc = "QEI Position"]
 pub mod pos;
-#[doc = "QEI Maximum Position\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [maxpos](maxpos) module"]
+#[doc = "QEI Maximum Position\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [maxpos](maxpos) module"]
 pub type MAXPOS = crate::Reg<u32, _MAXPOS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -66,7 +66,7 @@ impl crate::Readable for MAXPOS {}
 impl crate::Writable for MAXPOS {}
 #[doc = "QEI Maximum Position"]
 pub mod maxpos;
-#[doc = "QEI Timer Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [load](load) module"]
+#[doc = "QEI Timer Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [load](load) module"]
 pub type LOAD = crate::Reg<u32, _LOAD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -77,7 +77,7 @@ impl crate::Readable for LOAD {}
 impl crate::Writable for LOAD {}
 #[doc = "QEI Timer Load"]
 pub mod load;
-#[doc = "QEI Timer\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [time](time) module"]
+#[doc = "QEI Timer\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [time](time) module"]
 pub type TIME = crate::Reg<u32, _TIME>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -86,7 +86,7 @@ pub struct _TIME;
 impl crate::Readable for TIME {}
 #[doc = "QEI Timer"]
 pub mod time;
-#[doc = "QEI Velocity Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [count](count) module"]
+#[doc = "QEI Velocity Counter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [count](count) module"]
 pub type COUNT = crate::Reg<u32, _COUNT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -95,7 +95,7 @@ pub struct _COUNT;
 impl crate::Readable for COUNT {}
 #[doc = "QEI Velocity Counter"]
 pub mod count;
-#[doc = "QEI Velocity\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [speed](speed) module"]
+#[doc = "QEI Velocity\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [speed](speed) module"]
 pub type SPEED = crate::Reg<u32, _SPEED>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -104,7 +104,7 @@ pub struct _SPEED;
 impl crate::Readable for SPEED {}
 #[doc = "QEI Velocity"]
 pub mod speed;
-#[doc = "QEI Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [inten](inten) module"]
+#[doc = "QEI Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [inten](inten) module"]
 pub type INTEN = crate::Reg<u32, _INTEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -115,7 +115,7 @@ impl crate::Readable for INTEN {}
 impl crate::Writable for INTEN {}
 #[doc = "QEI Interrupt Enable"]
 pub mod inten;
-#[doc = "QEI Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "QEI Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -124,7 +124,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "QEI Raw Interrupt Status"]
 pub mod ris;
-#[doc = "QEI Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [isc](isc) module"]
+#[doc = "QEI Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [isc](isc) module"]
 pub type ISC = crate::Reg<u32, _ISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/qei0/ctl.rs
+++ b/crates/tm4c129x/src/qei0/ctl.rs
@@ -156,37 +156,29 @@ impl<'a> VELEN_W<'a> {
 }
 #[doc = "Predivide Velocity\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum VELDIV_A {
     #[doc = "0: QEI clock /1"]
-    _1,
+    _1 = 0,
     #[doc = "1: QEI clock /2"]
-    _2,
+    _2 = 1,
     #[doc = "2: QEI clock /4"]
-    _4,
+    _4 = 2,
     #[doc = "3: QEI clock /8"]
-    _8,
+    _8 = 3,
     #[doc = "4: QEI clock /16"]
-    _16,
+    _16 = 4,
     #[doc = "5: QEI clock /32"]
-    _32,
+    _32 = 5,
     #[doc = "6: QEI clock /64"]
-    _64,
+    _64 = 6,
     #[doc = "7: QEI clock /128"]
-    _128,
+    _128 = 7,
 }
 impl From<VELDIV_A> for u8 {
     #[inline(always)]
     fn from(variant: VELDIV_A) -> Self {
-        match variant {
-            VELDIV_A::_1 => 0,
-            VELDIV_A::_2 => 1,
-            VELDIV_A::_4 => 2,
-            VELDIV_A::_8 => 3,
-            VELDIV_A::_16 => 4,
-            VELDIV_A::_32 => 5,
-            VELDIV_A::_64 => 6,
-            VELDIV_A::_128 => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `VELDIV`"]

--- a/crates/tm4c129x/src/ssi0.rs
+++ b/crates/tm4c129x/src/ssi0.rs
@@ -28,7 +28,7 @@ pub struct RegisterBlock {
     #[doc = "0xfc8 - SSI Clock Configuration"]
     pub cc: CC,
 }
-#[doc = "SSI Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cr0](cr0) module"]
+#[doc = "SSI Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cr0](cr0) module"]
 pub type CR0 = crate::Reg<u32, _CR0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -39,7 +39,7 @@ impl crate::Readable for CR0 {}
 impl crate::Writable for CR0 {}
 #[doc = "SSI Control 0"]
 pub mod cr0;
-#[doc = "SSI Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cr1](cr1) module"]
+#[doc = "SSI Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cr1](cr1) module"]
 pub type CR1 = crate::Reg<u32, _CR1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -50,7 +50,7 @@ impl crate::Readable for CR1 {}
 impl crate::Writable for CR1 {}
 #[doc = "SSI Control 1"]
 pub mod cr1;
-#[doc = "SSI Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dr](dr) module"]
+#[doc = "SSI Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dr](dr) module"]
 pub type DR = crate::Reg<u32, _DR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -61,7 +61,7 @@ impl crate::Readable for DR {}
 impl crate::Writable for DR {}
 #[doc = "SSI Data"]
 pub mod dr;
-#[doc = "SSI Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sr](sr) module"]
+#[doc = "SSI Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sr](sr) module"]
 pub type SR = crate::Reg<u32, _SR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -70,7 +70,7 @@ pub struct _SR;
 impl crate::Readable for SR {}
 #[doc = "SSI Status"]
 pub mod sr;
-#[doc = "SSI Clock Prescale\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cpsr](cpsr) module"]
+#[doc = "SSI Clock Prescale\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cpsr](cpsr) module"]
 pub type CPSR = crate::Reg<u32, _CPSR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -81,7 +81,7 @@ impl crate::Readable for CPSR {}
 impl crate::Writable for CPSR {}
 #[doc = "SSI Clock Prescale"]
 pub mod cpsr;
-#[doc = "SSI Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [im](im) module"]
+#[doc = "SSI Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [im](im) module"]
 pub type IM = crate::Reg<u32, _IM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -92,7 +92,7 @@ impl crate::Readable for IM {}
 impl crate::Writable for IM {}
 #[doc = "SSI Interrupt Mask"]
 pub mod im;
-#[doc = "SSI Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "SSI Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -101,7 +101,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "SSI Raw Interrupt Status"]
 pub mod ris;
-#[doc = "SSI Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mis](mis) module"]
+#[doc = "SSI Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mis](mis) module"]
 pub type MIS = crate::Reg<u32, _MIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -110,7 +110,7 @@ pub struct _MIS;
 impl crate::Readable for MIS {}
 #[doc = "SSI Masked Interrupt Status"]
 pub mod mis;
-#[doc = "SSI Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [icr](icr) module"]
+#[doc = "SSI Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [icr](icr) module"]
 pub type ICR = crate::Reg<u32, _ICR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -119,7 +119,7 @@ pub struct _ICR;
 impl crate::Writable for ICR {}
 #[doc = "SSI Interrupt Clear"]
 pub mod icr;
-#[doc = "SSI DMA Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmactl](dmactl) module"]
+#[doc = "SSI DMA Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmactl](dmactl) module"]
 pub type DMACTL = crate::Reg<u32, _DMACTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -130,7 +130,7 @@ impl crate::Readable for DMACTL {}
 impl crate::Writable for DMACTL {}
 #[doc = "SSI DMA Control"]
 pub mod dmactl;
-#[doc = "SSI Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "SSI Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -139,7 +139,7 @@ pub struct _PP;
 impl crate::Readable for PP {}
 #[doc = "SSI Peripheral Properties"]
 pub mod pp;
-#[doc = "SSI Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc](cc) module"]
+#[doc = "SSI Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cc](cc) module"]
 pub type CC = crate::Reg<u32, _CC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/ssi0/cc.rs
+++ b/crates/tm4c129x/src/ssi0/cc.rs
@@ -12,19 +12,17 @@ impl crate::ResetValue for super::CC {
 }
 #[doc = "SSI Baud Clock Source\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CS_A {
     #[doc = "0: System clock (based on clock source and divisor factor)"]
-    SYSPLL,
+    SYSPLL = 0,
     #[doc = "5: PIOSC"]
-    PIOSC,
+    PIOSC = 5,
 }
 impl From<CS_A> for u8 {
     #[inline(always)]
     fn from(variant: CS_A) -> Self {
-        match variant {
-            CS_A::SYSPLL => 0,
-            CS_A::PIOSC => 5,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CS`"]

--- a/crates/tm4c129x/src/ssi0/cr0.rs
+++ b/crates/tm4c129x/src/ssi0/cr0.rs
@@ -12,52 +12,39 @@ impl crate::ResetValue for super::CR0 {
 }
 #[doc = "SSI Data Size Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DSS_A {
     #[doc = "3: 4-bit data"]
-    _4,
+    _4 = 3,
     #[doc = "4: 5-bit data"]
-    _5,
+    _5 = 4,
     #[doc = "5: 6-bit data"]
-    _6,
+    _6 = 5,
     #[doc = "6: 7-bit data"]
-    _7,
+    _7 = 6,
     #[doc = "7: 8-bit data"]
-    _8,
+    _8 = 7,
     #[doc = "8: 9-bit data"]
-    _9,
+    _9 = 8,
     #[doc = "9: 10-bit data"]
-    _10,
+    _10 = 9,
     #[doc = "10: 11-bit data"]
-    _11,
+    _11 = 10,
     #[doc = "11: 12-bit data"]
-    _12,
+    _12 = 11,
     #[doc = "12: 13-bit data"]
-    _13,
+    _13 = 12,
     #[doc = "13: 14-bit data"]
-    _14,
+    _14 = 13,
     #[doc = "14: 15-bit data"]
-    _15,
+    _15 = 14,
     #[doc = "15: 16-bit data"]
-    _16,
+    _16 = 15,
 }
 impl From<DSS_A> for u8 {
     #[inline(always)]
     fn from(variant: DSS_A) -> Self {
-        match variant {
-            DSS_A::_4 => 3,
-            DSS_A::_5 => 4,
-            DSS_A::_6 => 5,
-            DSS_A::_7 => 6,
-            DSS_A::_8 => 7,
-            DSS_A::_9 => 8,
-            DSS_A::_10 => 9,
-            DSS_A::_11 => 10,
-            DSS_A::_12 => 11,
-            DSS_A::_13 => 12,
-            DSS_A::_14 => 13,
-            DSS_A::_15 => 14,
-            DSS_A::_16 => 15,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DSS`"]
@@ -234,19 +221,17 @@ impl<'a> DSS_W<'a> {
 }
 #[doc = "SSI Frame Format Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum FRF_A {
     #[doc = "0: Freescale SPI Frame Format"]
-    MOTO,
+    MOTO = 0,
     #[doc = "1: Synchronous Serial Frame Format"]
-    TI,
+    TI = 1,
 }
 impl From<FRF_A> for u8 {
     #[inline(always)]
     fn from(variant: FRF_A) -> Self {
-        match variant {
-            FRF_A::MOTO => 0,
-            FRF_A::TI => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `FRF`"]

--- a/crates/tm4c129x/src/ssi0/cr1.rs
+++ b/crates/tm4c129x/src/ssi0/cr1.rs
@@ -108,25 +108,21 @@ impl<'a> EOT_W<'a> {
 }
 #[doc = "SSI Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MODE_A {
     #[doc = "0: Legacy SSI mode"]
-    LEGACY,
+    LEGACY = 0,
     #[doc = "1: Bi-SSI mode"]
-    BI,
+    BI = 1,
     #[doc = "2: Quad-SSI Mode"]
-    QUAD,
+    QUAD = 2,
     #[doc = "3: Advanced SSI Mode with 8-bit packet size"]
-    ADVANCED,
+    ADVANCED = 3,
 }
 impl From<MODE_A> for u8 {
     #[inline(always)]
     fn from(variant: MODE_A) -> Self {
-        match variant {
-            MODE_A::LEGACY => 0,
-            MODE_A::BI => 1,
-            MODE_A::QUAD => 2,
-            MODE_A::ADVANCED => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MODE`"]

--- a/crates/tm4c129x/src/ssi0/pp.rs
+++ b/crates/tm4c129x/src/ssi0/pp.rs
@@ -4,22 +4,19 @@ pub type R = crate::R<u32, super::PP>;
 pub type HSCLK_R = crate::R<bool, bool>;
 #[doc = "Mode of Operation\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MODE_A {
     #[doc = "0: Legacy SSI mode"]
-    LEGACY,
+    LEGACY = 0,
     #[doc = "1: Legacy mode, Advanced SSI mode and Bi-SSI mode enabled"]
-    ADVBI,
+    ADVBI = 1,
     #[doc = "2: Legacy mode, Advanced mode, Bi-SSI and Quad-SSI mode enabled"]
-    ADVBIQUAD,
+    ADVBIQUAD = 2,
 }
 impl From<MODE_A> for u8 {
     #[inline(always)]
     fn from(variant: MODE_A) -> Self {
-        match variant {
-            MODE_A::LEGACY => 0,
-            MODE_A::ADVBI => 1,
-            MODE_A::ADVBIQUAD => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MODE`"]

--- a/crates/tm4c129x/src/sysctl.rs
+++ b/crates/tm4c129x/src/sysctl.rs
@@ -407,7 +407,7 @@ pub struct RegisterBlock {
     #[doc = "0xa9c - Ethernet MAC Peripheral Ready"]
     pub premac: PREMAC,
 }
-#[doc = "Device Identification 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [did0](did0) module"]
+#[doc = "Device Identification 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [did0](did0) module"]
 pub type DID0 = crate::Reg<u32, _DID0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -416,7 +416,7 @@ pub struct _DID0;
 impl crate::Readable for DID0 {}
 #[doc = "Device Identification 0"]
 pub mod did0;
-#[doc = "Device Identification 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [did1](did1) module"]
+#[doc = "Device Identification 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [did1](did1) module"]
 pub type DID1 = crate::Reg<u32, _DID1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -425,7 +425,7 @@ pub struct _DID1;
 impl crate::Readable for DID1 {}
 #[doc = "Device Identification 1"]
 pub mod did1;
-#[doc = "Power-Temp Brown Out Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ptboctl](ptboctl) module"]
+#[doc = "Power-Temp Brown Out Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ptboctl](ptboctl) module"]
 pub type PTBOCTL = crate::Reg<u32, _PTBOCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -436,7 +436,7 @@ impl crate::Readable for PTBOCTL {}
 impl crate::Writable for PTBOCTL {}
 #[doc = "Power-Temp Brown Out Control"]
 pub mod ptboctl;
-#[doc = "Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -445,7 +445,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "Raw Interrupt Status"]
 pub mod ris;
-#[doc = "Interrupt Mask Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [imc](imc) module"]
+#[doc = "Interrupt Mask Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [imc](imc) module"]
 pub type IMC = crate::Reg<u32, _IMC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -456,7 +456,7 @@ impl crate::Readable for IMC {}
 impl crate::Writable for IMC {}
 #[doc = "Interrupt Mask Control"]
 pub mod imc;
-#[doc = "Masked Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [misc](misc) module"]
+#[doc = "Masked Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [misc](misc) module"]
 pub type MISC = crate::Reg<u32, _MISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -467,7 +467,7 @@ impl crate::Readable for MISC {}
 impl crate::Writable for MISC {}
 #[doc = "Masked Interrupt Status and Clear"]
 pub mod misc;
-#[doc = "Reset Cause\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [resc](resc) module"]
+#[doc = "Reset Cause\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [resc](resc) module"]
 pub type RESC = crate::Reg<u32, _RESC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -478,7 +478,7 @@ impl crate::Readable for RESC {}
 impl crate::Writable for RESC {}
 #[doc = "Reset Cause"]
 pub mod resc;
-#[doc = "Power-Temperature Cause\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pwrtc](pwrtc) module"]
+#[doc = "Power-Temperature Cause\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pwrtc](pwrtc) module"]
 pub type PWRTC = crate::Reg<u32, _PWRTC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -489,7 +489,7 @@ impl crate::Readable for PWRTC {}
 impl crate::Writable for PWRTC {}
 #[doc = "Power-Temperature Cause"]
 pub mod pwrtc;
-#[doc = "NMI Cause Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [nmic](nmic) module"]
+#[doc = "NMI Cause Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [nmic](nmic) module"]
 pub type NMIC = crate::Reg<u32, _NMIC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -500,7 +500,7 @@ impl crate::Readable for NMIC {}
 impl crate::Writable for NMIC {}
 #[doc = "NMI Cause Register"]
 pub mod nmic;
-#[doc = "Main Oscillator Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [moscctl](moscctl) module"]
+#[doc = "Main Oscillator Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [moscctl](moscctl) module"]
 pub type MOSCCTL = crate::Reg<u32, _MOSCCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -511,7 +511,7 @@ impl crate::Readable for MOSCCTL {}
 impl crate::Writable for MOSCCTL {}
 #[doc = "Main Oscillator Control"]
 pub mod moscctl;
-#[doc = "Run and Sleep Mode Configuration Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rsclkcfg](rsclkcfg) module"]
+#[doc = "Run and Sleep Mode Configuration Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rsclkcfg](rsclkcfg) module"]
 pub type RSCLKCFG = crate::Reg<u32, _RSCLKCFG>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -522,7 +522,7 @@ impl crate::Readable for RSCLKCFG {}
 impl crate::Writable for RSCLKCFG {}
 #[doc = "Run and Sleep Mode Configuration Register"]
 pub mod rsclkcfg;
-#[doc = "Memory Timing Parameter Register 0 for Main Flash and EEPROM\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [memtim0](memtim0) module"]
+#[doc = "Memory Timing Parameter Register 0 for Main Flash and EEPROM\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [memtim0](memtim0) module"]
 pub type MEMTIM0 = crate::Reg<u32, _MEMTIM0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -533,7 +533,7 @@ impl crate::Readable for MEMTIM0 {}
 impl crate::Writable for MEMTIM0 {}
 #[doc = "Memory Timing Parameter Register 0 for Main Flash and EEPROM"]
 pub mod memtim0;
-#[doc = "Alternate Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [altclkcfg](altclkcfg) module"]
+#[doc = "Alternate Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [altclkcfg](altclkcfg) module"]
 pub type ALTCLKCFG = crate::Reg<u32, _ALTCLKCFG>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -544,7 +544,7 @@ impl crate::Readable for ALTCLKCFG {}
 impl crate::Writable for ALTCLKCFG {}
 #[doc = "Alternate Clock Configuration"]
 pub mod altclkcfg;
-#[doc = "Deep Sleep Clock Configuration Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dsclkcfg](dsclkcfg) module"]
+#[doc = "Deep Sleep Clock Configuration Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dsclkcfg](dsclkcfg) module"]
 pub type DSCLKCFG = crate::Reg<u32, _DSCLKCFG>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -555,7 +555,7 @@ impl crate::Readable for DSCLKCFG {}
 impl crate::Writable for DSCLKCFG {}
 #[doc = "Deep Sleep Clock Configuration Register"]
 pub mod dsclkcfg;
-#[doc = "Divisor and Source Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [divsclk](divsclk) module"]
+#[doc = "Divisor and Source Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [divsclk](divsclk) module"]
 pub type DIVSCLK = crate::Reg<u32, _DIVSCLK>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -566,7 +566,7 @@ impl crate::Readable for DIVSCLK {}
 impl crate::Writable for DIVSCLK {}
 #[doc = "Divisor and Source Clock Configuration"]
 pub mod divsclk;
-#[doc = "System Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sysprop](sysprop) module"]
+#[doc = "System Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sysprop](sysprop) module"]
 pub type SYSPROP = crate::Reg<u32, _SYSPROP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -575,7 +575,7 @@ pub struct _SYSPROP;
 impl crate::Readable for SYSPROP {}
 #[doc = "System Properties"]
 pub mod sysprop;
-#[doc = "Precision Internal Oscillator Calibration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [piosccal](piosccal) module"]
+#[doc = "Precision Internal Oscillator Calibration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [piosccal](piosccal) module"]
 pub type PIOSCCAL = crate::Reg<u32, _PIOSCCAL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -586,7 +586,7 @@ impl crate::Readable for PIOSCCAL {}
 impl crate::Writable for PIOSCCAL {}
 #[doc = "Precision Internal Oscillator Calibration"]
 pub mod piosccal;
-#[doc = "Precision Internal Oscillator Statistics\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pioscstat](pioscstat) module"]
+#[doc = "Precision Internal Oscillator Statistics\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pioscstat](pioscstat) module"]
 pub type PIOSCSTAT = crate::Reg<u32, _PIOSCSTAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -595,7 +595,7 @@ pub struct _PIOSCSTAT;
 impl crate::Readable for PIOSCSTAT {}
 #[doc = "Precision Internal Oscillator Statistics"]
 pub mod pioscstat;
-#[doc = "PLL Frequency 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pllfreq0](pllfreq0) module"]
+#[doc = "PLL Frequency 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pllfreq0](pllfreq0) module"]
 pub type PLLFREQ0 = crate::Reg<u32, _PLLFREQ0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -606,7 +606,7 @@ impl crate::Readable for PLLFREQ0 {}
 impl crate::Writable for PLLFREQ0 {}
 #[doc = "PLL Frequency 0"]
 pub mod pllfreq0;
-#[doc = "PLL Frequency 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pllfreq1](pllfreq1) module"]
+#[doc = "PLL Frequency 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pllfreq1](pllfreq1) module"]
 pub type PLLFREQ1 = crate::Reg<u32, _PLLFREQ1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -617,7 +617,7 @@ impl crate::Readable for PLLFREQ1 {}
 impl crate::Writable for PLLFREQ1 {}
 #[doc = "PLL Frequency 1"]
 pub mod pllfreq1;
-#[doc = "PLL Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pllstat](pllstat) module"]
+#[doc = "PLL Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pllstat](pllstat) module"]
 pub type PLLSTAT = crate::Reg<u32, _PLLSTAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -626,7 +626,7 @@ pub struct _PLLSTAT;
 impl crate::Readable for PLLSTAT {}
 #[doc = "PLL Status"]
 pub mod pllstat;
-#[doc = "Sleep Power Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [slppwrcfg](slppwrcfg) module"]
+#[doc = "Sleep Power Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [slppwrcfg](slppwrcfg) module"]
 pub type SLPPWRCFG = crate::Reg<u32, _SLPPWRCFG>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -637,7 +637,7 @@ impl crate::Readable for SLPPWRCFG {}
 impl crate::Writable for SLPPWRCFG {}
 #[doc = "Sleep Power Configuration"]
 pub mod slppwrcfg;
-#[doc = "Deep-Sleep Power Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dslppwrcfg](dslppwrcfg) module"]
+#[doc = "Deep-Sleep Power Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dslppwrcfg](dslppwrcfg) module"]
 pub type DSLPPWRCFG = crate::Reg<u32, _DSLPPWRCFG>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -648,7 +648,7 @@ impl crate::Readable for DSLPPWRCFG {}
 impl crate::Writable for DSLPPWRCFG {}
 #[doc = "Deep-Sleep Power Configuration"]
 pub mod dslppwrcfg;
-#[doc = "Non-Volatile Memory Information\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [nvmstat](nvmstat) module"]
+#[doc = "Non-Volatile Memory Information\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [nvmstat](nvmstat) module"]
 pub type NVMSTAT = crate::Reg<u32, _NVMSTAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -657,7 +657,7 @@ pub struct _NVMSTAT;
 impl crate::Readable for NVMSTAT {}
 #[doc = "Non-Volatile Memory Information"]
 pub mod nvmstat;
-#[doc = "LDO Sleep Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ldospctl](ldospctl) module"]
+#[doc = "LDO Sleep Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ldospctl](ldospctl) module"]
 pub type LDOSPCTL = crate::Reg<u32, _LDOSPCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -668,7 +668,7 @@ impl crate::Readable for LDOSPCTL {}
 impl crate::Writable for LDOSPCTL {}
 #[doc = "LDO Sleep Power Control"]
 pub mod ldospctl;
-#[doc = "LDO Deep-Sleep Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ldodpctl](ldodpctl) module"]
+#[doc = "LDO Deep-Sleep Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ldodpctl](ldodpctl) module"]
 pub type LDODPCTL = crate::Reg<u32, _LDODPCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -679,7 +679,7 @@ impl crate::Readable for LDODPCTL {}
 impl crate::Writable for LDODPCTL {}
 #[doc = "LDO Deep-Sleep Power Control"]
 pub mod ldodpctl;
-#[doc = "Reset Behavior Control Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [resbehavctl](resbehavctl) module"]
+#[doc = "Reset Behavior Control Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [resbehavctl](resbehavctl) module"]
 pub type RESBEHAVCTL = crate::Reg<u32, _RESBEHAVCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -690,7 +690,7 @@ impl crate::Readable for RESBEHAVCTL {}
 impl crate::Writable for RESBEHAVCTL {}
 #[doc = "Reset Behavior Control Register"]
 pub mod resbehavctl;
-#[doc = "Hardware System Service Request\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hssr](hssr) module"]
+#[doc = "Hardware System Service Request\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hssr](hssr) module"]
 pub type HSSR = crate::Reg<u32, _HSSR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -701,7 +701,7 @@ impl crate::Readable for HSSR {}
 impl crate::Writable for HSSR {}
 #[doc = "Hardware System Service Request"]
 pub mod hssr;
-#[doc = "USB Power Domain Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [usbpds](usbpds) module"]
+#[doc = "USB Power Domain Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [usbpds](usbpds) module"]
 pub type USBPDS = crate::Reg<u32, _USBPDS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -710,7 +710,7 @@ pub struct _USBPDS;
 impl crate::Readable for USBPDS {}
 #[doc = "USB Power Domain Status"]
 pub mod usbpds;
-#[doc = "USB Memory Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [usbmpc](usbmpc) module"]
+#[doc = "USB Memory Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [usbmpc](usbmpc) module"]
 pub type USBMPC = crate::Reg<u32, _USBMPC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -721,7 +721,7 @@ impl crate::Readable for USBMPC {}
 impl crate::Writable for USBMPC {}
 #[doc = "USB Memory Power Control"]
 pub mod usbmpc;
-#[doc = "Ethernet MAC Power Domain Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [emacpds](emacpds) module"]
+#[doc = "Ethernet MAC Power Domain Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [emacpds](emacpds) module"]
 pub type EMACPDS = crate::Reg<u32, _EMACPDS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -730,7 +730,7 @@ pub struct _EMACPDS;
 impl crate::Readable for EMACPDS {}
 #[doc = "Ethernet MAC Power Domain Status"]
 pub mod emacpds;
-#[doc = "Ethernet MAC Memory Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [emacmpc](emacmpc) module"]
+#[doc = "Ethernet MAC Memory Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [emacmpc](emacmpc) module"]
 pub type EMACMPC = crate::Reg<u32, _EMACMPC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -741,7 +741,7 @@ impl crate::Readable for EMACMPC {}
 impl crate::Writable for EMACMPC {}
 #[doc = "Ethernet MAC Memory Power Control"]
 pub mod emacmpc;
-#[doc = "Watchdog Timer Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppwd](ppwd) module"]
+#[doc = "Watchdog Timer Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppwd](ppwd) module"]
 pub type PPWD = crate::Reg<u32, _PPWD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -750,7 +750,7 @@ pub struct _PPWD;
 impl crate::Readable for PPWD {}
 #[doc = "Watchdog Timer Peripheral Present"]
 pub mod ppwd;
-#[doc = "16/32-Bit General-Purpose Timer Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pptimer](pptimer) module"]
+#[doc = "16/32-Bit General-Purpose Timer Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pptimer](pptimer) module"]
 pub type PPTIMER = crate::Reg<u32, _PPTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -759,7 +759,7 @@ pub struct _PPTIMER;
 impl crate::Readable for PPTIMER {}
 #[doc = "16/32-Bit General-Purpose Timer Peripheral Present"]
 pub mod pptimer;
-#[doc = "General-Purpose Input/Output Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppgpio](ppgpio) module"]
+#[doc = "General-Purpose Input/Output Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppgpio](ppgpio) module"]
 pub type PPGPIO = crate::Reg<u32, _PPGPIO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -768,7 +768,7 @@ pub struct _PPGPIO;
 impl crate::Readable for PPGPIO {}
 #[doc = "General-Purpose Input/Output Peripheral Present"]
 pub mod ppgpio;
-#[doc = "Micro Direct Memory Access Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppdma](ppdma) module"]
+#[doc = "Micro Direct Memory Access Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppdma](ppdma) module"]
 pub type PPDMA = crate::Reg<u32, _PPDMA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -777,7 +777,7 @@ pub struct _PPDMA;
 impl crate::Readable for PPDMA {}
 #[doc = "Micro Direct Memory Access Peripheral Present"]
 pub mod ppdma;
-#[doc = "EPI Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppepi](ppepi) module"]
+#[doc = "EPI Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppepi](ppepi) module"]
 pub type PPEPI = crate::Reg<u32, _PPEPI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -786,7 +786,7 @@ pub struct _PPEPI;
 impl crate::Readable for PPEPI {}
 #[doc = "EPI Peripheral Present"]
 pub mod ppepi;
-#[doc = "Hibernation Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pphib](pphib) module"]
+#[doc = "Hibernation Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pphib](pphib) module"]
 pub type PPHIB = crate::Reg<u32, _PPHIB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -795,7 +795,7 @@ pub struct _PPHIB;
 impl crate::Readable for PPHIB {}
 #[doc = "Hibernation Peripheral Present"]
 pub mod pphib;
-#[doc = "Universal Asynchronous Receiver/Transmitter Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppuart](ppuart) module"]
+#[doc = "Universal Asynchronous Receiver/Transmitter Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppuart](ppuart) module"]
 pub type PPUART = crate::Reg<u32, _PPUART>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -804,7 +804,7 @@ pub struct _PPUART;
 impl crate::Readable for PPUART {}
 #[doc = "Universal Asynchronous Receiver/Transmitter Peripheral Present"]
 pub mod ppuart;
-#[doc = "Synchronous Serial Interface Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppssi](ppssi) module"]
+#[doc = "Synchronous Serial Interface Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppssi](ppssi) module"]
 pub type PPSSI = crate::Reg<u32, _PPSSI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -813,7 +813,7 @@ pub struct _PPSSI;
 impl crate::Readable for PPSSI {}
 #[doc = "Synchronous Serial Interface Peripheral Present"]
 pub mod ppssi;
-#[doc = "Inter-Integrated Circuit Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppi2c](ppi2c) module"]
+#[doc = "Inter-Integrated Circuit Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppi2c](ppi2c) module"]
 pub type PPI2C = crate::Reg<u32, _PPI2C>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -822,7 +822,7 @@ pub struct _PPI2C;
 impl crate::Readable for PPI2C {}
 #[doc = "Inter-Integrated Circuit Peripheral Present"]
 pub mod ppi2c;
-#[doc = "Universal Serial Bus Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppusb](ppusb) module"]
+#[doc = "Universal Serial Bus Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppusb](ppusb) module"]
 pub type PPUSB = crate::Reg<u32, _PPUSB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -831,7 +831,7 @@ pub struct _PPUSB;
 impl crate::Readable for PPUSB {}
 #[doc = "Universal Serial Bus Peripheral Present"]
 pub mod ppusb;
-#[doc = "Ethernet PHY Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppephy](ppephy) module"]
+#[doc = "Ethernet PHY Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppephy](ppephy) module"]
 pub type PPEPHY = crate::Reg<u32, _PPEPHY>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -840,7 +840,7 @@ pub struct _PPEPHY;
 impl crate::Readable for PPEPHY {}
 #[doc = "Ethernet PHY Peripheral Present"]
 pub mod ppephy;
-#[doc = "Controller Area Network Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppcan](ppcan) module"]
+#[doc = "Controller Area Network Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppcan](ppcan) module"]
 pub type PPCAN = crate::Reg<u32, _PPCAN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -849,7 +849,7 @@ pub struct _PPCAN;
 impl crate::Readable for PPCAN {}
 #[doc = "Controller Area Network Peripheral Present"]
 pub mod ppcan;
-#[doc = "Analog-to-Digital Converter Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppadc](ppadc) module"]
+#[doc = "Analog-to-Digital Converter Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppadc](ppadc) module"]
 pub type PPADC = crate::Reg<u32, _PPADC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -858,7 +858,7 @@ pub struct _PPADC;
 impl crate::Readable for PPADC {}
 #[doc = "Analog-to-Digital Converter Peripheral Present"]
 pub mod ppadc;
-#[doc = "Analog Comparator Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppacmp](ppacmp) module"]
+#[doc = "Analog Comparator Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppacmp](ppacmp) module"]
 pub type PPACMP = crate::Reg<u32, _PPACMP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -867,7 +867,7 @@ pub struct _PPACMP;
 impl crate::Readable for PPACMP {}
 #[doc = "Analog Comparator Peripheral Present"]
 pub mod ppacmp;
-#[doc = "Pulse Width Modulator Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pppwm](pppwm) module"]
+#[doc = "Pulse Width Modulator Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pppwm](pppwm) module"]
 pub type PPPWM = crate::Reg<u32, _PPPWM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -876,7 +876,7 @@ pub struct _PPPWM;
 impl crate::Readable for PPPWM {}
 #[doc = "Pulse Width Modulator Peripheral Present"]
 pub mod pppwm;
-#[doc = "Quadrature Encoder Interface Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppqei](ppqei) module"]
+#[doc = "Quadrature Encoder Interface Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppqei](ppqei) module"]
 pub type PPQEI = crate::Reg<u32, _PPQEI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -885,7 +885,7 @@ pub struct _PPQEI;
 impl crate::Readable for PPQEI {}
 #[doc = "Quadrature Encoder Interface Peripheral Present"]
 pub mod ppqei;
-#[doc = "Low Pin Count Interface Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pplpc](pplpc) module"]
+#[doc = "Low Pin Count Interface Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pplpc](pplpc) module"]
 pub type PPLPC = crate::Reg<u32, _PPLPC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -894,7 +894,7 @@ pub struct _PPLPC;
 impl crate::Readable for PPLPC {}
 #[doc = "Low Pin Count Interface Peripheral Present"]
 pub mod pplpc;
-#[doc = "Platform Environment Control Interface Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pppeci](pppeci) module"]
+#[doc = "Platform Environment Control Interface Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pppeci](pppeci) module"]
 pub type PPPECI = crate::Reg<u32, _PPPECI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -903,7 +903,7 @@ pub struct _PPPECI;
 impl crate::Readable for PPPECI {}
 #[doc = "Platform Environment Control Interface Peripheral Present"]
 pub mod pppeci;
-#[doc = "Fan Control Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppfan](ppfan) module"]
+#[doc = "Fan Control Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppfan](ppfan) module"]
 pub type PPFAN = crate::Reg<u32, _PPFAN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -912,7 +912,7 @@ pub struct _PPFAN;
 impl crate::Readable for PPFAN {}
 #[doc = "Fan Control Peripheral Present"]
 pub mod ppfan;
-#[doc = "EEPROM Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppeeprom](ppeeprom) module"]
+#[doc = "EEPROM Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppeeprom](ppeeprom) module"]
 pub type PPEEPROM = crate::Reg<u32, _PPEEPROM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -921,7 +921,7 @@ pub struct _PPEEPROM;
 impl crate::Readable for PPEEPROM {}
 #[doc = "EEPROM Peripheral Present"]
 pub mod ppeeprom;
-#[doc = "32/64-Bit Wide General-Purpose Timer Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppwtimer](ppwtimer) module"]
+#[doc = "32/64-Bit Wide General-Purpose Timer Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppwtimer](ppwtimer) module"]
 pub type PPWTIMER = crate::Reg<u32, _PPWTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -930,7 +930,7 @@ pub struct _PPWTIMER;
 impl crate::Readable for PPWTIMER {}
 #[doc = "32/64-Bit Wide General-Purpose Timer Peripheral Present"]
 pub mod ppwtimer;
-#[doc = "Remote Temperature Sensor Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pprts](pprts) module"]
+#[doc = "Remote Temperature Sensor Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pprts](pprts) module"]
 pub type PPRTS = crate::Reg<u32, _PPRTS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -939,7 +939,7 @@ pub struct _PPRTS;
 impl crate::Readable for PPRTS {}
 #[doc = "Remote Temperature Sensor Peripheral Present"]
 pub mod pprts;
-#[doc = "CRC and Cryptographic Modules Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppccm](ppccm) module"]
+#[doc = "CRC and Cryptographic Modules Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppccm](ppccm) module"]
 pub type PPCCM = crate::Reg<u32, _PPCCM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -948,7 +948,7 @@ pub struct _PPCCM;
 impl crate::Readable for PPCCM {}
 #[doc = "CRC and Cryptographic Modules Peripheral Present"]
 pub mod ppccm;
-#[doc = "LCD Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pplcd](pplcd) module"]
+#[doc = "LCD Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pplcd](pplcd) module"]
 pub type PPLCD = crate::Reg<u32, _PPLCD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -957,7 +957,7 @@ pub struct _PPLCD;
 impl crate::Readable for PPLCD {}
 #[doc = "LCD Peripheral Present"]
 pub mod pplcd;
-#[doc = "1-Wire Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppowire](ppowire) module"]
+#[doc = "1-Wire Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppowire](ppowire) module"]
 pub type PPOWIRE = crate::Reg<u32, _PPOWIRE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -966,7 +966,7 @@ pub struct _PPOWIRE;
 impl crate::Readable for PPOWIRE {}
 #[doc = "1-Wire Peripheral Present"]
 pub mod ppowire;
-#[doc = "Ethernet MAC Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ppemac](ppemac) module"]
+#[doc = "Ethernet MAC Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ppemac](ppemac) module"]
 pub type PPEMAC = crate::Reg<u32, _PPEMAC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -975,7 +975,7 @@ pub struct _PPEMAC;
 impl crate::Readable for PPEMAC {}
 #[doc = "Ethernet MAC Peripheral Present"]
 pub mod ppemac;
-#[doc = "Human Interface Master Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pphim](pphim) module"]
+#[doc = "Human Interface Master Peripheral Present\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pphim](pphim) module"]
 pub type PPHIM = crate::Reg<u32, _PPHIM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -984,7 +984,7 @@ pub struct _PPHIM;
 impl crate::Readable for PPHIM {}
 #[doc = "Human Interface Master Peripheral Present"]
 pub mod pphim;
-#[doc = "Watchdog Timer Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srwd](srwd) module"]
+#[doc = "Watchdog Timer Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srwd](srwd) module"]
 pub type SRWD = crate::Reg<u32, _SRWD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -995,7 +995,7 @@ impl crate::Readable for SRWD {}
 impl crate::Writable for SRWD {}
 #[doc = "Watchdog Timer Software Reset"]
 pub mod srwd;
-#[doc = "16/32-Bit General-Purpose Timer Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srtimer](srtimer) module"]
+#[doc = "16/32-Bit General-Purpose Timer Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srtimer](srtimer) module"]
 pub type SRTIMER = crate::Reg<u32, _SRTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1006,7 +1006,7 @@ impl crate::Readable for SRTIMER {}
 impl crate::Writable for SRTIMER {}
 #[doc = "16/32-Bit General-Purpose Timer Software Reset"]
 pub mod srtimer;
-#[doc = "General-Purpose Input/Output Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srgpio](srgpio) module"]
+#[doc = "General-Purpose Input/Output Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srgpio](srgpio) module"]
 pub type SRGPIO = crate::Reg<u32, _SRGPIO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1017,7 +1017,7 @@ impl crate::Readable for SRGPIO {}
 impl crate::Writable for SRGPIO {}
 #[doc = "General-Purpose Input/Output Software Reset"]
 pub mod srgpio;
-#[doc = "Micro Direct Memory Access Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srdma](srdma) module"]
+#[doc = "Micro Direct Memory Access Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srdma](srdma) module"]
 pub type SRDMA = crate::Reg<u32, _SRDMA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1028,7 +1028,7 @@ impl crate::Readable for SRDMA {}
 impl crate::Writable for SRDMA {}
 #[doc = "Micro Direct Memory Access Software Reset"]
 pub mod srdma;
-#[doc = "EPI Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srepi](srepi) module"]
+#[doc = "EPI Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srepi](srepi) module"]
 pub type SREPI = crate::Reg<u32, _SREPI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1039,7 +1039,7 @@ impl crate::Readable for SREPI {}
 impl crate::Writable for SREPI {}
 #[doc = "EPI Software Reset"]
 pub mod srepi;
-#[doc = "Hibernation Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srhib](srhib) module"]
+#[doc = "Hibernation Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srhib](srhib) module"]
 pub type SRHIB = crate::Reg<u32, _SRHIB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1050,7 +1050,7 @@ impl crate::Readable for SRHIB {}
 impl crate::Writable for SRHIB {}
 #[doc = "Hibernation Software Reset"]
 pub mod srhib;
-#[doc = "Universal Asynchronous Receiver/Transmitter Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sruart](sruart) module"]
+#[doc = "Universal Asynchronous Receiver/Transmitter Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sruart](sruart) module"]
 pub type SRUART = crate::Reg<u32, _SRUART>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1061,7 +1061,7 @@ impl crate::Readable for SRUART {}
 impl crate::Writable for SRUART {}
 #[doc = "Universal Asynchronous Receiver/Transmitter Software Reset"]
 pub mod sruart;
-#[doc = "Synchronous Serial Interface Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srssi](srssi) module"]
+#[doc = "Synchronous Serial Interface Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srssi](srssi) module"]
 pub type SRSSI = crate::Reg<u32, _SRSSI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1072,7 +1072,7 @@ impl crate::Readable for SRSSI {}
 impl crate::Writable for SRSSI {}
 #[doc = "Synchronous Serial Interface Software Reset"]
 pub mod srssi;
-#[doc = "Inter-Integrated Circuit Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sri2c](sri2c) module"]
+#[doc = "Inter-Integrated Circuit Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sri2c](sri2c) module"]
 pub type SRI2C = crate::Reg<u32, _SRI2C>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1083,7 +1083,7 @@ impl crate::Readable for SRI2C {}
 impl crate::Writable for SRI2C {}
 #[doc = "Inter-Integrated Circuit Software Reset"]
 pub mod sri2c;
-#[doc = "Universal Serial Bus Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srusb](srusb) module"]
+#[doc = "Universal Serial Bus Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srusb](srusb) module"]
 pub type SRUSB = crate::Reg<u32, _SRUSB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1094,7 +1094,7 @@ impl crate::Readable for SRUSB {}
 impl crate::Writable for SRUSB {}
 #[doc = "Universal Serial Bus Software Reset"]
 pub mod srusb;
-#[doc = "Ethernet PHY Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srephy](srephy) module"]
+#[doc = "Ethernet PHY Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srephy](srephy) module"]
 pub type SREPHY = crate::Reg<u32, _SREPHY>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1105,7 +1105,7 @@ impl crate::Readable for SREPHY {}
 impl crate::Writable for SREPHY {}
 #[doc = "Ethernet PHY Software Reset"]
 pub mod srephy;
-#[doc = "Controller Area Network Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srcan](srcan) module"]
+#[doc = "Controller Area Network Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srcan](srcan) module"]
 pub type SRCAN = crate::Reg<u32, _SRCAN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1116,7 +1116,7 @@ impl crate::Readable for SRCAN {}
 impl crate::Writable for SRCAN {}
 #[doc = "Controller Area Network Software Reset"]
 pub mod srcan;
-#[doc = "Analog-to-Digital Converter Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sradc](sradc) module"]
+#[doc = "Analog-to-Digital Converter Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sradc](sradc) module"]
 pub type SRADC = crate::Reg<u32, _SRADC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1127,7 +1127,7 @@ impl crate::Readable for SRADC {}
 impl crate::Writable for SRADC {}
 #[doc = "Analog-to-Digital Converter Software Reset"]
 pub mod sradc;
-#[doc = "Analog Comparator Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sracmp](sracmp) module"]
+#[doc = "Analog Comparator Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sracmp](sracmp) module"]
 pub type SRACMP = crate::Reg<u32, _SRACMP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1138,7 +1138,7 @@ impl crate::Readable for SRACMP {}
 impl crate::Writable for SRACMP {}
 #[doc = "Analog Comparator Software Reset"]
 pub mod sracmp;
-#[doc = "Pulse Width Modulator Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srpwm](srpwm) module"]
+#[doc = "Pulse Width Modulator Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srpwm](srpwm) module"]
 pub type SRPWM = crate::Reg<u32, _SRPWM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1149,7 +1149,7 @@ impl crate::Readable for SRPWM {}
 impl crate::Writable for SRPWM {}
 #[doc = "Pulse Width Modulator Software Reset"]
 pub mod srpwm;
-#[doc = "Quadrature Encoder Interface Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srqei](srqei) module"]
+#[doc = "Quadrature Encoder Interface Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srqei](srqei) module"]
 pub type SRQEI = crate::Reg<u32, _SRQEI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1160,7 +1160,7 @@ impl crate::Readable for SRQEI {}
 impl crate::Writable for SRQEI {}
 #[doc = "Quadrature Encoder Interface Software Reset"]
 pub mod srqei;
-#[doc = "EEPROM Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sreeprom](sreeprom) module"]
+#[doc = "EEPROM Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sreeprom](sreeprom) module"]
 pub type SREEPROM = crate::Reg<u32, _SREEPROM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1171,7 +1171,7 @@ impl crate::Readable for SREEPROM {}
 impl crate::Writable for SREEPROM {}
 #[doc = "EEPROM Software Reset"]
 pub mod sreeprom;
-#[doc = "CRC and Cryptographic Modules Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [srccm](srccm) module"]
+#[doc = "CRC and Cryptographic Modules Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [srccm](srccm) module"]
 pub type SRCCM = crate::Reg<u32, _SRCCM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1182,7 +1182,7 @@ impl crate::Readable for SRCCM {}
 impl crate::Writable for SRCCM {}
 #[doc = "CRC and Cryptographic Modules Software Reset"]
 pub mod srccm;
-#[doc = "Ethernet MAC Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sremac](sremac) module"]
+#[doc = "Ethernet MAC Software Reset\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sremac](sremac) module"]
 pub type SREMAC = crate::Reg<u32, _SREMAC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1193,7 +1193,7 @@ impl crate::Readable for SREMAC {}
 impl crate::Writable for SREMAC {}
 #[doc = "Ethernet MAC Software Reset"]
 pub mod sremac;
-#[doc = "Watchdog Timer Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcwd](rcgcwd) module"]
+#[doc = "Watchdog Timer Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcwd](rcgcwd) module"]
 pub type RCGCWD = crate::Reg<u32, _RCGCWD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1204,7 +1204,7 @@ impl crate::Readable for RCGCWD {}
 impl crate::Writable for RCGCWD {}
 #[doc = "Watchdog Timer Run Mode Clock Gating Control"]
 pub mod rcgcwd;
-#[doc = "16/32-Bit General-Purpose Timer Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgctimer](rcgctimer) module"]
+#[doc = "16/32-Bit General-Purpose Timer Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgctimer](rcgctimer) module"]
 pub type RCGCTIMER = crate::Reg<u32, _RCGCTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1215,7 +1215,7 @@ impl crate::Readable for RCGCTIMER {}
 impl crate::Writable for RCGCTIMER {}
 #[doc = "16/32-Bit General-Purpose Timer Run Mode Clock Gating Control"]
 pub mod rcgctimer;
-#[doc = "General-Purpose Input/Output Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcgpio](rcgcgpio) module"]
+#[doc = "General-Purpose Input/Output Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcgpio](rcgcgpio) module"]
 pub type RCGCGPIO = crate::Reg<u32, _RCGCGPIO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1226,7 +1226,7 @@ impl crate::Readable for RCGCGPIO {}
 impl crate::Writable for RCGCGPIO {}
 #[doc = "General-Purpose Input/Output Run Mode Clock Gating Control"]
 pub mod rcgcgpio;
-#[doc = "Micro Direct Memory Access Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcdma](rcgcdma) module"]
+#[doc = "Micro Direct Memory Access Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcdma](rcgcdma) module"]
 pub type RCGCDMA = crate::Reg<u32, _RCGCDMA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1237,7 +1237,7 @@ impl crate::Readable for RCGCDMA {}
 impl crate::Writable for RCGCDMA {}
 #[doc = "Micro Direct Memory Access Run Mode Clock Gating Control"]
 pub mod rcgcdma;
-#[doc = "EPI Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcepi](rcgcepi) module"]
+#[doc = "EPI Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcepi](rcgcepi) module"]
 pub type RCGCEPI = crate::Reg<u32, _RCGCEPI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1248,7 +1248,7 @@ impl crate::Readable for RCGCEPI {}
 impl crate::Writable for RCGCEPI {}
 #[doc = "EPI Run Mode Clock Gating Control"]
 pub mod rcgcepi;
-#[doc = "Hibernation Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgchib](rcgchib) module"]
+#[doc = "Hibernation Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgchib](rcgchib) module"]
 pub type RCGCHIB = crate::Reg<u32, _RCGCHIB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1259,7 +1259,7 @@ impl crate::Readable for RCGCHIB {}
 impl crate::Writable for RCGCHIB {}
 #[doc = "Hibernation Run Mode Clock Gating Control"]
 pub mod rcgchib;
-#[doc = "Universal Asynchronous Receiver/Transmitter Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcuart](rcgcuart) module"]
+#[doc = "Universal Asynchronous Receiver/Transmitter Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcuart](rcgcuart) module"]
 pub type RCGCUART = crate::Reg<u32, _RCGCUART>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1270,7 +1270,7 @@ impl crate::Readable for RCGCUART {}
 impl crate::Writable for RCGCUART {}
 #[doc = "Universal Asynchronous Receiver/Transmitter Run Mode Clock Gating Control"]
 pub mod rcgcuart;
-#[doc = "Synchronous Serial Interface Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcssi](rcgcssi) module"]
+#[doc = "Synchronous Serial Interface Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcssi](rcgcssi) module"]
 pub type RCGCSSI = crate::Reg<u32, _RCGCSSI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1281,7 +1281,7 @@ impl crate::Readable for RCGCSSI {}
 impl crate::Writable for RCGCSSI {}
 #[doc = "Synchronous Serial Interface Run Mode Clock Gating Control"]
 pub mod rcgcssi;
-#[doc = "Inter-Integrated Circuit Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgci2c](rcgci2c) module"]
+#[doc = "Inter-Integrated Circuit Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgci2c](rcgci2c) module"]
 pub type RCGCI2C = crate::Reg<u32, _RCGCI2C>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1292,7 +1292,7 @@ impl crate::Readable for RCGCI2C {}
 impl crate::Writable for RCGCI2C {}
 #[doc = "Inter-Integrated Circuit Run Mode Clock Gating Control"]
 pub mod rcgci2c;
-#[doc = "Universal Serial Bus Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcusb](rcgcusb) module"]
+#[doc = "Universal Serial Bus Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcusb](rcgcusb) module"]
 pub type RCGCUSB = crate::Reg<u32, _RCGCUSB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1303,7 +1303,7 @@ impl crate::Readable for RCGCUSB {}
 impl crate::Writable for RCGCUSB {}
 #[doc = "Universal Serial Bus Run Mode Clock Gating Control"]
 pub mod rcgcusb;
-#[doc = "Ethernet PHY Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcephy](rcgcephy) module"]
+#[doc = "Ethernet PHY Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcephy](rcgcephy) module"]
 pub type RCGCEPHY = crate::Reg<u32, _RCGCEPHY>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1314,7 +1314,7 @@ impl crate::Readable for RCGCEPHY {}
 impl crate::Writable for RCGCEPHY {}
 #[doc = "Ethernet PHY Run Mode Clock Gating Control"]
 pub mod rcgcephy;
-#[doc = "Controller Area Network Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgccan](rcgccan) module"]
+#[doc = "Controller Area Network Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgccan](rcgccan) module"]
 pub type RCGCCAN = crate::Reg<u32, _RCGCCAN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1325,7 +1325,7 @@ impl crate::Readable for RCGCCAN {}
 impl crate::Writable for RCGCCAN {}
 #[doc = "Controller Area Network Run Mode Clock Gating Control"]
 pub mod rcgccan;
-#[doc = "Analog-to-Digital Converter Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcadc](rcgcadc) module"]
+#[doc = "Analog-to-Digital Converter Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcadc](rcgcadc) module"]
 pub type RCGCADC = crate::Reg<u32, _RCGCADC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1336,7 +1336,7 @@ impl crate::Readable for RCGCADC {}
 impl crate::Writable for RCGCADC {}
 #[doc = "Analog-to-Digital Converter Run Mode Clock Gating Control"]
 pub mod rcgcadc;
-#[doc = "Analog Comparator Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcacmp](rcgcacmp) module"]
+#[doc = "Analog Comparator Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcacmp](rcgcacmp) module"]
 pub type RCGCACMP = crate::Reg<u32, _RCGCACMP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1347,7 +1347,7 @@ impl crate::Readable for RCGCACMP {}
 impl crate::Writable for RCGCACMP {}
 #[doc = "Analog Comparator Run Mode Clock Gating Control"]
 pub mod rcgcacmp;
-#[doc = "Pulse Width Modulator Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcpwm](rcgcpwm) module"]
+#[doc = "Pulse Width Modulator Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcpwm](rcgcpwm) module"]
 pub type RCGCPWM = crate::Reg<u32, _RCGCPWM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1358,7 +1358,7 @@ impl crate::Readable for RCGCPWM {}
 impl crate::Writable for RCGCPWM {}
 #[doc = "Pulse Width Modulator Run Mode Clock Gating Control"]
 pub mod rcgcpwm;
-#[doc = "Quadrature Encoder Interface Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcqei](rcgcqei) module"]
+#[doc = "Quadrature Encoder Interface Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcqei](rcgcqei) module"]
 pub type RCGCQEI = crate::Reg<u32, _RCGCQEI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1369,7 +1369,7 @@ impl crate::Readable for RCGCQEI {}
 impl crate::Writable for RCGCQEI {}
 #[doc = "Quadrature Encoder Interface Run Mode Clock Gating Control"]
 pub mod rcgcqei;
-#[doc = "EEPROM Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgceeprom](rcgceeprom) module"]
+#[doc = "EEPROM Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgceeprom](rcgceeprom) module"]
 pub type RCGCEEPROM = crate::Reg<u32, _RCGCEEPROM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1380,7 +1380,7 @@ impl crate::Readable for RCGCEEPROM {}
 impl crate::Writable for RCGCEEPROM {}
 #[doc = "EEPROM Run Mode Clock Gating Control"]
 pub mod rcgceeprom;
-#[doc = "CRC and Cryptographic Modules Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcccm](rcgcccm) module"]
+#[doc = "CRC and Cryptographic Modules Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcccm](rcgcccm) module"]
 pub type RCGCCCM = crate::Reg<u32, _RCGCCCM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1391,7 +1391,7 @@ impl crate::Readable for RCGCCCM {}
 impl crate::Writable for RCGCCCM {}
 #[doc = "CRC and Cryptographic Modules Run Mode Clock Gating Control"]
 pub mod rcgcccm;
-#[doc = "Ethernet MAC Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcgcemac](rcgcemac) module"]
+#[doc = "Ethernet MAC Run Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rcgcemac](rcgcemac) module"]
 pub type RCGCEMAC = crate::Reg<u32, _RCGCEMAC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1402,7 +1402,7 @@ impl crate::Readable for RCGCEMAC {}
 impl crate::Writable for RCGCEMAC {}
 #[doc = "Ethernet MAC Run Mode Clock Gating Control"]
 pub mod rcgcemac;
-#[doc = "Watchdog Timer Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcwd](scgcwd) module"]
+#[doc = "Watchdog Timer Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcwd](scgcwd) module"]
 pub type SCGCWD = crate::Reg<u32, _SCGCWD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1413,7 +1413,7 @@ impl crate::Readable for SCGCWD {}
 impl crate::Writable for SCGCWD {}
 #[doc = "Watchdog Timer Sleep Mode Clock Gating Control"]
 pub mod scgcwd;
-#[doc = "16/32-Bit General-Purpose Timer Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgctimer](scgctimer) module"]
+#[doc = "16/32-Bit General-Purpose Timer Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgctimer](scgctimer) module"]
 pub type SCGCTIMER = crate::Reg<u32, _SCGCTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1424,7 +1424,7 @@ impl crate::Readable for SCGCTIMER {}
 impl crate::Writable for SCGCTIMER {}
 #[doc = "16/32-Bit General-Purpose Timer Sleep Mode Clock Gating Control"]
 pub mod scgctimer;
-#[doc = "General-Purpose Input/Output Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcgpio](scgcgpio) module"]
+#[doc = "General-Purpose Input/Output Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcgpio](scgcgpio) module"]
 pub type SCGCGPIO = crate::Reg<u32, _SCGCGPIO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1435,7 +1435,7 @@ impl crate::Readable for SCGCGPIO {}
 impl crate::Writable for SCGCGPIO {}
 #[doc = "General-Purpose Input/Output Sleep Mode Clock Gating Control"]
 pub mod scgcgpio;
-#[doc = "Micro Direct Memory Access Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcdma](scgcdma) module"]
+#[doc = "Micro Direct Memory Access Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcdma](scgcdma) module"]
 pub type SCGCDMA = crate::Reg<u32, _SCGCDMA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1446,7 +1446,7 @@ impl crate::Readable for SCGCDMA {}
 impl crate::Writable for SCGCDMA {}
 #[doc = "Micro Direct Memory Access Sleep Mode Clock Gating Control"]
 pub mod scgcdma;
-#[doc = "EPI Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcepi](scgcepi) module"]
+#[doc = "EPI Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcepi](scgcepi) module"]
 pub type SCGCEPI = crate::Reg<u32, _SCGCEPI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1457,7 +1457,7 @@ impl crate::Readable for SCGCEPI {}
 impl crate::Writable for SCGCEPI {}
 #[doc = "EPI Sleep Mode Clock Gating Control"]
 pub mod scgcepi;
-#[doc = "Hibernation Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgchib](scgchib) module"]
+#[doc = "Hibernation Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgchib](scgchib) module"]
 pub type SCGCHIB = crate::Reg<u32, _SCGCHIB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1468,7 +1468,7 @@ impl crate::Readable for SCGCHIB {}
 impl crate::Writable for SCGCHIB {}
 #[doc = "Hibernation Sleep Mode Clock Gating Control"]
 pub mod scgchib;
-#[doc = "Universal Asynchronous Receiver/Transmitter Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcuart](scgcuart) module"]
+#[doc = "Universal Asynchronous Receiver/Transmitter Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcuart](scgcuart) module"]
 pub type SCGCUART = crate::Reg<u32, _SCGCUART>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1479,7 +1479,7 @@ impl crate::Readable for SCGCUART {}
 impl crate::Writable for SCGCUART {}
 #[doc = "Universal Asynchronous Receiver/Transmitter Sleep Mode Clock Gating Control"]
 pub mod scgcuart;
-#[doc = "Synchronous Serial Interface Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcssi](scgcssi) module"]
+#[doc = "Synchronous Serial Interface Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcssi](scgcssi) module"]
 pub type SCGCSSI = crate::Reg<u32, _SCGCSSI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1490,7 +1490,7 @@ impl crate::Readable for SCGCSSI {}
 impl crate::Writable for SCGCSSI {}
 #[doc = "Synchronous Serial Interface Sleep Mode Clock Gating Control"]
 pub mod scgcssi;
-#[doc = "Inter-Integrated Circuit Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgci2c](scgci2c) module"]
+#[doc = "Inter-Integrated Circuit Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgci2c](scgci2c) module"]
 pub type SCGCI2C = crate::Reg<u32, _SCGCI2C>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1501,7 +1501,7 @@ impl crate::Readable for SCGCI2C {}
 impl crate::Writable for SCGCI2C {}
 #[doc = "Inter-Integrated Circuit Sleep Mode Clock Gating Control"]
 pub mod scgci2c;
-#[doc = "Universal Serial Bus Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcusb](scgcusb) module"]
+#[doc = "Universal Serial Bus Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcusb](scgcusb) module"]
 pub type SCGCUSB = crate::Reg<u32, _SCGCUSB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1512,7 +1512,7 @@ impl crate::Readable for SCGCUSB {}
 impl crate::Writable for SCGCUSB {}
 #[doc = "Universal Serial Bus Sleep Mode Clock Gating Control"]
 pub mod scgcusb;
-#[doc = "Ethernet PHY Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcephy](scgcephy) module"]
+#[doc = "Ethernet PHY Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcephy](scgcephy) module"]
 pub type SCGCEPHY = crate::Reg<u32, _SCGCEPHY>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1523,7 +1523,7 @@ impl crate::Readable for SCGCEPHY {}
 impl crate::Writable for SCGCEPHY {}
 #[doc = "Ethernet PHY Sleep Mode Clock Gating Control"]
 pub mod scgcephy;
-#[doc = "Controller Area Network Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgccan](scgccan) module"]
+#[doc = "Controller Area Network Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgccan](scgccan) module"]
 pub type SCGCCAN = crate::Reg<u32, _SCGCCAN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1534,7 +1534,7 @@ impl crate::Readable for SCGCCAN {}
 impl crate::Writable for SCGCCAN {}
 #[doc = "Controller Area Network Sleep Mode Clock Gating Control"]
 pub mod scgccan;
-#[doc = "Analog-to-Digital Converter Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcadc](scgcadc) module"]
+#[doc = "Analog-to-Digital Converter Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcadc](scgcadc) module"]
 pub type SCGCADC = crate::Reg<u32, _SCGCADC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1545,7 +1545,7 @@ impl crate::Readable for SCGCADC {}
 impl crate::Writable for SCGCADC {}
 #[doc = "Analog-to-Digital Converter Sleep Mode Clock Gating Control"]
 pub mod scgcadc;
-#[doc = "Analog Comparator Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcacmp](scgcacmp) module"]
+#[doc = "Analog Comparator Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcacmp](scgcacmp) module"]
 pub type SCGCACMP = crate::Reg<u32, _SCGCACMP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1556,7 +1556,7 @@ impl crate::Readable for SCGCACMP {}
 impl crate::Writable for SCGCACMP {}
 #[doc = "Analog Comparator Sleep Mode Clock Gating Control"]
 pub mod scgcacmp;
-#[doc = "Pulse Width Modulator Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcpwm](scgcpwm) module"]
+#[doc = "Pulse Width Modulator Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcpwm](scgcpwm) module"]
 pub type SCGCPWM = crate::Reg<u32, _SCGCPWM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1567,7 +1567,7 @@ impl crate::Readable for SCGCPWM {}
 impl crate::Writable for SCGCPWM {}
 #[doc = "Pulse Width Modulator Sleep Mode Clock Gating Control"]
 pub mod scgcpwm;
-#[doc = "Quadrature Encoder Interface Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcqei](scgcqei) module"]
+#[doc = "Quadrature Encoder Interface Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcqei](scgcqei) module"]
 pub type SCGCQEI = crate::Reg<u32, _SCGCQEI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1578,7 +1578,7 @@ impl crate::Readable for SCGCQEI {}
 impl crate::Writable for SCGCQEI {}
 #[doc = "Quadrature Encoder Interface Sleep Mode Clock Gating Control"]
 pub mod scgcqei;
-#[doc = "EEPROM Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgceeprom](scgceeprom) module"]
+#[doc = "EEPROM Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgceeprom](scgceeprom) module"]
 pub type SCGCEEPROM = crate::Reg<u32, _SCGCEEPROM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1589,7 +1589,7 @@ impl crate::Readable for SCGCEEPROM {}
 impl crate::Writable for SCGCEEPROM {}
 #[doc = "EEPROM Sleep Mode Clock Gating Control"]
 pub mod scgceeprom;
-#[doc = "CRC and Cryptographic Modules Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcccm](scgcccm) module"]
+#[doc = "CRC and Cryptographic Modules Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcccm](scgcccm) module"]
 pub type SCGCCCM = crate::Reg<u32, _SCGCCCM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1600,7 +1600,7 @@ impl crate::Readable for SCGCCCM {}
 impl crate::Writable for SCGCCCM {}
 #[doc = "CRC and Cryptographic Modules Sleep Mode Clock Gating Control"]
 pub mod scgcccm;
-#[doc = "Ethernet MAC Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scgcemac](scgcemac) module"]
+#[doc = "Ethernet MAC Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [scgcemac](scgcemac) module"]
 pub type SCGCEMAC = crate::Reg<u32, _SCGCEMAC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1611,7 +1611,7 @@ impl crate::Readable for SCGCEMAC {}
 impl crate::Writable for SCGCEMAC {}
 #[doc = "Ethernet MAC Sleep Mode Clock Gating Control"]
 pub mod scgcemac;
-#[doc = "Watchdog Timer Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcwd](dcgcwd) module"]
+#[doc = "Watchdog Timer Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcwd](dcgcwd) module"]
 pub type DCGCWD = crate::Reg<u32, _DCGCWD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1622,7 +1622,7 @@ impl crate::Readable for DCGCWD {}
 impl crate::Writable for DCGCWD {}
 #[doc = "Watchdog Timer Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcwd;
-#[doc = "16/32-Bit General-Purpose Timer Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgctimer](dcgctimer) module"]
+#[doc = "16/32-Bit General-Purpose Timer Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgctimer](dcgctimer) module"]
 pub type DCGCTIMER = crate::Reg<u32, _DCGCTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1633,7 +1633,7 @@ impl crate::Readable for DCGCTIMER {}
 impl crate::Writable for DCGCTIMER {}
 #[doc = "16/32-Bit General-Purpose Timer Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgctimer;
-#[doc = "General-Purpose Input/Output Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcgpio](dcgcgpio) module"]
+#[doc = "General-Purpose Input/Output Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcgpio](dcgcgpio) module"]
 pub type DCGCGPIO = crate::Reg<u32, _DCGCGPIO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1644,7 +1644,7 @@ impl crate::Readable for DCGCGPIO {}
 impl crate::Writable for DCGCGPIO {}
 #[doc = "General-Purpose Input/Output Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcgpio;
-#[doc = "Micro Direct Memory Access Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcdma](dcgcdma) module"]
+#[doc = "Micro Direct Memory Access Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcdma](dcgcdma) module"]
 pub type DCGCDMA = crate::Reg<u32, _DCGCDMA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1655,7 +1655,7 @@ impl crate::Readable for DCGCDMA {}
 impl crate::Writable for DCGCDMA {}
 #[doc = "Micro Direct Memory Access Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcdma;
-#[doc = "EPI Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcepi](dcgcepi) module"]
+#[doc = "EPI Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcepi](dcgcepi) module"]
 pub type DCGCEPI = crate::Reg<u32, _DCGCEPI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1666,7 +1666,7 @@ impl crate::Readable for DCGCEPI {}
 impl crate::Writable for DCGCEPI {}
 #[doc = "EPI Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcepi;
-#[doc = "Hibernation Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgchib](dcgchib) module"]
+#[doc = "Hibernation Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgchib](dcgchib) module"]
 pub type DCGCHIB = crate::Reg<u32, _DCGCHIB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1677,7 +1677,7 @@ impl crate::Readable for DCGCHIB {}
 impl crate::Writable for DCGCHIB {}
 #[doc = "Hibernation Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgchib;
-#[doc = "Universal Asynchronous Receiver/Transmitter Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcuart](dcgcuart) module"]
+#[doc = "Universal Asynchronous Receiver/Transmitter Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcuart](dcgcuart) module"]
 pub type DCGCUART = crate::Reg<u32, _DCGCUART>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1688,7 +1688,7 @@ impl crate::Readable for DCGCUART {}
 impl crate::Writable for DCGCUART {}
 #[doc = "Universal Asynchronous Receiver/Transmitter Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcuart;
-#[doc = "Synchronous Serial Interface Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcssi](dcgcssi) module"]
+#[doc = "Synchronous Serial Interface Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcssi](dcgcssi) module"]
 pub type DCGCSSI = crate::Reg<u32, _DCGCSSI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1699,7 +1699,7 @@ impl crate::Readable for DCGCSSI {}
 impl crate::Writable for DCGCSSI {}
 #[doc = "Synchronous Serial Interface Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcssi;
-#[doc = "Inter-Integrated Circuit Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgci2c](dcgci2c) module"]
+#[doc = "Inter-Integrated Circuit Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgci2c](dcgci2c) module"]
 pub type DCGCI2C = crate::Reg<u32, _DCGCI2C>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1710,7 +1710,7 @@ impl crate::Readable for DCGCI2C {}
 impl crate::Writable for DCGCI2C {}
 #[doc = "Inter-Integrated Circuit Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgci2c;
-#[doc = "Universal Serial Bus Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcusb](dcgcusb) module"]
+#[doc = "Universal Serial Bus Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcusb](dcgcusb) module"]
 pub type DCGCUSB = crate::Reg<u32, _DCGCUSB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1721,7 +1721,7 @@ impl crate::Readable for DCGCUSB {}
 impl crate::Writable for DCGCUSB {}
 #[doc = "Universal Serial Bus Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcusb;
-#[doc = "Ethernet PHY Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcephy](dcgcephy) module"]
+#[doc = "Ethernet PHY Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcephy](dcgcephy) module"]
 pub type DCGCEPHY = crate::Reg<u32, _DCGCEPHY>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1732,7 +1732,7 @@ impl crate::Readable for DCGCEPHY {}
 impl crate::Writable for DCGCEPHY {}
 #[doc = "Ethernet PHY Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcephy;
-#[doc = "Controller Area Network Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgccan](dcgccan) module"]
+#[doc = "Controller Area Network Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgccan](dcgccan) module"]
 pub type DCGCCAN = crate::Reg<u32, _DCGCCAN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1743,7 +1743,7 @@ impl crate::Readable for DCGCCAN {}
 impl crate::Writable for DCGCCAN {}
 #[doc = "Controller Area Network Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgccan;
-#[doc = "Analog-to-Digital Converter Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcadc](dcgcadc) module"]
+#[doc = "Analog-to-Digital Converter Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcadc](dcgcadc) module"]
 pub type DCGCADC = crate::Reg<u32, _DCGCADC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1754,7 +1754,7 @@ impl crate::Readable for DCGCADC {}
 impl crate::Writable for DCGCADC {}
 #[doc = "Analog-to-Digital Converter Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcadc;
-#[doc = "Analog Comparator Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcacmp](dcgcacmp) module"]
+#[doc = "Analog Comparator Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcacmp](dcgcacmp) module"]
 pub type DCGCACMP = crate::Reg<u32, _DCGCACMP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1765,7 +1765,7 @@ impl crate::Readable for DCGCACMP {}
 impl crate::Writable for DCGCACMP {}
 #[doc = "Analog Comparator Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcacmp;
-#[doc = "Pulse Width Modulator Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcpwm](dcgcpwm) module"]
+#[doc = "Pulse Width Modulator Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcpwm](dcgcpwm) module"]
 pub type DCGCPWM = crate::Reg<u32, _DCGCPWM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1776,7 +1776,7 @@ impl crate::Readable for DCGCPWM {}
 impl crate::Writable for DCGCPWM {}
 #[doc = "Pulse Width Modulator Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcpwm;
-#[doc = "Quadrature Encoder Interface Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcqei](dcgcqei) module"]
+#[doc = "Quadrature Encoder Interface Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcqei](dcgcqei) module"]
 pub type DCGCQEI = crate::Reg<u32, _DCGCQEI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1787,7 +1787,7 @@ impl crate::Readable for DCGCQEI {}
 impl crate::Writable for DCGCQEI {}
 #[doc = "Quadrature Encoder Interface Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcqei;
-#[doc = "EEPROM Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgceeprom](dcgceeprom) module"]
+#[doc = "EEPROM Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgceeprom](dcgceeprom) module"]
 pub type DCGCEEPROM = crate::Reg<u32, _DCGCEEPROM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1798,7 +1798,7 @@ impl crate::Readable for DCGCEEPROM {}
 impl crate::Writable for DCGCEEPROM {}
 #[doc = "EEPROM Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgceeprom;
-#[doc = "CRC and Cryptographic Modules Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcccm](dcgcccm) module"]
+#[doc = "CRC and Cryptographic Modules Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcccm](dcgcccm) module"]
 pub type DCGCCCM = crate::Reg<u32, _DCGCCCM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1809,7 +1809,7 @@ impl crate::Readable for DCGCCCM {}
 impl crate::Writable for DCGCCCM {}
 #[doc = "CRC and Cryptographic Modules Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcccm;
-#[doc = "Ethernet MAC Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcgcemac](dcgcemac) module"]
+#[doc = "Ethernet MAC Deep-Sleep Mode Clock Gating Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dcgcemac](dcgcemac) module"]
 pub type DCGCEMAC = crate::Reg<u32, _DCGCEMAC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1820,7 +1820,7 @@ impl crate::Readable for DCGCEMAC {}
 impl crate::Writable for DCGCEMAC {}
 #[doc = "Ethernet MAC Deep-Sleep Mode Clock Gating Control"]
 pub mod dcgcemac;
-#[doc = "Watchdog Timer Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pcwd](pcwd) module"]
+#[doc = "Watchdog Timer Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pcwd](pcwd) module"]
 pub type PCWD = crate::Reg<u32, _PCWD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1831,7 +1831,7 @@ impl crate::Readable for PCWD {}
 impl crate::Writable for PCWD {}
 #[doc = "Watchdog Timer Power Control"]
 pub mod pcwd;
-#[doc = "16/32-Bit General-Purpose Timer Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pctimer](pctimer) module"]
+#[doc = "16/32-Bit General-Purpose Timer Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pctimer](pctimer) module"]
 pub type PCTIMER = crate::Reg<u32, _PCTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1842,7 +1842,7 @@ impl crate::Readable for PCTIMER {}
 impl crate::Writable for PCTIMER {}
 #[doc = "16/32-Bit General-Purpose Timer Power Control"]
 pub mod pctimer;
-#[doc = "General-Purpose Input/Output Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pcgpio](pcgpio) module"]
+#[doc = "General-Purpose Input/Output Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pcgpio](pcgpio) module"]
 pub type PCGPIO = crate::Reg<u32, _PCGPIO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1853,7 +1853,7 @@ impl crate::Readable for PCGPIO {}
 impl crate::Writable for PCGPIO {}
 #[doc = "General-Purpose Input/Output Power Control"]
 pub mod pcgpio;
-#[doc = "Micro Direct Memory Access Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pcdma](pcdma) module"]
+#[doc = "Micro Direct Memory Access Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pcdma](pcdma) module"]
 pub type PCDMA = crate::Reg<u32, _PCDMA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1864,7 +1864,7 @@ impl crate::Readable for PCDMA {}
 impl crate::Writable for PCDMA {}
 #[doc = "Micro Direct Memory Access Power Control"]
 pub mod pcdma;
-#[doc = "External Peripheral Interface Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pcepi](pcepi) module"]
+#[doc = "External Peripheral Interface Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pcepi](pcepi) module"]
 pub type PCEPI = crate::Reg<u32, _PCEPI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1875,7 +1875,7 @@ impl crate::Readable for PCEPI {}
 impl crate::Writable for PCEPI {}
 #[doc = "External Peripheral Interface Power Control"]
 pub mod pcepi;
-#[doc = "Hibernation Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pchib](pchib) module"]
+#[doc = "Hibernation Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pchib](pchib) module"]
 pub type PCHIB = crate::Reg<u32, _PCHIB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1886,7 +1886,7 @@ impl crate::Readable for PCHIB {}
 impl crate::Writable for PCHIB {}
 #[doc = "Hibernation Power Control"]
 pub mod pchib;
-#[doc = "Universal Asynchronous Receiver/Transmitter Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pcuart](pcuart) module"]
+#[doc = "Universal Asynchronous Receiver/Transmitter Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pcuart](pcuart) module"]
 pub type PCUART = crate::Reg<u32, _PCUART>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1897,7 +1897,7 @@ impl crate::Readable for PCUART {}
 impl crate::Writable for PCUART {}
 #[doc = "Universal Asynchronous Receiver/Transmitter Power Control"]
 pub mod pcuart;
-#[doc = "Synchronous Serial Interface Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pcssi](pcssi) module"]
+#[doc = "Synchronous Serial Interface Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pcssi](pcssi) module"]
 pub type PCSSI = crate::Reg<u32, _PCSSI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1908,7 +1908,7 @@ impl crate::Readable for PCSSI {}
 impl crate::Writable for PCSSI {}
 #[doc = "Synchronous Serial Interface Power Control"]
 pub mod pcssi;
-#[doc = "Inter-Integrated Circuit Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pci2c](pci2c) module"]
+#[doc = "Inter-Integrated Circuit Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pci2c](pci2c) module"]
 pub type PCI2C = crate::Reg<u32, _PCI2C>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1919,7 +1919,7 @@ impl crate::Readable for PCI2C {}
 impl crate::Writable for PCI2C {}
 #[doc = "Inter-Integrated Circuit Power Control"]
 pub mod pci2c;
-#[doc = "Universal Serial Bus Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pcusb](pcusb) module"]
+#[doc = "Universal Serial Bus Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pcusb](pcusb) module"]
 pub type PCUSB = crate::Reg<u32, _PCUSB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1930,7 +1930,7 @@ impl crate::Readable for PCUSB {}
 impl crate::Writable for PCUSB {}
 #[doc = "Universal Serial Bus Power Control"]
 pub mod pcusb;
-#[doc = "Ethernet PHY Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pcephy](pcephy) module"]
+#[doc = "Ethernet PHY Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pcephy](pcephy) module"]
 pub type PCEPHY = crate::Reg<u32, _PCEPHY>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1941,7 +1941,7 @@ impl crate::Readable for PCEPHY {}
 impl crate::Writable for PCEPHY {}
 #[doc = "Ethernet PHY Power Control"]
 pub mod pcephy;
-#[doc = "Controller Area Network Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pccan](pccan) module"]
+#[doc = "Controller Area Network Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pccan](pccan) module"]
 pub type PCCAN = crate::Reg<u32, _PCCAN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1952,7 +1952,7 @@ impl crate::Readable for PCCAN {}
 impl crate::Writable for PCCAN {}
 #[doc = "Controller Area Network Power Control"]
 pub mod pccan;
-#[doc = "Analog-to-Digital Converter Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pcadc](pcadc) module"]
+#[doc = "Analog-to-Digital Converter Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pcadc](pcadc) module"]
 pub type PCADC = crate::Reg<u32, _PCADC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1963,7 +1963,7 @@ impl crate::Readable for PCADC {}
 impl crate::Writable for PCADC {}
 #[doc = "Analog-to-Digital Converter Power Control"]
 pub mod pcadc;
-#[doc = "Analog Comparator Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pcacmp](pcacmp) module"]
+#[doc = "Analog Comparator Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pcacmp](pcacmp) module"]
 pub type PCACMP = crate::Reg<u32, _PCACMP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1974,7 +1974,7 @@ impl crate::Readable for PCACMP {}
 impl crate::Writable for PCACMP {}
 #[doc = "Analog Comparator Power Control"]
 pub mod pcacmp;
-#[doc = "Pulse Width Modulator Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pcpwm](pcpwm) module"]
+#[doc = "Pulse Width Modulator Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pcpwm](pcpwm) module"]
 pub type PCPWM = crate::Reg<u32, _PCPWM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1985,7 +1985,7 @@ impl crate::Readable for PCPWM {}
 impl crate::Writable for PCPWM {}
 #[doc = "Pulse Width Modulator Power Control"]
 pub mod pcpwm;
-#[doc = "Quadrature Encoder Interface Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pcqei](pcqei) module"]
+#[doc = "Quadrature Encoder Interface Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pcqei](pcqei) module"]
 pub type PCQEI = crate::Reg<u32, _PCQEI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1996,7 +1996,7 @@ impl crate::Readable for PCQEI {}
 impl crate::Writable for PCQEI {}
 #[doc = "Quadrature Encoder Interface Power Control"]
 pub mod pcqei;
-#[doc = "EEPROM Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pceeprom](pceeprom) module"]
+#[doc = "EEPROM Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pceeprom](pceeprom) module"]
 pub type PCEEPROM = crate::Reg<u32, _PCEEPROM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2007,7 +2007,7 @@ impl crate::Readable for PCEEPROM {}
 impl crate::Writable for PCEEPROM {}
 #[doc = "EEPROM Power Control"]
 pub mod pceeprom;
-#[doc = "CRC and Cryptographic Modules Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pcccm](pcccm) module"]
+#[doc = "CRC and Cryptographic Modules Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pcccm](pcccm) module"]
 pub type PCCCM = crate::Reg<u32, _PCCCM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2018,7 +2018,7 @@ impl crate::Readable for PCCCM {}
 impl crate::Writable for PCCCM {}
 #[doc = "CRC and Cryptographic Modules Power Control"]
 pub mod pcccm;
-#[doc = "Ethernet MAC Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pcemac](pcemac) module"]
+#[doc = "Ethernet MAC Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pcemac](pcemac) module"]
 pub type PCEMAC = crate::Reg<u32, _PCEMAC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2029,7 +2029,7 @@ impl crate::Readable for PCEMAC {}
 impl crate::Writable for PCEMAC {}
 #[doc = "Ethernet MAC Power Control"]
 pub mod pcemac;
-#[doc = "Watchdog Timer Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prwd](prwd) module"]
+#[doc = "Watchdog Timer Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prwd](prwd) module"]
 pub type PRWD = crate::Reg<u32, _PRWD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2038,7 +2038,7 @@ pub struct _PRWD;
 impl crate::Readable for PRWD {}
 #[doc = "Watchdog Timer Peripheral Ready"]
 pub mod prwd;
-#[doc = "16/32-Bit General-Purpose Timer Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prtimer](prtimer) module"]
+#[doc = "16/32-Bit General-Purpose Timer Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prtimer](prtimer) module"]
 pub type PRTIMER = crate::Reg<u32, _PRTIMER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2047,7 +2047,7 @@ pub struct _PRTIMER;
 impl crate::Readable for PRTIMER {}
 #[doc = "16/32-Bit General-Purpose Timer Peripheral Ready"]
 pub mod prtimer;
-#[doc = "General-Purpose Input/Output Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prgpio](prgpio) module"]
+#[doc = "General-Purpose Input/Output Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prgpio](prgpio) module"]
 pub type PRGPIO = crate::Reg<u32, _PRGPIO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2056,7 +2056,7 @@ pub struct _PRGPIO;
 impl crate::Readable for PRGPIO {}
 #[doc = "General-Purpose Input/Output Peripheral Ready"]
 pub mod prgpio;
-#[doc = "Micro Direct Memory Access Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prdma](prdma) module"]
+#[doc = "Micro Direct Memory Access Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prdma](prdma) module"]
 pub type PRDMA = crate::Reg<u32, _PRDMA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2065,7 +2065,7 @@ pub struct _PRDMA;
 impl crate::Readable for PRDMA {}
 #[doc = "Micro Direct Memory Access Peripheral Ready"]
 pub mod prdma;
-#[doc = "EPI Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prepi](prepi) module"]
+#[doc = "EPI Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prepi](prepi) module"]
 pub type PREPI = crate::Reg<u32, _PREPI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2074,7 +2074,7 @@ pub struct _PREPI;
 impl crate::Readable for PREPI {}
 #[doc = "EPI Peripheral Ready"]
 pub mod prepi;
-#[doc = "Hibernation Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prhib](prhib) module"]
+#[doc = "Hibernation Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prhib](prhib) module"]
 pub type PRHIB = crate::Reg<u32, _PRHIB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2083,7 +2083,7 @@ pub struct _PRHIB;
 impl crate::Readable for PRHIB {}
 #[doc = "Hibernation Peripheral Ready"]
 pub mod prhib;
-#[doc = "Universal Asynchronous Receiver/Transmitter Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pruart](pruart) module"]
+#[doc = "Universal Asynchronous Receiver/Transmitter Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pruart](pruart) module"]
 pub type PRUART = crate::Reg<u32, _PRUART>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2092,7 +2092,7 @@ pub struct _PRUART;
 impl crate::Readable for PRUART {}
 #[doc = "Universal Asynchronous Receiver/Transmitter Peripheral Ready"]
 pub mod pruart;
-#[doc = "Synchronous Serial Interface Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prssi](prssi) module"]
+#[doc = "Synchronous Serial Interface Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prssi](prssi) module"]
 pub type PRSSI = crate::Reg<u32, _PRSSI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2101,7 +2101,7 @@ pub struct _PRSSI;
 impl crate::Readable for PRSSI {}
 #[doc = "Synchronous Serial Interface Peripheral Ready"]
 pub mod prssi;
-#[doc = "Inter-Integrated Circuit Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pri2c](pri2c) module"]
+#[doc = "Inter-Integrated Circuit Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pri2c](pri2c) module"]
 pub type PRI2C = crate::Reg<u32, _PRI2C>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2110,7 +2110,7 @@ pub struct _PRI2C;
 impl crate::Readable for PRI2C {}
 #[doc = "Inter-Integrated Circuit Peripheral Ready"]
 pub mod pri2c;
-#[doc = "Universal Serial Bus Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prusb](prusb) module"]
+#[doc = "Universal Serial Bus Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prusb](prusb) module"]
 pub type PRUSB = crate::Reg<u32, _PRUSB>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2119,7 +2119,7 @@ pub struct _PRUSB;
 impl crate::Readable for PRUSB {}
 #[doc = "Universal Serial Bus Peripheral Ready"]
 pub mod prusb;
-#[doc = "Ethernet PHY Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prephy](prephy) module"]
+#[doc = "Ethernet PHY Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prephy](prephy) module"]
 pub type PREPHY = crate::Reg<u32, _PREPHY>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2128,7 +2128,7 @@ pub struct _PREPHY;
 impl crate::Readable for PREPHY {}
 #[doc = "Ethernet PHY Peripheral Ready"]
 pub mod prephy;
-#[doc = "Controller Area Network Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prcan](prcan) module"]
+#[doc = "Controller Area Network Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prcan](prcan) module"]
 pub type PRCAN = crate::Reg<u32, _PRCAN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2137,7 +2137,7 @@ pub struct _PRCAN;
 impl crate::Readable for PRCAN {}
 #[doc = "Controller Area Network Peripheral Ready"]
 pub mod prcan;
-#[doc = "Analog-to-Digital Converter Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pradc](pradc) module"]
+#[doc = "Analog-to-Digital Converter Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pradc](pradc) module"]
 pub type PRADC = crate::Reg<u32, _PRADC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2146,7 +2146,7 @@ pub struct _PRADC;
 impl crate::Readable for PRADC {}
 #[doc = "Analog-to-Digital Converter Peripheral Ready"]
 pub mod pradc;
-#[doc = "Analog Comparator Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pracmp](pracmp) module"]
+#[doc = "Analog Comparator Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pracmp](pracmp) module"]
 pub type PRACMP = crate::Reg<u32, _PRACMP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2155,7 +2155,7 @@ pub struct _PRACMP;
 impl crate::Readable for PRACMP {}
 #[doc = "Analog Comparator Peripheral Ready"]
 pub mod pracmp;
-#[doc = "Pulse Width Modulator Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prpwm](prpwm) module"]
+#[doc = "Pulse Width Modulator Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prpwm](prpwm) module"]
 pub type PRPWM = crate::Reg<u32, _PRPWM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2164,7 +2164,7 @@ pub struct _PRPWM;
 impl crate::Readable for PRPWM {}
 #[doc = "Pulse Width Modulator Peripheral Ready"]
 pub mod prpwm;
-#[doc = "Quadrature Encoder Interface Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prqei](prqei) module"]
+#[doc = "Quadrature Encoder Interface Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prqei](prqei) module"]
 pub type PRQEI = crate::Reg<u32, _PRQEI>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2173,7 +2173,7 @@ pub struct _PRQEI;
 impl crate::Readable for PRQEI {}
 #[doc = "Quadrature Encoder Interface Peripheral Ready"]
 pub mod prqei;
-#[doc = "EEPROM Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [preeprom](preeprom) module"]
+#[doc = "EEPROM Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [preeprom](preeprom) module"]
 pub type PREEPROM = crate::Reg<u32, _PREEPROM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2182,7 +2182,7 @@ pub struct _PREEPROM;
 impl crate::Readable for PREEPROM {}
 #[doc = "EEPROM Peripheral Ready"]
 pub mod preeprom;
-#[doc = "CRC and Cryptographic Modules Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prccm](prccm) module"]
+#[doc = "CRC and Cryptographic Modules Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prccm](prccm) module"]
 pub type PRCCM = crate::Reg<u32, _PRCCM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2191,7 +2191,7 @@ pub struct _PRCCM;
 impl crate::Readable for PRCCM {}
 #[doc = "CRC and Cryptographic Modules Peripheral Ready"]
 pub mod prccm;
-#[doc = "Ethernet MAC Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [premac](premac) module"]
+#[doc = "Ethernet MAC Peripheral Ready\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [premac](premac) module"]
 pub type PREMAC = crate::Reg<u32, _PREMAC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/sysctl/altclkcfg.rs
+++ b/crates/tm4c129x/src/sysctl/altclkcfg.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::ALTCLKCFG {
 }
 #[doc = "Alternate Clock Source\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum ALTCLK_A {
     #[doc = "0: PIOSC"]
-    PIOSC,
+    PIOSC = 0,
     #[doc = "3: Hibernation Module Real-time clock output (RTCOSC)"]
-    RTCOSC,
+    RTCOSC = 3,
     #[doc = "4: Low-frequency internal oscillator (LFIOSC)"]
-    LFIOSC,
+    LFIOSC = 4,
 }
 impl From<ALTCLK_A> for u8 {
     #[inline(always)]
     fn from(variant: ALTCLK_A) -> Self {
-        match variant {
-            ALTCLK_A::PIOSC => 0,
-            ALTCLK_A::RTCOSC => 3,
-            ALTCLK_A::LFIOSC => 4,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `ALTCLK`"]

--- a/crates/tm4c129x/src/sysctl/did0.rs
+++ b/crates/tm4c129x/src/sysctl/did0.rs
@@ -2,22 +2,19 @@
 pub type R = crate::R<u32, super::DID0>;
 #[doc = "Minor Revision\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MIN_A {
     #[doc = "0: Initial device, or a major revision update"]
-    _0,
+    _0 = 0,
     #[doc = "1: First metal layer change"]
-    _1,
+    _1 = 1,
     #[doc = "2: Second metal layer change"]
-    _2,
+    _2 = 2,
 }
 impl From<MIN_A> for u8 {
     #[inline(always)]
     fn from(variant: MIN_A) -> Self {
-        match variant {
-            MIN_A::_0 => 0,
-            MIN_A::_1 => 1,
-            MIN_A::_2 => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MIN`"]
@@ -52,22 +49,19 @@ impl MIN_R {
 }
 #[doc = "Major Revision\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MAJ_A {
     #[doc = "0: Revision A (initial device)"]
-    REVA,
+    REVA = 0,
     #[doc = "1: Revision B (first base layer revision)"]
-    REVB,
+    REVB = 1,
     #[doc = "2: Revision C (second base layer revision)"]
-    REVC,
+    REVC = 2,
 }
 impl From<MAJ_A> for u8 {
     #[inline(always)]
     fn from(variant: MAJ_A) -> Self {
-        match variant {
-            MAJ_A::REVA => 0,
-            MAJ_A::REVB => 1,
-            MAJ_A::REVC => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MAJ`"]
@@ -102,16 +96,15 @@ impl MAJ_R {
 }
 #[doc = "Device Class\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CLASS_A {
     #[doc = "10: Tiva(TM) TM4C129-class microcontrollers"]
-    TM4C129,
+    TM4C129 = 10,
 }
 impl From<CLASS_A> for u8 {
     #[inline(always)]
     fn from(variant: CLASS_A) -> Self {
-        match variant {
-            CLASS_A::TM4C129 => 10,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CLASS`"]
@@ -134,16 +127,15 @@ impl CLASS_R {
 }
 #[doc = "DID0 Version\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum VER_A {
     #[doc = "1: Second version of the DID0 register format."]
-    _1,
+    _1 = 1,
 }
 impl From<VER_A> for u8 {
     #[inline(always)]
     fn from(variant: VER_A) -> Self {
-        match variant {
-            VER_A::_1 => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `VER`"]

--- a/crates/tm4c129x/src/sysctl/did1.rs
+++ b/crates/tm4c129x/src/sysctl/did1.rs
@@ -2,22 +2,19 @@
 pub type R = crate::R<u32, super::DID1>;
 #[doc = "Qualification Status\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum QUAL_A {
     #[doc = "0: Engineering Sample (unqualified)"]
-    ES,
+    ES = 0,
     #[doc = "1: Pilot Production (unqualified)"]
-    PP,
+    PP = 1,
     #[doc = "2: Fully Qualified"]
-    FQ,
+    FQ = 2,
 }
 impl From<QUAL_A> for u8 {
     #[inline(always)]
     fn from(variant: QUAL_A) -> Self {
-        match variant {
-            QUAL_A::ES => 0,
-            QUAL_A::PP => 1,
-            QUAL_A::FQ => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `QUAL`"]
@@ -54,19 +51,17 @@ impl QUAL_R {
 pub type ROHS_R = crate::R<bool, bool>;
 #[doc = "Package Type\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PKG_A {
     #[doc = "1: QFP package"]
-    QFP,
+    QFP = 1,
     #[doc = "2: BGA package"]
-    BGA,
+    BGA = 2,
 }
 impl From<PKG_A> for u8 {
     #[inline(always)]
     fn from(variant: PKG_A) -> Self {
-        match variant {
-            PKG_A::QFP => 1,
-            PKG_A::BGA => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PKG`"]
@@ -95,22 +90,19 @@ impl PKG_R {
 }
 #[doc = "Temperature Range\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TEMP_A {
     #[doc = "0: Commercial temperature range"]
-    C,
+    C = 0,
     #[doc = "1: Industrial temperature range"]
-    I,
+    I = 1,
     #[doc = "2: Extended temperature range"]
-    E,
+    E = 2,
 }
 impl From<TEMP_A> for u8 {
     #[inline(always)]
     fn from(variant: TEMP_A) -> Self {
-        match variant {
-            TEMP_A::C => 0,
-            TEMP_A::I => 1,
-            TEMP_A::E => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TEMP`"]
@@ -145,28 +137,23 @@ impl TEMP_R {
 }
 #[doc = "Package Pin Count\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PINCNT_A {
     #[doc = "2: 100-pin LQFP package"]
-    _100,
+    _100 = 2,
     #[doc = "3: 64-pin LQFP package"]
-    _64,
+    _64 = 3,
     #[doc = "4: 144-pin LQFP package"]
-    _144,
+    _144 = 4,
     #[doc = "5: 157-pin BGA package"]
-    _157,
+    _157 = 5,
     #[doc = "6: 128-pin TQFP package"]
-    _128,
+    _128 = 6,
 }
 impl From<PINCNT_A> for u8 {
     #[inline(always)]
     fn from(variant: PINCNT_A) -> Self {
-        match variant {
-            PINCNT_A::_100 => 2,
-            PINCNT_A::_64 => 3,
-            PINCNT_A::_144 => 4,
-            PINCNT_A::_157 => 5,
-            PINCNT_A::_128 => 6,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PINCNT`"]

--- a/crates/tm4c129x/src/sysctl/divsclk.rs
+++ b/crates/tm4c129x/src/sysctl/divsclk.rs
@@ -26,22 +26,19 @@ impl<'a> DIV_W<'a> {
 }
 #[doc = "Clock Source\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SRC_A {
     #[doc = "0: System Clock"]
-    SYSCLK,
+    SYSCLK = 0,
     #[doc = "1: PIOSC"]
-    PIOSC,
+    PIOSC = 1,
     #[doc = "2: MOSC"]
-    MOSC,
+    MOSC = 2,
 }
 impl From<SRC_A> for u8 {
     #[inline(always)]
     fn from(variant: SRC_A) -> Self {
-        match variant {
-            SRC_A::SYSCLK => 0,
-            SRC_A::PIOSC => 1,
-            SRC_A::MOSC => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SRC`"]

--- a/crates/tm4c129x/src/sysctl/dsclkcfg.rs
+++ b/crates/tm4c129x/src/sysctl/dsclkcfg.rs
@@ -26,25 +26,21 @@ impl<'a> DSSYSDIV_W<'a> {
 }
 #[doc = "Deep Sleep Oscillator Source\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DSOSCSRC_A {
     #[doc = "0: PIOSC"]
-    PIOSC,
+    PIOSC = 0,
     #[doc = "2: LFIOSC"]
-    LFIOSC,
+    LFIOSC = 2,
     #[doc = "3: MOSC"]
-    MOSC,
+    MOSC = 3,
     #[doc = "4: Hibernation Module RTCOSC"]
-    RTC,
+    RTC = 4,
 }
 impl From<DSOSCSRC_A> for u8 {
     #[inline(always)]
     fn from(variant: DSOSCSRC_A) -> Self {
-        match variant {
-            DSOSCSRC_A::PIOSC => 0,
-            DSOSCSRC_A::LFIOSC => 2,
-            DSOSCSRC_A::MOSC => 3,
-            DSOSCSRC_A::RTC => 4,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DSOSCSRC`"]

--- a/crates/tm4c129x/src/sysctl/dslppwrcfg.rs
+++ b/crates/tm4c129x/src/sysctl/dslppwrcfg.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::DSLPPWRCFG {
 }
 #[doc = "SRAM Power Modes\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SRAMPM_A {
     #[doc = "0: Active Mode"]
-    NRM,
+    NRM = 0,
     #[doc = "1: Standby Mode"]
-    SBY,
+    SBY = 1,
     #[doc = "3: Low Power Mode"]
-    LP,
+    LP = 3,
 }
 impl From<SRAMPM_A> for u8 {
     #[inline(always)]
     fn from(variant: SRAMPM_A) -> Self {
-        match variant {
-            SRAMPM_A::NRM => 0,
-            SRAMPM_A::SBY => 1,
-            SRAMPM_A::LP => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SRAMPM`"]
@@ -94,19 +91,17 @@ impl<'a> SRAMPM_W<'a> {
 }
 #[doc = "Flash Power Modes\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum FLASHPM_A {
     #[doc = "0: Active Mode"]
-    NRM,
+    NRM = 0,
     #[doc = "2: Low Power Mode"]
-    SLP,
+    SLP = 2,
 }
 impl From<FLASHPM_A> for u8 {
     #[inline(always)]
     fn from(variant: FLASHPM_A) -> Self {
-        match variant {
-            FLASHPM_A::NRM => 0,
-            FLASHPM_A::SLP => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `FLASHPM`"]

--- a/crates/tm4c129x/src/sysctl/emacmpc.rs
+++ b/crates/tm4c129x/src/sysctl/emacmpc.rs
@@ -12,19 +12,17 @@ impl crate::ResetValue for super::EMACMPC {
 }
 #[doc = "Memory Array Power Control\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PWRCTL_A {
     #[doc = "0: Array OFF"]
-    OFF,
+    OFF = 0,
     #[doc = "3: Array On"]
-    ON,
+    ON = 3,
 }
 impl From<PWRCTL_A> for u8 {
     #[inline(always)]
     fn from(variant: PWRCTL_A) -> Self {
-        match variant {
-            PWRCTL_A::OFF => 0,
-            PWRCTL_A::ON => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PWRCTL`"]

--- a/crates/tm4c129x/src/sysctl/emacpds.rs
+++ b/crates/tm4c129x/src/sysctl/emacpds.rs
@@ -2,19 +2,17 @@
 pub type R = crate::R<u32, super::EMACPDS>;
 #[doc = "Power Domain Status\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PWRSTAT_A {
     #[doc = "0: OFF"]
-    OFF,
+    OFF = 0,
     #[doc = "3: ON"]
-    ON,
+    ON = 3,
 }
 impl From<PWRSTAT_A> for u8 {
     #[inline(always)]
     fn from(variant: PWRSTAT_A) -> Self {
-        match variant {
-            PWRSTAT_A::OFF => 0,
-            PWRSTAT_A::ON => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PWRSTAT`"]
@@ -43,19 +41,17 @@ impl PWRSTAT_R {
 }
 #[doc = "Memory Array Power Status\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MEMSTAT_A {
     #[doc = "0: Array OFF"]
-    OFF,
+    OFF = 0,
     #[doc = "3: Array On"]
-    ON,
+    ON = 3,
 }
 impl From<MEMSTAT_A> for u8 {
     #[inline(always)]
     fn from(variant: MEMSTAT_A) -> Self {
-        match variant {
-            MEMSTAT_A::OFF => 0,
-            MEMSTAT_A::ON => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MEMSTAT`"]

--- a/crates/tm4c129x/src/sysctl/ldodpctl.rs
+++ b/crates/tm4c129x/src/sysctl/ldodpctl.rs
@@ -12,43 +12,33 @@ impl crate::ResetValue for super::LDODPCTL {
 }
 #[doc = "LDO Output Voltage\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum VLDO_A {
     #[doc = "18: 0.90 V"]
-    _0_90V,
+    _0_90V = 18,
     #[doc = "19: 0.95 V"]
-    _0_95V,
+    _0_95V = 19,
     #[doc = "20: 1.00 V"]
-    _1_00V,
+    _1_00V = 20,
     #[doc = "21: 1.05 V"]
-    _1_05V,
+    _1_05V = 21,
     #[doc = "22: 1.10 V"]
-    _1_10V,
+    _1_10V = 22,
     #[doc = "23: 1.15 V"]
-    _1_15V,
+    _1_15V = 23,
     #[doc = "24: 1.20 V"]
-    _1_20V,
+    _1_20V = 24,
     #[doc = "25: 1.25 V"]
-    _1_25V,
+    _1_25V = 25,
     #[doc = "26: 1.30 V"]
-    _1_30V,
+    _1_30V = 26,
     #[doc = "27: 1.35 V"]
-    _1_35V,
+    _1_35V = 27,
 }
 impl From<VLDO_A> for u8 {
     #[inline(always)]
     fn from(variant: VLDO_A) -> Self {
-        match variant {
-            VLDO_A::_0_90V => 18,
-            VLDO_A::_0_95V => 19,
-            VLDO_A::_1_00V => 20,
-            VLDO_A::_1_05V => 21,
-            VLDO_A::_1_10V => 22,
-            VLDO_A::_1_15V => 23,
-            VLDO_A::_1_20V => 24,
-            VLDO_A::_1_25V => 25,
-            VLDO_A::_1_30V => 26,
-            VLDO_A::_1_35V => 27,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `VLDO`"]

--- a/crates/tm4c129x/src/sysctl/ldospctl.rs
+++ b/crates/tm4c129x/src/sysctl/ldospctl.rs
@@ -12,34 +12,27 @@ impl crate::ResetValue for super::LDOSPCTL {
 }
 #[doc = "LDO Output Voltage\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum VLDO_A {
     #[doc = "18: 0.90 V"]
-    _0_90V,
+    _0_90V = 18,
     #[doc = "19: 0.95 V"]
-    _0_95V,
+    _0_95V = 19,
     #[doc = "20: 1.00 V"]
-    _1_00V,
+    _1_00V = 20,
     #[doc = "21: 1.05 V"]
-    _1_05V,
+    _1_05V = 21,
     #[doc = "22: 1.10 V"]
-    _1_10V,
+    _1_10V = 22,
     #[doc = "23: 1.15 V"]
-    _1_15V,
+    _1_15V = 23,
     #[doc = "24: 1.20 V"]
-    _1_20V,
+    _1_20V = 24,
 }
 impl From<VLDO_A> for u8 {
     #[inline(always)]
     fn from(variant: VLDO_A) -> Self {
-        match variant {
-            VLDO_A::_0_90V => 18,
-            VLDO_A::_0_95V => 19,
-            VLDO_A::_1_00V => 20,
-            VLDO_A::_1_05V => 21,
-            VLDO_A::_1_10V => 22,
-            VLDO_A::_1_15V => 23,
-            VLDO_A::_1_20V => 24,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `VLDO`"]

--- a/crates/tm4c129x/src/sysctl/memtim0.rs
+++ b/crates/tm4c129x/src/sysctl/memtim0.rs
@@ -50,40 +50,31 @@ impl<'a> FBCE_W<'a> {
 }
 #[doc = "Flash Bank Clock High Time\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum FBCHT_A {
     #[doc = "0: 1/2 system clock period"]
-    _0_5,
+    _0_5 = 0,
     #[doc = "1: 1 system clock period"]
-    _1,
+    _1 = 1,
     #[doc = "2: 1.5 system clock periods"]
-    _1_5,
+    _1_5 = 2,
     #[doc = "3: 2 system clock periods"]
-    _2,
+    _2 = 3,
     #[doc = "4: 2.5 system clock periods"]
-    _2_5,
+    _2_5 = 4,
     #[doc = "5: 3 system clock periods"]
-    _3,
+    _3 = 5,
     #[doc = "6: 3.5 system clock periods"]
-    _3_5,
+    _3_5 = 6,
     #[doc = "7: 4 system clock periods"]
-    _4,
+    _4 = 7,
     #[doc = "8: 4.5 system clock periods"]
-    _4_5,
+    _4_5 = 8,
 }
 impl From<FBCHT_A> for u8 {
     #[inline(always)]
     fn from(variant: FBCHT_A) -> Self {
-        match variant {
-            FBCHT_A::_0_5 => 0,
-            FBCHT_A::_1 => 1,
-            FBCHT_A::_1_5 => 2,
-            FBCHT_A::_2 => 3,
-            FBCHT_A::_2_5 => 4,
-            FBCHT_A::_3 => 5,
-            FBCHT_A::_3_5 => 6,
-            FBCHT_A::_4 => 7,
-            FBCHT_A::_4_5 => 8,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `FBCHT`"]
@@ -254,40 +245,31 @@ impl<'a> EBCE_W<'a> {
 }
 #[doc = "EEPROM Clock High Time\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum EBCHT_A {
     #[doc = "0: 1/2 system clock period"]
-    _0_5,
+    _0_5 = 0,
     #[doc = "1: 1 system clock period"]
-    _1,
+    _1 = 1,
     #[doc = "2: 1.5 system clock periods"]
-    _1_5,
+    _1_5 = 2,
     #[doc = "3: 2 system clock periods"]
-    _2,
+    _2 = 3,
     #[doc = "4: 2.5 system clock periods"]
-    _2_5,
+    _2_5 = 4,
     #[doc = "5: 3 system clock periods"]
-    _3,
+    _3 = 5,
     #[doc = "6: 3.5 system clock periods"]
-    _3_5,
+    _3_5 = 6,
     #[doc = "7: 4 system clock periods"]
-    _4,
+    _4 = 7,
     #[doc = "8: 4.5 system clock periods"]
-    _4_5,
+    _4_5 = 8,
 }
 impl From<EBCHT_A> for u8 {
     #[inline(always)]
     fn from(variant: EBCHT_A) -> Self {
-        match variant {
-            EBCHT_A::_0_5 => 0,
-            EBCHT_A::_1 => 1,
-            EBCHT_A::_1_5 => 2,
-            EBCHT_A::_2 => 3,
-            EBCHT_A::_2_5 => 4,
-            EBCHT_A::_3 => 5,
-            EBCHT_A::_3_5 => 6,
-            EBCHT_A::_4 => 7,
-            EBCHT_A::_4_5 => 8,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `EBCHT`"]

--- a/crates/tm4c129x/src/sysctl/pioscstat.rs
+++ b/crates/tm4c129x/src/sysctl/pioscstat.rs
@@ -4,22 +4,19 @@ pub type R = crate::R<u32, super::PIOSCSTAT>;
 pub type CT_R = crate::R<u8, u8>;
 #[doc = "Calibration Result\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CR_A {
     #[doc = "0: Calibration has not been attempted"]
-    CRNONE,
+    CRNONE = 0,
     #[doc = "1: The last calibration operation completed to meet 1% accuracy"]
-    CRPASS,
+    CRPASS = 1,
     #[doc = "2: The last calibration operation failed to meet 1% accuracy"]
-    CRFAIL,
+    CRFAIL = 2,
 }
 impl From<CR_A> for u8 {
     #[inline(always)]
     fn from(variant: CR_A) -> Self {
-        match variant {
-            CR_A::CRNONE => 0,
-            CR_A::CRPASS => 1,
-            CR_A::CRFAIL => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CR`"]

--- a/crates/tm4c129x/src/sysctl/ptboctl.rs
+++ b/crates/tm4c129x/src/sysctl/ptboctl.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::PTBOCTL {
 }
 #[doc = "VDD (VDDS) under BOR Event Action\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum VDD_UBOR_A {
     #[doc = "0: No Action"]
-    NONE,
+    NONE = 0,
     #[doc = "1: System control interrupt"]
-    SYSINT,
+    SYSINT = 1,
     #[doc = "2: NMI"]
-    NMI,
+    NMI = 2,
     #[doc = "3: Reset"]
-    RST,
+    RST = 3,
 }
 impl From<VDD_UBOR_A> for u8 {
     #[inline(always)]
     fn from(variant: VDD_UBOR_A) -> Self {
-        match variant {
-            VDD_UBOR_A::NONE => 0,
-            VDD_UBOR_A::SYSINT => 1,
-            VDD_UBOR_A::NMI => 2,
-            VDD_UBOR_A::RST => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `VDD_UBOR`"]
@@ -109,25 +105,21 @@ impl<'a> VDD_UBOR_W<'a> {
 }
 #[doc = "VDDA under BOR Event Action\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum VDDA_UBOR_A {
     #[doc = "0: No Action"]
-    NONE,
+    NONE = 0,
     #[doc = "1: System control interrupt"]
-    SYSINT,
+    SYSINT = 1,
     #[doc = "2: NMI"]
-    NMI,
+    NMI = 2,
     #[doc = "3: Reset"]
-    RST,
+    RST = 3,
 }
 impl From<VDDA_UBOR_A> for u8 {
     #[inline(always)]
     fn from(variant: VDDA_UBOR_A) -> Self {
-        match variant {
-            VDDA_UBOR_A::NONE => 0,
-            VDDA_UBOR_A::SYSINT => 1,
-            VDDA_UBOR_A::NMI => 2,
-            VDDA_UBOR_A::RST => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `VDDA_UBOR`"]

--- a/crates/tm4c129x/src/sysctl/resbehavctl.rs
+++ b/crates/tm4c129x/src/sysctl/resbehavctl.rs
@@ -12,19 +12,17 @@ impl crate::ResetValue for super::RESBEHAVCTL {
 }
 #[doc = "External RST Pin Operation\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum EXTRES_A {
     #[doc = "2: External RST assertion issues a system reset. The application starts within 10 us"]
-    SYSRST,
+    SYSRST = 2,
     #[doc = "3: External RST assertion issues a simulated POR sequence. Application starts less than 500 us after deassertion (Default)"]
-    POR,
+    POR = 3,
 }
 impl From<EXTRES_A> for u8 {
     #[inline(always)]
     fn from(variant: EXTRES_A) -> Self {
-        match variant {
-            EXTRES_A::SYSRST => 2,
-            EXTRES_A::POR => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `EXTRES`"]
@@ -80,19 +78,17 @@ impl<'a> EXTRES_W<'a> {
 }
 #[doc = "BOR Reset operation\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum BOR_A {
     #[doc = "2: Brown Out Reset issues system reset. The application starts within 10 us"]
-    SYSRST,
+    SYSRST = 2,
     #[doc = "3: Brown Out Reset issues a simulated POR sequence. The application starts less than 500 us after deassertion (Default)"]
-    POR,
+    POR = 3,
 }
 impl From<BOR_A> for u8 {
     #[inline(always)]
     fn from(variant: BOR_A) -> Self {
-        match variant {
-            BOR_A::SYSRST => 2,
-            BOR_A::POR => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `BOR`"]
@@ -148,19 +144,17 @@ impl<'a> BOR_W<'a> {
 }
 #[doc = "Watchdog 0 Reset Operation\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum WDOG0_A {
     #[doc = "2: Watchdog 0 issues a system reset. The application starts within 10 us"]
-    SYSRST,
+    SYSRST = 2,
     #[doc = "3: Watchdog 0 issues a simulated POR sequence. Application starts less than 500 us after deassertion (Default)"]
-    POR,
+    POR = 3,
 }
 impl From<WDOG0_A> for u8 {
     #[inline(always)]
     fn from(variant: WDOG0_A) -> Self {
-        match variant {
-            WDOG0_A::SYSRST => 2,
-            WDOG0_A::POR => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `WDOG0`"]
@@ -216,19 +210,17 @@ impl<'a> WDOG0_W<'a> {
 }
 #[doc = "Watchdog 1 Reset Operation\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum WDOG1_A {
     #[doc = "2: Watchdog 1 issues a system reset. The application starts within 10 us"]
-    SYSRST,
+    SYSRST = 2,
     #[doc = "3: Watchdog 1 issues a simulated POR sequence. Application starts less than 500 us after deassertion (Default)"]
-    POR,
+    POR = 3,
 }
 impl From<WDOG1_A> for u8 {
     #[inline(always)]
     fn from(variant: WDOG1_A) -> Self {
-        match variant {
-            WDOG1_A::SYSRST => 2,
-            WDOG1_A::POR => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `WDOG1`"]

--- a/crates/tm4c129x/src/sysctl/rsclkcfg.rs
+++ b/crates/tm4c129x/src/sysctl/rsclkcfg.rs
@@ -40,25 +40,21 @@ impl<'a> OSYSDIV_W<'a> {
 }
 #[doc = "Oscillator Source\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum OSCSRC_A {
     #[doc = "0: PIOSC is oscillator source"]
-    PIOSC,
+    PIOSC = 0,
     #[doc = "2: LFIOSC is oscillator source"]
-    LFIOSC,
+    LFIOSC = 2,
     #[doc = "3: MOSC is oscillator source"]
-    MOSC,
+    MOSC = 3,
     #[doc = "4: Hibernation Module RTC Oscillator (RTCOSC)"]
-    RTC,
+    RTC = 4,
 }
 impl From<OSCSRC_A> for u8 {
     #[inline(always)]
     fn from(variant: OSCSRC_A) -> Self {
-        match variant {
-            OSCSRC_A::PIOSC => 0,
-            OSCSRC_A::LFIOSC => 2,
-            OSCSRC_A::MOSC => 3,
-            OSCSRC_A::RTC => 4,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `OSCSRC`"]
@@ -136,19 +132,17 @@ impl<'a> OSCSRC_W<'a> {
 }
 #[doc = "PLL Source\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PLLSRC_A {
     #[doc = "0: PIOSC is PLL input clock source"]
-    PIOSC,
+    PIOSC = 0,
     #[doc = "3: MOSC is the PLL input clock source"]
-    MOSC,
+    MOSC = 3,
 }
 impl From<PLLSRC_A> for u8 {
     #[inline(always)]
     fn from(variant: PLLSRC_A) -> Self {
-        match variant {
-            PLLSRC_A::PIOSC => 0,
-            PLLSRC_A::MOSC => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PLLSRC`"]

--- a/crates/tm4c129x/src/sysctl/slppwrcfg.rs
+++ b/crates/tm4c129x/src/sysctl/slppwrcfg.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::SLPPWRCFG {
 }
 #[doc = "SRAM Power Modes\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SRAMPM_A {
     #[doc = "0: Active Mode"]
-    NRM,
+    NRM = 0,
     #[doc = "1: Standby Mode"]
-    SBY,
+    SBY = 1,
     #[doc = "3: Low Power Mode"]
-    LP,
+    LP = 3,
 }
 impl From<SRAMPM_A> for u8 {
     #[inline(always)]
     fn from(variant: SRAMPM_A) -> Self {
-        match variant {
-            SRAMPM_A::NRM => 0,
-            SRAMPM_A::SBY => 1,
-            SRAMPM_A::LP => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SRAMPM`"]
@@ -94,19 +91,17 @@ impl<'a> SRAMPM_W<'a> {
 }
 #[doc = "Flash Power Modes\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum FLASHPM_A {
     #[doc = "0: Active Mode"]
-    NRM,
+    NRM = 0,
     #[doc = "2: Low Power Mode"]
-    SLP,
+    SLP = 2,
 }
 impl From<FLASHPM_A> for u8 {
     #[inline(always)]
     fn from(variant: FLASHPM_A) -> Self {
-        match variant {
-            FLASHPM_A::NRM => 0,
-            FLASHPM_A::SLP => 2,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `FLASHPM`"]

--- a/crates/tm4c129x/src/sysctl/usbmpc.rs
+++ b/crates/tm4c129x/src/sysctl/usbmpc.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::USBMPC {
 }
 #[doc = "Memory Array Power Control\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PWRCTL_A {
     #[doc = "0: Array OFF"]
-    OFF,
+    OFF = 0,
     #[doc = "1: SRAM Retention"]
-    RETAIN,
+    RETAIN = 1,
     #[doc = "3: Array On"]
-    ON,
+    ON = 3,
 }
 impl From<PWRCTL_A> for u8 {
     #[inline(always)]
     fn from(variant: PWRCTL_A) -> Self {
-        match variant {
-            PWRCTL_A::OFF => 0,
-            PWRCTL_A::RETAIN => 1,
-            PWRCTL_A::ON => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PWRCTL`"]

--- a/crates/tm4c129x/src/sysctl/usbpds.rs
+++ b/crates/tm4c129x/src/sysctl/usbpds.rs
@@ -2,19 +2,17 @@
 pub type R = crate::R<u32, super::USBPDS>;
 #[doc = "Power Domain Status\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PWRSTAT_A {
     #[doc = "0: OFF"]
-    OFF,
+    OFF = 0,
     #[doc = "3: ON"]
-    ON,
+    ON = 3,
 }
 impl From<PWRSTAT_A> for u8 {
     #[inline(always)]
     fn from(variant: PWRSTAT_A) -> Self {
-        match variant {
-            PWRSTAT_A::OFF => 0,
-            PWRSTAT_A::ON => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PWRSTAT`"]
@@ -43,22 +41,19 @@ impl PWRSTAT_R {
 }
 #[doc = "Memory Array Power Status\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum MEMSTAT_A {
     #[doc = "0: Array OFF"]
-    OFF,
+    OFF = 0,
     #[doc = "1: SRAM Retention"]
-    RETAIN,
+    RETAIN = 1,
     #[doc = "3: Array On"]
-    ON,
+    ON = 3,
 }
 impl From<MEMSTAT_A> for u8 {
     #[inline(always)]
     fn from(variant: MEMSTAT_A) -> Self {
-        match variant {
-            MEMSTAT_A::OFF => 0,
-            MEMSTAT_A::RETAIN => 1,
-            MEMSTAT_A::ON => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `MEMSTAT`"]

--- a/crates/tm4c129x/src/sysexc.rs
+++ b/crates/tm4c129x/src/sysexc.rs
@@ -10,7 +10,7 @@ pub struct RegisterBlock {
     #[doc = "0x0c - System Exception Interrupt Clear"]
     pub ic: IC,
 }
-#[doc = "System Exception Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "System Exception Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -19,7 +19,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "System Exception Raw Interrupt Status"]
 pub mod ris;
-#[doc = "System Exception Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [im](im) module"]
+#[doc = "System Exception Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [im](im) module"]
 pub type IM = crate::Reg<u32, _IM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -30,7 +30,7 @@ impl crate::Readable for IM {}
 impl crate::Writable for IM {}
 #[doc = "System Exception Interrupt Mask"]
 pub mod im;
-#[doc = "System Exception Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mis](mis) module"]
+#[doc = "System Exception Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mis](mis) module"]
 pub type MIS = crate::Reg<u32, _MIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -39,7 +39,7 @@ pub struct _MIS;
 impl crate::Readable for MIS {}
 #[doc = "System Exception Masked Interrupt Status"]
 pub mod mis;
-#[doc = "System Exception Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ic](ic) module"]
+#[doc = "System Exception Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ic](ic) module"]
 pub type IC = crate::Reg<u32, _IC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/timer0.rs
+++ b/crates/tm4c129x/src/timer0.rs
@@ -73,7 +73,7 @@ impl crate::Readable for CFG {}
 impl crate::Writable for CFG {}
 #[doc = "GPTM Configuration"]
 pub mod cfg;
-#[doc = "GPTM Timer A Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tamr](tamr) module"]
+#[doc = "GPTM Timer A Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tamr](tamr) module"]
 pub type TAMR = crate::Reg<u32, _TAMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -84,7 +84,7 @@ impl crate::Readable for TAMR {}
 impl crate::Writable for TAMR {}
 #[doc = "GPTM Timer A Mode"]
 pub mod tamr;
-#[doc = "GPTM Timer B Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbmr](tbmr) module"]
+#[doc = "GPTM Timer B Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbmr](tbmr) module"]
 pub type TBMR = crate::Reg<u32, _TBMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -95,7 +95,7 @@ impl crate::Readable for TBMR {}
 impl crate::Writable for TBMR {}
 #[doc = "GPTM Timer B Mode"]
 pub mod tbmr;
-#[doc = "GPTM Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctl](ctl) module"]
+#[doc = "GPTM Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctl](ctl) module"]
 pub type CTL = crate::Reg<u32, _CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -106,7 +106,7 @@ impl crate::Readable for CTL {}
 impl crate::Writable for CTL {}
 #[doc = "GPTM Control"]
 pub mod ctl;
-#[doc = "GPTM Synchronize\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sync](sync) module"]
+#[doc = "GPTM Synchronize\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [sync](sync) module"]
 pub type SYNC = crate::Reg<u32, _SYNC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -117,7 +117,7 @@ impl crate::Readable for SYNC {}
 impl crate::Writable for SYNC {}
 #[doc = "GPTM Synchronize"]
 pub mod sync;
-#[doc = "GPTM Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [imr](imr) module"]
+#[doc = "GPTM Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [imr](imr) module"]
 pub type IMR = crate::Reg<u32, _IMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -128,7 +128,7 @@ impl crate::Readable for IMR {}
 impl crate::Writable for IMR {}
 #[doc = "GPTM Interrupt Mask"]
 pub mod imr;
-#[doc = "GPTM Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "GPTM Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -137,7 +137,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "GPTM Raw Interrupt Status"]
 pub mod ris;
-#[doc = "GPTM Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mis](mis) module"]
+#[doc = "GPTM Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mis](mis) module"]
 pub type MIS = crate::Reg<u32, _MIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -146,7 +146,7 @@ pub struct _MIS;
 impl crate::Readable for MIS {}
 #[doc = "GPTM Masked Interrupt Status"]
 pub mod mis;
-#[doc = "GPTM Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [icr](icr) module"]
+#[doc = "GPTM Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [icr](icr) module"]
 pub type ICR = crate::Reg<u32, _ICR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -155,7 +155,7 @@ pub struct _ICR;
 impl crate::Writable for ICR {}
 #[doc = "GPTM Interrupt Clear"]
 pub mod icr;
-#[doc = "GPTM Timer A Interval Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tailr](tailr) module"]
+#[doc = "GPTM Timer A Interval Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tailr](tailr) module"]
 pub type TAILR = crate::Reg<u32, _TAILR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -166,7 +166,7 @@ impl crate::Readable for TAILR {}
 impl crate::Writable for TAILR {}
 #[doc = "GPTM Timer A Interval Load"]
 pub mod tailr;
-#[doc = "GPTM Timer B Interval Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbilr](tbilr) module"]
+#[doc = "GPTM Timer B Interval Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbilr](tbilr) module"]
 pub type TBILR = crate::Reg<u32, _TBILR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -177,7 +177,7 @@ impl crate::Readable for TBILR {}
 impl crate::Writable for TBILR {}
 #[doc = "GPTM Timer B Interval Load"]
 pub mod tbilr;
-#[doc = "GPTM Timer A Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tamatchr](tamatchr) module"]
+#[doc = "GPTM Timer A Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tamatchr](tamatchr) module"]
 pub type TAMATCHR = crate::Reg<u32, _TAMATCHR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -188,7 +188,7 @@ impl crate::Readable for TAMATCHR {}
 impl crate::Writable for TAMATCHR {}
 #[doc = "GPTM Timer A Match"]
 pub mod tamatchr;
-#[doc = "GPTM Timer B Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbmatchr](tbmatchr) module"]
+#[doc = "GPTM Timer B Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbmatchr](tbmatchr) module"]
 pub type TBMATCHR = crate::Reg<u32, _TBMATCHR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -199,7 +199,7 @@ impl crate::Readable for TBMATCHR {}
 impl crate::Writable for TBMATCHR {}
 #[doc = "GPTM Timer B Match"]
 pub mod tbmatchr;
-#[doc = "GPTM Timer A Prescale\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tapr](tapr) module"]
+#[doc = "GPTM Timer A Prescale\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tapr](tapr) module"]
 pub type TAPR = crate::Reg<u32, _TAPR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -210,7 +210,7 @@ impl crate::Readable for TAPR {}
 impl crate::Writable for TAPR {}
 #[doc = "GPTM Timer A Prescale"]
 pub mod tapr;
-#[doc = "GPTM Timer B Prescale\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbpr](tbpr) module"]
+#[doc = "GPTM Timer B Prescale\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbpr](tbpr) module"]
 pub type TBPR = crate::Reg<u32, _TBPR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -221,7 +221,7 @@ impl crate::Readable for TBPR {}
 impl crate::Writable for TBPR {}
 #[doc = "GPTM Timer B Prescale"]
 pub mod tbpr;
-#[doc = "GPTM TimerA Prescale Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tapmr](tapmr) module"]
+#[doc = "GPTM TimerA Prescale Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tapmr](tapmr) module"]
 pub type TAPMR = crate::Reg<u32, _TAPMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -232,7 +232,7 @@ impl crate::Readable for TAPMR {}
 impl crate::Writable for TAPMR {}
 #[doc = "GPTM TimerA Prescale Match"]
 pub mod tapmr;
-#[doc = "GPTM TimerB Prescale Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbpmr](tbpmr) module"]
+#[doc = "GPTM TimerB Prescale Match\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbpmr](tbpmr) module"]
 pub type TBPMR = crate::Reg<u32, _TBPMR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -243,7 +243,7 @@ impl crate::Readable for TBPMR {}
 impl crate::Writable for TBPMR {}
 #[doc = "GPTM TimerB Prescale Match"]
 pub mod tbpmr;
-#[doc = "GPTM Timer A\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tar](tar) module"]
+#[doc = "GPTM Timer A\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tar](tar) module"]
 pub type TAR = crate::Reg<u32, _TAR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -252,7 +252,7 @@ pub struct _TAR;
 impl crate::Readable for TAR {}
 #[doc = "GPTM Timer A"]
 pub mod tar;
-#[doc = "GPTM Timer B\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbr](tbr) module"]
+#[doc = "GPTM Timer B\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbr](tbr) module"]
 pub type TBR = crate::Reg<u32, _TBR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -261,7 +261,7 @@ pub struct _TBR;
 impl crate::Readable for TBR {}
 #[doc = "GPTM Timer B"]
 pub mod tbr;
-#[doc = "GPTM Timer A Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tav](tav) module"]
+#[doc = "GPTM Timer A Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tav](tav) module"]
 pub type TAV = crate::Reg<u32, _TAV>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -272,7 +272,7 @@ impl crate::Readable for TAV {}
 impl crate::Writable for TAV {}
 #[doc = "GPTM Timer A Value"]
 pub mod tav;
-#[doc = "GPTM Timer B Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbv](tbv) module"]
+#[doc = "GPTM Timer B Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbv](tbv) module"]
 pub type TBV = crate::Reg<u32, _TBV>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -283,7 +283,7 @@ impl crate::Readable for TBV {}
 impl crate::Writable for TBV {}
 #[doc = "GPTM Timer B Value"]
 pub mod tbv;
-#[doc = "GPTM RTC Predivide\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rtcpd](rtcpd) module"]
+#[doc = "GPTM RTC Predivide\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rtcpd](rtcpd) module"]
 pub type RTCPD = crate::Reg<u32, _RTCPD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -292,7 +292,7 @@ pub struct _RTCPD;
 impl crate::Readable for RTCPD {}
 #[doc = "GPTM RTC Predivide"]
 pub mod rtcpd;
-#[doc = "GPTM Timer A Prescale Snapshot\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [taps](taps) module"]
+#[doc = "GPTM Timer A Prescale Snapshot\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [taps](taps) module"]
 pub type TAPS = crate::Reg<u32, _TAPS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -301,7 +301,7 @@ pub struct _TAPS;
 impl crate::Readable for TAPS {}
 #[doc = "GPTM Timer A Prescale Snapshot"]
 pub mod taps;
-#[doc = "GPTM Timer B Prescale Snapshot\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [tbps](tbps) module"]
+#[doc = "GPTM Timer B Prescale Snapshot\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [tbps](tbps) module"]
 pub type TBPS = crate::Reg<u32, _TBPS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -310,7 +310,7 @@ pub struct _TBPS;
 impl crate::Readable for TBPS {}
 #[doc = "GPTM Timer B Prescale Snapshot"]
 pub mod tbps;
-#[doc = "GPTM DMA Event\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmaev](dmaev) module"]
+#[doc = "GPTM DMA Event\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmaev](dmaev) module"]
 pub type DMAEV = crate::Reg<u32, _DMAEV>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -321,7 +321,7 @@ impl crate::Readable for DMAEV {}
 impl crate::Writable for DMAEV {}
 #[doc = "GPTM DMA Event"]
 pub mod dmaev;
-#[doc = "GPTM ADC Event\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [adcev](adcev) module"]
+#[doc = "GPTM ADC Event\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [adcev](adcev) module"]
 pub type ADCEV = crate::Reg<u32, _ADCEV>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -332,7 +332,7 @@ impl crate::Readable for ADCEV {}
 impl crate::Writable for ADCEV {}
 #[doc = "GPTM ADC Event"]
 pub mod adcev;
-#[doc = "GPTM Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "GPTM Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -341,7 +341,7 @@ pub struct _PP;
 impl crate::Readable for PP {}
 #[doc = "GPTM Peripheral Properties"]
 pub mod pp;
-#[doc = "GPTM Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc](cc) module"]
+#[doc = "GPTM Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cc](cc) module"]
 pub type CC = crate::Reg<u32, _CC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/timer0/cfg.rs
+++ b/crates/tm4c129x/src/timer0/cfg.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::CFG {
 }
 #[doc = "GPTM Configuration\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CFG_A {
     #[doc = "0: For a 16/32-bit timer, this value selects the 32-bit timer configuration"]
-    _32_BIT_TIMER,
+    _32_BIT_TIMER = 0,
     #[doc = "1: For a 16/32-bit timer, this value selects the 32-bit real-time clock (RTC) counter configuration"]
-    _32_BIT_RTC,
+    _32_BIT_RTC = 1,
     #[doc = "4: For a 16/32-bit timer, this value selects the 16-bit timer configuration"]
-    _16_BIT,
+    _16_BIT = 4,
 }
 impl From<CFG_A> for u8 {
     #[inline(always)]
     fn from(variant: CFG_A) -> Self {
-        match variant {
-            CFG_A::_32_BIT_TIMER => 0,
-            CFG_A::_32_BIT_RTC => 1,
-            CFG_A::_16_BIT => 4,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CFG`"]

--- a/crates/tm4c129x/src/timer0/ctl.rs
+++ b/crates/tm4c129x/src/timer0/ctl.rs
@@ -60,22 +60,19 @@ impl<'a> TASTALL_W<'a> {
 }
 #[doc = "GPTM Timer A Event Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TAEVENT_A {
     #[doc = "0: Positive edge"]
-    POS,
+    POS = 0,
     #[doc = "1: Negative edge"]
-    NEG,
+    NEG = 1,
     #[doc = "3: Both edges"]
-    BOTH,
+    BOTH = 3,
 }
 impl From<TAEVENT_A> for u8 {
     #[inline(always)]
     fn from(variant: TAEVENT_A) -> Self {
-        match variant {
-            TAEVENT_A::POS => 0,
-            TAEVENT_A::NEG => 1,
-            TAEVENT_A::BOTH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TAEVENT`"]
@@ -262,22 +259,19 @@ impl<'a> TBSTALL_W<'a> {
 }
 #[doc = "GPTM Timer B Event Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TBEVENT_A {
     #[doc = "0: Positive edge"]
-    POS,
+    POS = 0,
     #[doc = "1: Negative edge"]
-    NEG,
+    NEG = 1,
     #[doc = "3: Both edges"]
-    BOTH,
+    BOTH = 3,
 }
 impl From<TBEVENT_A> for u8 {
     #[inline(always)]
     fn from(variant: TBEVENT_A) -> Self {
-        match variant {
-            TBEVENT_A::POS => 0,
-            TBEVENT_A::NEG => 1,
-            TBEVENT_A::BOTH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TBEVENT`"]

--- a/crates/tm4c129x/src/timer0/pp.rs
+++ b/crates/tm4c129x/src/timer0/pp.rs
@@ -2,19 +2,17 @@
 pub type R = crate::R<u32, super::PP>;
 #[doc = "Count Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SIZE_A {
     #[doc = "0: Timer A and Timer B counters are 16 bits each with an 8-bit prescale counter"]
-    _16,
+    _16 = 0,
     #[doc = "1: Timer A and Timer B counters are 32 bits each with a 16-bit prescale counter"]
-    _32,
+    _32 = 1,
 }
 impl From<SIZE_A> for u8 {
     #[inline(always)]
     fn from(variant: SIZE_A) -> Self {
-        match variant {
-            SIZE_A::_16 => 0,
-            SIZE_A::_32 => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SIZE`"]

--- a/crates/tm4c129x/src/timer0/sync.rs
+++ b/crates/tm4c129x/src/timer0/sync.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::SYNC {
 }
 #[doc = "Synchronize GPTM Timer 0\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT0_A {
     #[doc = "0: GPTM0 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM0 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM0 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM0 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT0_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT0_A) -> Self {
-        match variant {
-            SYNCT0_A::NONE => 0,
-            SYNCT0_A::TA => 1,
-            SYNCT0_A::TB => 2,
-            SYNCT0_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT0`"]
@@ -109,25 +105,21 @@ impl<'a> SYNCT0_W<'a> {
 }
 #[doc = "Synchronize GPTM Timer 1\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT1_A {
     #[doc = "0: GPTM1 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM1 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM1 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM1 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT1_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT1_A) -> Self {
-        match variant {
-            SYNCT1_A::NONE => 0,
-            SYNCT1_A::TA => 1,
-            SYNCT1_A::TB => 2,
-            SYNCT1_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT1`"]
@@ -206,25 +198,21 @@ impl<'a> SYNCT1_W<'a> {
 }
 #[doc = "Synchronize GPTM Timer 2\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT2_A {
     #[doc = "0: GPTM2 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM2 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM2 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM2 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT2_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT2_A) -> Self {
-        match variant {
-            SYNCT2_A::NONE => 0,
-            SYNCT2_A::TA => 1,
-            SYNCT2_A::TB => 2,
-            SYNCT2_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT2`"]
@@ -303,25 +291,21 @@ impl<'a> SYNCT2_W<'a> {
 }
 #[doc = "Synchronize GPTM Timer 3\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT3_A {
     #[doc = "0: GPTM3 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM3 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM3 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM3 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT3_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT3_A) -> Self {
-        match variant {
-            SYNCT3_A::NONE => 0,
-            SYNCT3_A::TA => 1,
-            SYNCT3_A::TB => 2,
-            SYNCT3_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT3`"]
@@ -400,25 +384,21 @@ impl<'a> SYNCT3_W<'a> {
 }
 #[doc = "Synchronize GPTM Timer 4\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT4_A {
     #[doc = "0: GPTM4 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM4 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM4 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM4 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT4_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT4_A) -> Self {
-        match variant {
-            SYNCT4_A::NONE => 0,
-            SYNCT4_A::TA => 1,
-            SYNCT4_A::TB => 2,
-            SYNCT4_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT4`"]
@@ -497,25 +477,21 @@ impl<'a> SYNCT4_W<'a> {
 }
 #[doc = "Synchronize GPTM Timer 5\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT5_A {
     #[doc = "0: GPTM5 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM5 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM5 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM5 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT5_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT5_A) -> Self {
-        match variant {
-            SYNCT5_A::NONE => 0,
-            SYNCT5_A::TA => 1,
-            SYNCT5_A::TB => 2,
-            SYNCT5_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT5`"]
@@ -594,25 +570,21 @@ impl<'a> SYNCT5_W<'a> {
 }
 #[doc = "Synchronize GPTM Timer 6\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT6_A {
     #[doc = "0: GPTM6 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM6 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM6 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM6 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT6_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT6_A) -> Self {
-        match variant {
-            SYNCT6_A::NONE => 0,
-            SYNCT6_A::TA => 1,
-            SYNCT6_A::TB => 2,
-            SYNCT6_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT6`"]
@@ -691,25 +663,21 @@ impl<'a> SYNCT6_W<'a> {
 }
 #[doc = "Synchronize GPTM Timer 7\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SYNCT7_A {
     #[doc = "0: GPT7 is not affected"]
-    NONE,
+    NONE = 0,
     #[doc = "1: A timeout event for Timer A of GPTM7 is triggered"]
-    TA,
+    TA = 1,
     #[doc = "2: A timeout event for Timer B of GPTM7 is triggered"]
-    TB,
+    TB = 2,
     #[doc = "3: A timeout event for both Timer A and Timer B of GPTM7 is triggered"]
-    TATB,
+    TATB = 3,
 }
 impl From<SYNCT7_A> for u8 {
     #[inline(always)]
     fn from(variant: SYNCT7_A) -> Self {
-        match variant {
-            SYNCT7_A::NONE => 0,
-            SYNCT7_A::TA => 1,
-            SYNCT7_A::TB => 2,
-            SYNCT7_A::TATB => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SYNCT7`"]

--- a/crates/tm4c129x/src/timer0/tamr.rs
+++ b/crates/tm4c129x/src/timer0/tamr.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::TAMR {
 }
 #[doc = "GPTM Timer A Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TAMR_A {
     #[doc = "1: One-Shot Timer mode"]
-    _1_SHOT,
+    _1_SHOT = 1,
     #[doc = "2: Periodic Timer mode"]
-    PERIOD,
+    PERIOD = 2,
     #[doc = "3: Capture mode"]
-    CAP,
+    CAP = 3,
 }
 impl From<TAMR_A> for u8 {
     #[inline(always)]
     fn from(variant: TAMR_A) -> Self {
-        match variant {
-            TAMR_A::_1_SHOT => 1,
-            TAMR_A::PERIOD => 2,
-            TAMR_A::CAP => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TAMR`"]
@@ -358,37 +355,29 @@ impl<'a> TACINTD_W<'a> {
 }
 #[doc = "Timer Compare Action Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TCACT_A {
     #[doc = "0: Disable compare operations"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Toggle State on Time-Out"]
-    TOGGLE,
+    TOGGLE = 1,
     #[doc = "2: Clear CCP on Time-Out"]
-    CLRTO,
+    CLRTO = 2,
     #[doc = "3: Set CCP on Time-Out"]
-    SETTO,
+    SETTO = 3,
     #[doc = "4: Set CCP immediately and toggle on Time-Out"]
-    SETTOGTO,
+    SETTOGTO = 4,
     #[doc = "5: Clear CCP immediately and toggle on Time-Out"]
-    CLRTOGTO,
+    CLRTOGTO = 5,
     #[doc = "6: Set CCP immediately and clear on Time-Out"]
-    SETCLRTO,
+    SETCLRTO = 6,
     #[doc = "7: Clear CCP immediately and set on Time-Out"]
-    CLRSETTO,
+    CLRSETTO = 7,
 }
 impl From<TCACT_A> for u8 {
     #[inline(always)]
     fn from(variant: TCACT_A) -> Self {
-        match variant {
-            TCACT_A::NONE => 0,
-            TCACT_A::TOGGLE => 1,
-            TCACT_A::CLRTO => 2,
-            TCACT_A::SETTO => 3,
-            TCACT_A::SETTOGTO => 4,
-            TCACT_A::CLRTOGTO => 5,
-            TCACT_A::SETCLRTO => 6,
-            TCACT_A::CLRSETTO => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TCACT`"]

--- a/crates/tm4c129x/src/timer0/tbmr.rs
+++ b/crates/tm4c129x/src/timer0/tbmr.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::TBMR {
 }
 #[doc = "GPTM Timer B Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TBMR_A {
     #[doc = "1: One-Shot Timer mode"]
-    _1_SHOT,
+    _1_SHOT = 1,
     #[doc = "2: Periodic Timer mode"]
-    PERIOD,
+    PERIOD = 2,
     #[doc = "3: Capture mode"]
-    CAP,
+    CAP = 3,
 }
 impl From<TBMR_A> for u8 {
     #[inline(always)]
     fn from(variant: TBMR_A) -> Self {
-        match variant {
-            TBMR_A::_1_SHOT => 1,
-            TBMR_A::PERIOD => 2,
-            TBMR_A::CAP => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TBMR`"]
@@ -358,37 +355,29 @@ impl<'a> TBCINTD_W<'a> {
 }
 #[doc = "Timer Compare Action Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TCACT_A {
     #[doc = "0: Disable compare operations"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Toggle State on Time-Out"]
-    TOGGLE,
+    TOGGLE = 1,
     #[doc = "2: Clear CCP on Time-Out"]
-    CLRTO,
+    CLRTO = 2,
     #[doc = "3: Set CCP on Time-Out"]
-    SETTO,
+    SETTO = 3,
     #[doc = "4: Set CCP immediately and toggle on Time-Out"]
-    SETTOGTO,
+    SETTOGTO = 4,
     #[doc = "5: Clear CCP immediately and toggle on Time-Out"]
-    CLRTOGTO,
+    CLRTOGTO = 5,
     #[doc = "6: Set CCP immediately and clear on Time-Out"]
-    SETCLRTO,
+    SETCLRTO = 6,
     #[doc = "7: Clear CCP immediately and set on Time-Out"]
-    CLRSETTO,
+    CLRSETTO = 7,
 }
 impl From<TCACT_A> for u8 {
     #[inline(always)]
     fn from(variant: TCACT_A) -> Self {
-        match variant {
-            TCACT_A::NONE => 0,
-            TCACT_A::TOGGLE => 1,
-            TCACT_A::CLRTO => 2,
-            TCACT_A::SETTO => 3,
-            TCACT_A::SETTOGTO => 4,
-            TCACT_A::CLRTOGTO => 5,
-            TCACT_A::SETCLRTO => 6,
-            TCACT_A::CLRSETTO => 7,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TCACT`"]

--- a/crates/tm4c129x/src/uart0.rs
+++ b/crates/tm4c129x/src/uart0.rs
@@ -64,7 +64,7 @@ impl RegisterBlock {
         unsafe { &mut *(((self as *const Self) as *mut u8).add(4usize) as *mut RSR) }
     }
 }
-#[doc = "UART Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dr](dr) module"]
+#[doc = "UART Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dr](dr) module"]
 pub type DR = crate::Reg<u32, _DR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -75,7 +75,7 @@ impl crate::Readable for DR {}
 impl crate::Writable for DR {}
 #[doc = "UART Data"]
 pub mod dr;
-#[doc = "UART Receive Status/Error Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rsr](rsr) module"]
+#[doc = "UART Receive Status/Error Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rsr](rsr) module"]
 pub type RSR = crate::Reg<u32, _RSR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -86,7 +86,7 @@ impl crate::Readable for RSR {}
 impl crate::Writable for RSR {}
 #[doc = "UART Receive Status/Error Clear"]
 pub mod rsr;
-#[doc = "UART Receive Status/Error Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ecr](ecr) module"]
+#[doc = "UART Receive Status/Error Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ecr](ecr) module"]
 pub type ECR = crate::Reg<u32, _ECR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -97,7 +97,7 @@ impl crate::Readable for ECR {}
 impl crate::Writable for ECR {}
 #[doc = "UART Receive Status/Error Clear"]
 pub mod ecr;
-#[doc = "UART Flag\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fr](fr) module"]
+#[doc = "UART Flag\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fr](fr) module"]
 pub type FR = crate::Reg<u32, _FR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -106,7 +106,7 @@ pub struct _FR;
 impl crate::Readable for FR {}
 #[doc = "UART Flag"]
 pub mod fr;
-#[doc = "UART IrDA Low-Power Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ilpr](ilpr) module"]
+#[doc = "UART IrDA Low-Power Register\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ilpr](ilpr) module"]
 pub type ILPR = crate::Reg<u32, _ILPR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -117,7 +117,7 @@ impl crate::Readable for ILPR {}
 impl crate::Writable for ILPR {}
 #[doc = "UART IrDA Low-Power Register"]
 pub mod ilpr;
-#[doc = "UART Integer Baud-Rate Divisor\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ibrd](ibrd) module"]
+#[doc = "UART Integer Baud-Rate Divisor\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ibrd](ibrd) module"]
 pub type IBRD = crate::Reg<u32, _IBRD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -128,7 +128,7 @@ impl crate::Readable for IBRD {}
 impl crate::Writable for IBRD {}
 #[doc = "UART Integer Baud-Rate Divisor"]
 pub mod ibrd;
-#[doc = "UART Fractional Baud-Rate Divisor\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fbrd](fbrd) module"]
+#[doc = "UART Fractional Baud-Rate Divisor\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fbrd](fbrd) module"]
 pub type FBRD = crate::Reg<u32, _FBRD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -139,7 +139,7 @@ impl crate::Readable for FBRD {}
 impl crate::Writable for FBRD {}
 #[doc = "UART Fractional Baud-Rate Divisor"]
 pub mod fbrd;
-#[doc = "UART Line Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [lcrh](lcrh) module"]
+#[doc = "UART Line Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [lcrh](lcrh) module"]
 pub type LCRH = crate::Reg<u32, _LCRH>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -150,7 +150,7 @@ impl crate::Readable for LCRH {}
 impl crate::Writable for LCRH {}
 #[doc = "UART Line Control"]
 pub mod lcrh;
-#[doc = "UART Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctl](ctl) module"]
+#[doc = "UART Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctl](ctl) module"]
 pub type CTL = crate::Reg<u32, _CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -161,7 +161,7 @@ impl crate::Readable for CTL {}
 impl crate::Writable for CTL {}
 #[doc = "UART Control"]
 pub mod ctl;
-#[doc = "UART Interrupt FIFO Level Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ifls](ifls) module"]
+#[doc = "UART Interrupt FIFO Level Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ifls](ifls) module"]
 pub type IFLS = crate::Reg<u32, _IFLS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -172,7 +172,7 @@ impl crate::Readable for IFLS {}
 impl crate::Writable for IFLS {}
 #[doc = "UART Interrupt FIFO Level Select"]
 pub mod ifls;
-#[doc = "UART Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [im](im) module"]
+#[doc = "UART Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [im](im) module"]
 pub type IM = crate::Reg<u32, _IM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -183,7 +183,7 @@ impl crate::Readable for IM {}
 impl crate::Writable for IM {}
 #[doc = "UART Interrupt Mask"]
 pub mod im;
-#[doc = "UART Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "UART Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -192,7 +192,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "UART Raw Interrupt Status"]
 pub mod ris;
-#[doc = "UART Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mis](mis) module"]
+#[doc = "UART Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mis](mis) module"]
 pub type MIS = crate::Reg<u32, _MIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -201,7 +201,7 @@ pub struct _MIS;
 impl crate::Readable for MIS {}
 #[doc = "UART Masked Interrupt Status"]
 pub mod mis;
-#[doc = "UART Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [icr](icr) module"]
+#[doc = "UART Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [icr](icr) module"]
 pub type ICR = crate::Reg<u32, _ICR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -210,7 +210,7 @@ pub struct _ICR;
 impl crate::Writable for ICR {}
 #[doc = "UART Interrupt Clear"]
 pub mod icr;
-#[doc = "UART DMA Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmactl](dmactl) module"]
+#[doc = "UART DMA Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmactl](dmactl) module"]
 pub type DMACTL = crate::Reg<u32, _DMACTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -221,7 +221,7 @@ impl crate::Readable for DMACTL {}
 impl crate::Writable for DMACTL {}
 #[doc = "UART DMA Control"]
 pub mod dmactl;
-#[doc = "UART 9-Bit Self Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_9bitaddr](_9bitaddr) module"]
+#[doc = "UART 9-Bit Self Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_9bitaddr](_9bitaddr) module"]
 pub type _9BITADDR = crate::Reg<u32, __9BITADDR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -232,7 +232,7 @@ impl crate::Readable for _9BITADDR {}
 impl crate::Writable for _9BITADDR {}
 #[doc = "UART 9-Bit Self Address"]
 pub mod _9bitaddr;
-#[doc = "UART 9-Bit Self Address Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [_9bitamask](_9bitamask) module"]
+#[doc = "UART 9-Bit Self Address Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [_9bitamask](_9bitamask) module"]
 pub type _9BITAMASK = crate::Reg<u32, __9BITAMASK>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -243,7 +243,7 @@ impl crate::Readable for _9BITAMASK {}
 impl crate::Writable for _9BITAMASK {}
 #[doc = "UART 9-Bit Self Address Mask"]
 pub mod _9bitamask;
-#[doc = "UART Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "UART Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -252,7 +252,7 @@ pub struct _PP;
 impl crate::Readable for PP {}
 #[doc = "UART Peripheral Properties"]
 pub mod pp;
-#[doc = "UART Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc](cc) module"]
+#[doc = "UART Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cc](cc) module"]
 pub type CC = crate::Reg<u32, _CC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/uart0/cc.rs
+++ b/crates/tm4c129x/src/uart0/cc.rs
@@ -12,19 +12,17 @@ impl crate::ResetValue for super::CC {
 }
 #[doc = "UART Baud Clock Source\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum CS_A {
     #[doc = "0: System clock (based on clock source and divisor factor)"]
-    SYSCLK,
+    SYSCLK = 0,
     #[doc = "5: Alternate clock (as defined in System Control Module)"]
-    ALTCLK,
+    ALTCLK = 5,
 }
 impl From<CS_A> for u8 {
     #[inline(always)]
     fn from(variant: CS_A) -> Self {
-        match variant {
-            CS_A::SYSCLK => 0,
-            CS_A::ALTCLK => 5,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CS`"]

--- a/crates/tm4c129x/src/uart0/ifls.rs
+++ b/crates/tm4c129x/src/uart0/ifls.rs
@@ -12,28 +12,23 @@ impl crate::ResetValue for super::IFLS {
 }
 #[doc = "UART Transmit Interrupt FIFO Level Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TX_A {
     #[doc = "0: TX FIFO &lt;= 1/8 full"]
-    TX1_8,
+    TX1_8 = 0,
     #[doc = "1: TX FIFO &lt;= 1/4 full"]
-    TX2_8,
+    TX2_8 = 1,
     #[doc = "2: TX FIFO &lt;= 1/2 full (default)"]
-    TX4_8,
+    TX4_8 = 2,
     #[doc = "3: TX FIFO &lt;= 3/4 full"]
-    TX6_8,
+    TX6_8 = 3,
     #[doc = "4: TX FIFO &lt;= 7/8 full"]
-    TX7_8,
+    TX7_8 = 4,
 }
 impl From<TX_A> for u8 {
     #[inline(always)]
     fn from(variant: TX_A) -> Self {
-        match variant {
-            TX_A::TX1_8 => 0,
-            TX_A::TX2_8 => 1,
-            TX_A::TX4_8 => 2,
-            TX_A::TX6_8 => 3,
-            TX_A::TX7_8 => 4,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TX`"]
@@ -122,28 +117,23 @@ impl<'a> TX_W<'a> {
 }
 #[doc = "UART Receive Interrupt FIFO Level Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum RX_A {
     #[doc = "0: RX FIFO >= 1/8 full"]
-    RX1_8,
+    RX1_8 = 0,
     #[doc = "1: RX FIFO >= 1/4 full"]
-    RX2_8,
+    RX2_8 = 1,
     #[doc = "2: RX FIFO >= 1/2 full (default)"]
-    RX4_8,
+    RX4_8 = 2,
     #[doc = "3: RX FIFO >= 3/4 full"]
-    RX6_8,
+    RX6_8 = 3,
     #[doc = "4: RX FIFO >= 7/8 full"]
-    RX7_8,
+    RX7_8 = 4,
 }
 impl From<RX_A> for u8 {
     #[inline(always)]
     fn from(variant: RX_A) -> Self {
-        match variant {
-            RX_A::RX1_8 => 0,
-            RX_A::RX2_8 => 1,
-            RX_A::RX4_8 => 2,
-            RX_A::RX6_8 => 3,
-            RX_A::RX7_8 => 4,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `RX`"]

--- a/crates/tm4c129x/src/uart0/lcrh.rs
+++ b/crates/tm4c129x/src/uart0/lcrh.rs
@@ -132,25 +132,21 @@ impl<'a> FEN_W<'a> {
 }
 #[doc = "UART Word Length\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum WLEN_A {
     #[doc = "0: 5 bits (default)"]
-    _5,
+    _5 = 0,
     #[doc = "1: 6 bits"]
-    _6,
+    _6 = 1,
     #[doc = "2: 7 bits"]
-    _7,
+    _7 = 2,
     #[doc = "3: 8 bits"]
-    _8,
+    _8 = 3,
 }
 impl From<WLEN_A> for u8 {
     #[inline(always)]
     fn from(variant: WLEN_A) -> Self {
-        match variant {
-            WLEN_A::_5 => 0,
-            WLEN_A::_6 => 1,
-            WLEN_A::_7 => 2,
-            WLEN_A::_8 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `WLEN`"]

--- a/crates/tm4c129x/src/udma.rs
+++ b/crates/tm4c129x/src/udma.rs
@@ -49,7 +49,7 @@ pub struct RegisterBlock {
     #[doc = "0x51c - DMA Channel Map Select 3"]
     pub chmap3: CHMAP3,
 }
-#[doc = "DMA Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [stat](stat) module"]
+#[doc = "DMA Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [stat](stat) module"]
 pub type STAT = crate::Reg<u32, _STAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -67,7 +67,7 @@ pub struct _CFG;
 impl crate::Writable for CFG {}
 #[doc = "DMA Configuration"]
 pub mod cfg;
-#[doc = "DMA Channel Control Base Pointer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctlbase](ctlbase) module"]
+#[doc = "DMA Channel Control Base Pointer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctlbase](ctlbase) module"]
 pub type CTLBASE = crate::Reg<u32, _CTLBASE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -78,7 +78,7 @@ impl crate::Readable for CTLBASE {}
 impl crate::Writable for CTLBASE {}
 #[doc = "DMA Channel Control Base Pointer"]
 pub mod ctlbase;
-#[doc = "DMA Alternate Channel Control Base Pointer\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [altbase](altbase) module"]
+#[doc = "DMA Alternate Channel Control Base Pointer\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [altbase](altbase) module"]
 pub type ALTBASE = crate::Reg<u32, _ALTBASE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -87,7 +87,7 @@ pub struct _ALTBASE;
 impl crate::Readable for ALTBASE {}
 #[doc = "DMA Alternate Channel Control Base Pointer"]
 pub mod altbase;
-#[doc = "DMA Channel Wait-on-Request Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [waitstat](waitstat) module"]
+#[doc = "DMA Channel Wait-on-Request Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [waitstat](waitstat) module"]
 pub type WAITSTAT = crate::Reg<u32, _WAITSTAT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -96,7 +96,7 @@ pub struct _WAITSTAT;
 impl crate::Readable for WAITSTAT {}
 #[doc = "DMA Channel Wait-on-Request Status"]
 pub mod waitstat;
-#[doc = "DMA Channel Software Request\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [swreq](swreq) module"]
+#[doc = "DMA Channel Software Request\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [swreq](swreq) module"]
 pub type SWREQ = crate::Reg<u32, _SWREQ>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -105,7 +105,7 @@ pub struct _SWREQ;
 impl crate::Writable for SWREQ {}
 #[doc = "DMA Channel Software Request"]
 pub mod swreq;
-#[doc = "DMA Channel Useburst Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [useburstset](useburstset) module"]
+#[doc = "DMA Channel Useburst Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [useburstset](useburstset) module"]
 pub type USEBURSTSET = crate::Reg<u32, _USEBURSTSET>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -116,7 +116,7 @@ impl crate::Readable for USEBURSTSET {}
 impl crate::Writable for USEBURSTSET {}
 #[doc = "DMA Channel Useburst Set"]
 pub mod useburstset;
-#[doc = "DMA Channel Useburst Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [useburstclr](useburstclr) module"]
+#[doc = "DMA Channel Useburst Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [useburstclr](useburstclr) module"]
 pub type USEBURSTCLR = crate::Reg<u32, _USEBURSTCLR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -125,7 +125,7 @@ pub struct _USEBURSTCLR;
 impl crate::Writable for USEBURSTCLR {}
 #[doc = "DMA Channel Useburst Clear"]
 pub mod useburstclr;
-#[doc = "DMA Channel Request Mask Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [reqmaskset](reqmaskset) module"]
+#[doc = "DMA Channel Request Mask Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [reqmaskset](reqmaskset) module"]
 pub type REQMASKSET = crate::Reg<u32, _REQMASKSET>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -136,7 +136,7 @@ impl crate::Readable for REQMASKSET {}
 impl crate::Writable for REQMASKSET {}
 #[doc = "DMA Channel Request Mask Set"]
 pub mod reqmaskset;
-#[doc = "DMA Channel Request Mask Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [reqmaskclr](reqmaskclr) module"]
+#[doc = "DMA Channel Request Mask Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [reqmaskclr](reqmaskclr) module"]
 pub type REQMASKCLR = crate::Reg<u32, _REQMASKCLR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -145,7 +145,7 @@ pub struct _REQMASKCLR;
 impl crate::Writable for REQMASKCLR {}
 #[doc = "DMA Channel Request Mask Clear"]
 pub mod reqmaskclr;
-#[doc = "DMA Channel Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [enaset](enaset) module"]
+#[doc = "DMA Channel Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [enaset](enaset) module"]
 pub type ENASET = crate::Reg<u32, _ENASET>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -156,7 +156,7 @@ impl crate::Readable for ENASET {}
 impl crate::Writable for ENASET {}
 #[doc = "DMA Channel Enable Set"]
 pub mod enaset;
-#[doc = "DMA Channel Enable Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [enaclr](enaclr) module"]
+#[doc = "DMA Channel Enable Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [enaclr](enaclr) module"]
 pub type ENACLR = crate::Reg<u32, _ENACLR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -165,7 +165,7 @@ pub struct _ENACLR;
 impl crate::Writable for ENACLR {}
 #[doc = "DMA Channel Enable Clear"]
 pub mod enaclr;
-#[doc = "DMA Channel Primary Alternate Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [altset](altset) module"]
+#[doc = "DMA Channel Primary Alternate Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [altset](altset) module"]
 pub type ALTSET = crate::Reg<u32, _ALTSET>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -176,7 +176,7 @@ impl crate::Readable for ALTSET {}
 impl crate::Writable for ALTSET {}
 #[doc = "DMA Channel Primary Alternate Set"]
 pub mod altset;
-#[doc = "DMA Channel Primary Alternate Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [altclr](altclr) module"]
+#[doc = "DMA Channel Primary Alternate Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [altclr](altclr) module"]
 pub type ALTCLR = crate::Reg<u32, _ALTCLR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -185,7 +185,7 @@ pub struct _ALTCLR;
 impl crate::Writable for ALTCLR {}
 #[doc = "DMA Channel Primary Alternate Clear"]
 pub mod altclr;
-#[doc = "DMA Channel Priority Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prioset](prioset) module"]
+#[doc = "DMA Channel Priority Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prioset](prioset) module"]
 pub type PRIOSET = crate::Reg<u32, _PRIOSET>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -196,7 +196,7 @@ impl crate::Readable for PRIOSET {}
 impl crate::Writable for PRIOSET {}
 #[doc = "DMA Channel Priority Set"]
 pub mod prioset;
-#[doc = "DMA Channel Priority Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prioclr](prioclr) module"]
+#[doc = "DMA Channel Priority Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [prioclr](prioclr) module"]
 pub type PRIOCLR = crate::Reg<u32, _PRIOCLR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -205,7 +205,7 @@ pub struct _PRIOCLR;
 impl crate::Writable for PRIOCLR {}
 #[doc = "DMA Channel Priority Clear"]
 pub mod prioclr;
-#[doc = "DMA Bus Error Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [errclr](errclr) module"]
+#[doc = "DMA Bus Error Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [errclr](errclr) module"]
 pub type ERRCLR = crate::Reg<u32, _ERRCLR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -216,7 +216,7 @@ impl crate::Readable for ERRCLR {}
 impl crate::Writable for ERRCLR {}
 #[doc = "DMA Bus Error Clear"]
 pub mod errclr;
-#[doc = "DMA Channel Assignment\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chasgn](chasgn) module"]
+#[doc = "DMA Channel Assignment\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [chasgn](chasgn) module"]
 pub type CHASGN = crate::Reg<u32, _CHASGN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -227,7 +227,7 @@ impl crate::Readable for CHASGN {}
 impl crate::Writable for CHASGN {}
 #[doc = "DMA Channel Assignment"]
 pub mod chasgn;
-#[doc = "DMA Channel Map Select 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chmap0](chmap0) module"]
+#[doc = "DMA Channel Map Select 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [chmap0](chmap0) module"]
 pub type CHMAP0 = crate::Reg<u32, _CHMAP0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -238,7 +238,7 @@ impl crate::Readable for CHMAP0 {}
 impl crate::Writable for CHMAP0 {}
 #[doc = "DMA Channel Map Select 0"]
 pub mod chmap0;
-#[doc = "DMA Channel Map Select 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chmap1](chmap1) module"]
+#[doc = "DMA Channel Map Select 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [chmap1](chmap1) module"]
 pub type CHMAP1 = crate::Reg<u32, _CHMAP1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -249,7 +249,7 @@ impl crate::Readable for CHMAP1 {}
 impl crate::Writable for CHMAP1 {}
 #[doc = "DMA Channel Map Select 1"]
 pub mod chmap1;
-#[doc = "DMA Channel Map Select 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chmap2](chmap2) module"]
+#[doc = "DMA Channel Map Select 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [chmap2](chmap2) module"]
 pub type CHMAP2 = crate::Reg<u32, _CHMAP2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -260,7 +260,7 @@ impl crate::Readable for CHMAP2 {}
 impl crate::Writable for CHMAP2 {}
 #[doc = "DMA Channel Map Select 2"]
 pub mod chmap2;
-#[doc = "DMA Channel Map Select 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chmap3](chmap3) module"]
+#[doc = "DMA Channel Map Select 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [chmap3](chmap3) module"]
 pub type CHMAP3 = crate::Reg<u32, _CHMAP3>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/udma/altclr.rs
+++ b/crates/tm4c129x/src/udma/altclr.rs
@@ -21,7 +21,8 @@ impl<'a> CLR_W<'a> {
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Alternate Clear"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Alternate Clear"]
     #[inline(always)]
     pub fn clr(&mut self) -> CLR_W {
         CLR_W { w: self }

--- a/crates/tm4c129x/src/udma/altset.rs
+++ b/crates/tm4c129x/src/udma/altset.rs
@@ -25,14 +25,16 @@ impl<'a> SET_W<'a> {
     }
 }
 impl R {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Alternate Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Alternate Set"]
     #[inline(always)]
     pub fn set(&self) -> SET_R {
         SET_R::new((self.bits & 0xffff_ffff) as u32)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Alternate Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Alternate Set"]
     #[inline(always)]
     pub fn set(&mut self) -> SET_W {
         SET_W { w: self }

--- a/crates/tm4c129x/src/udma/chasgn.rs
+++ b/crates/tm4c129x/src/udma/chasgn.rs
@@ -10,21 +10,20 @@ impl crate::ResetValue for super::CHASGN {
         0
     }
 }
-#[doc = "Channel \\[n\\] Assignment Select\n\nValue on reset: 0"]
+#[doc = "Channel \\[n\\]
+Assignment Select\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u32)]
 pub enum CHASGN_A {
     #[doc = "0: Use the primary channel assignment"]
-    PRIMARY,
+    PRIMARY = 0,
     #[doc = "1: Use the secondary channel assignment"]
-    SECONDARY,
+    SECONDARY = 1,
 }
 impl From<CHASGN_A> for u32 {
     #[inline(always)]
     fn from(variant: CHASGN_A) -> Self {
-        match variant {
-            CHASGN_A::PRIMARY => 0,
-            CHASGN_A::SECONDARY => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `CHASGN`"]
@@ -79,14 +78,16 @@ impl<'a> CHASGN_W<'a> {
     }
 }
 impl R {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Assignment Select"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Assignment Select"]
     #[inline(always)]
     pub fn chasgn(&self) -> CHASGN_R {
         CHASGN_R::new((self.bits & 0xffff_ffff) as u32)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Assignment Select"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Assignment Select"]
     #[inline(always)]
     pub fn chasgn(&mut self) -> CHASGN_W {
         CHASGN_W { w: self }

--- a/crates/tm4c129x/src/udma/enaclr.rs
+++ b/crates/tm4c129x/src/udma/enaclr.rs
@@ -21,7 +21,8 @@ impl<'a> CLR_W<'a> {
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Clear Channel \\[n\\] Enable Clear"]
+    #[doc = "Bits 0:31 - Clear Channel \\[n\\]
+Enable Clear"]
     #[inline(always)]
     pub fn clr(&mut self) -> CLR_W {
         CLR_W { w: self }

--- a/crates/tm4c129x/src/udma/enaset.rs
+++ b/crates/tm4c129x/src/udma/enaset.rs
@@ -25,14 +25,16 @@ impl<'a> SET_W<'a> {
     }
 }
 impl R {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Enable Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Enable Set"]
     #[inline(always)]
     pub fn set(&self) -> SET_R {
         SET_R::new((self.bits & 0xffff_ffff) as u32)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Enable Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Enable Set"]
     #[inline(always)]
     pub fn set(&mut self) -> SET_W {
         SET_W { w: self }

--- a/crates/tm4c129x/src/udma/prioclr.rs
+++ b/crates/tm4c129x/src/udma/prioclr.rs
@@ -21,7 +21,8 @@ impl<'a> CLR_W<'a> {
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Priority Clear"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Priority Clear"]
     #[inline(always)]
     pub fn clr(&mut self) -> CLR_W {
         CLR_W { w: self }

--- a/crates/tm4c129x/src/udma/prioset.rs
+++ b/crates/tm4c129x/src/udma/prioset.rs
@@ -25,14 +25,16 @@ impl<'a> SET_W<'a> {
     }
 }
 impl R {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Priority Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Priority Set"]
     #[inline(always)]
     pub fn set(&self) -> SET_R {
         SET_R::new((self.bits & 0xffff_ffff) as u32)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Priority Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Priority Set"]
     #[inline(always)]
     pub fn set(&mut self) -> SET_W {
         SET_W { w: self }

--- a/crates/tm4c129x/src/udma/reqmaskclr.rs
+++ b/crates/tm4c129x/src/udma/reqmaskclr.rs
@@ -21,7 +21,8 @@ impl<'a> CLR_W<'a> {
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Request Mask Clear"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Request Mask Clear"]
     #[inline(always)]
     pub fn clr(&mut self) -> CLR_W {
         CLR_W { w: self }

--- a/crates/tm4c129x/src/udma/reqmaskset.rs
+++ b/crates/tm4c129x/src/udma/reqmaskset.rs
@@ -25,14 +25,16 @@ impl<'a> SET_W<'a> {
     }
 }
 impl R {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Request Mask Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Request Mask Set"]
     #[inline(always)]
     pub fn set(&self) -> SET_R {
         SET_R::new((self.bits & 0xffff_ffff) as u32)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Request Mask Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Request Mask Set"]
     #[inline(always)]
     pub fn set(&mut self) -> SET_W {
         SET_W { w: self }

--- a/crates/tm4c129x/src/udma/stat.rs
+++ b/crates/tm4c129x/src/udma/stat.rs
@@ -4,46 +4,35 @@ pub type R = crate::R<u32, super::STAT>;
 pub type MASTEN_R = crate::R<bool, bool>;
 #[doc = "Control State Machine Status\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum STATE_A {
     #[doc = "0: Idle"]
-    IDLE,
+    IDLE = 0,
     #[doc = "1: Reading channel controller data"]
-    RD_CTRL,
+    RD_CTRL = 1,
     #[doc = "2: Reading source end pointer"]
-    RD_SRCENDP,
+    RD_SRCENDP = 2,
     #[doc = "3: Reading destination end pointer"]
-    RD_DSTENDP,
+    RD_DSTENDP = 3,
     #[doc = "4: Reading source data"]
-    RD_SRCDAT,
+    RD_SRCDAT = 4,
     #[doc = "5: Writing destination data"]
-    WR_DSTDAT,
+    WR_DSTDAT = 5,
     #[doc = "6: Waiting for uDMA request to clear"]
-    WAIT,
+    WAIT = 6,
     #[doc = "7: Writing channel controller data"]
-    WR_CTRL,
+    WR_CTRL = 7,
     #[doc = "8: Stalled"]
-    STALL,
+    STALL = 8,
     #[doc = "9: Done"]
-    DONE,
+    DONE = 9,
     #[doc = "10: Undefined"]
-    UNDEF,
+    UNDEF = 10,
 }
 impl From<STATE_A> for u8 {
     #[inline(always)]
     fn from(variant: STATE_A) -> Self {
-        match variant {
-            STATE_A::IDLE => 0,
-            STATE_A::RD_CTRL => 1,
-            STATE_A::RD_SRCENDP => 2,
-            STATE_A::RD_DSTENDP => 3,
-            STATE_A::RD_SRCDAT => 4,
-            STATE_A::WR_DSTDAT => 5,
-            STATE_A::WAIT => 6,
-            STATE_A::WR_CTRL => 7,
-            STATE_A::STALL => 8,
-            STATE_A::DONE => 9,
-            STATE_A::UNDEF => 10,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `STATE`"]

--- a/crates/tm4c129x/src/udma/useburstclr.rs
+++ b/crates/tm4c129x/src/udma/useburstclr.rs
@@ -21,7 +21,8 @@ impl<'a> CLR_W<'a> {
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Useburst Clear"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Useburst Clear"]
     #[inline(always)]
     pub fn clr(&mut self) -> CLR_W {
         CLR_W { w: self }

--- a/crates/tm4c129x/src/udma/useburstset.rs
+++ b/crates/tm4c129x/src/udma/useburstset.rs
@@ -25,14 +25,16 @@ impl<'a> SET_W<'a> {
     }
 }
 impl R {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Useburst Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Useburst Set"]
     #[inline(always)]
     pub fn set(&self) -> SET_R {
         SET_R::new((self.bits & 0xffff_ffff) as u32)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Useburst Set"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Useburst Set"]
     #[inline(always)]
     pub fn set(&mut self) -> SET_W {
         SET_W { w: self }

--- a/crates/tm4c129x/src/udma/waitstat.rs
+++ b/crates/tm4c129x/src/udma/waitstat.rs
@@ -3,7 +3,8 @@ pub type R = crate::R<u32, super::WAITSTAT>;
 #[doc = "Reader of field `WAITREQ`"]
 pub type WAITREQ_R = crate::R<u32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - Channel \\[n\\] Wait Status"]
+    #[doc = "Bits 0:31 - Channel \\[n\\]
+Wait Status"]
     #[inline(always)]
     pub fn waitreq(&self) -> WAITREQ_R {
         WAITREQ_R::new((self.bits & 0xffff_ffff) as u32)

--- a/crates/tm4c129x/src/usb0.rs
+++ b/crates/tm4c129x/src/usb0.rs
@@ -503,7 +503,7 @@ pub struct RegisterBlock {
     #[doc = "0xfc8 - USB Clock Configuration"]
     pub cc: CC,
 }
-#[doc = "USB Device Functional Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [faddr](faddr) module"]
+#[doc = "USB Device Functional Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [faddr](faddr) module"]
 pub type FADDR = crate::Reg<u8, _FADDR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -514,7 +514,7 @@ impl crate::Readable for FADDR {}
 impl crate::Writable for FADDR {}
 #[doc = "USB Device Functional Address"]
 pub mod faddr;
-#[doc = "USB Power\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [power](power) module"]
+#[doc = "USB Power\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [power](power) module"]
 pub type POWER = crate::Reg<u8, _POWER>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -525,7 +525,7 @@ impl crate::Readable for POWER {}
 impl crate::Writable for POWER {}
 #[doc = "USB Power"]
 pub mod power;
-#[doc = "USB Transmit Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txis](txis) module"]
+#[doc = "USB Transmit Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txis](txis) module"]
 pub type TXIS = crate::Reg<u16, _TXIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -534,7 +534,7 @@ pub struct _TXIS;
 impl crate::Readable for TXIS {}
 #[doc = "USB Transmit Interrupt Status"]
 pub mod txis;
-#[doc = "USB Receive Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxis](rxis) module"]
+#[doc = "USB Receive Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxis](rxis) module"]
 pub type RXIS = crate::Reg<u16, _RXIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -543,7 +543,7 @@ pub struct _RXIS;
 impl crate::Readable for RXIS {}
 #[doc = "USB Receive Interrupt Status"]
 pub mod rxis;
-#[doc = "USB Transmit Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txie](txie) module"]
+#[doc = "USB Transmit Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txie](txie) module"]
 pub type TXIE = crate::Reg<u16, _TXIE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -554,7 +554,7 @@ impl crate::Readable for TXIE {}
 impl crate::Writable for TXIE {}
 #[doc = "USB Transmit Interrupt Enable"]
 pub mod txie;
-#[doc = "USB Receive Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxie](rxie) module"]
+#[doc = "USB Receive Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxie](rxie) module"]
 pub type RXIE = crate::Reg<u16, _RXIE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -565,7 +565,7 @@ impl crate::Readable for RXIE {}
 impl crate::Writable for RXIE {}
 #[doc = "USB Receive Interrupt Enable"]
 pub mod rxie;
-#[doc = "USB General Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [is](is) module"]
+#[doc = "USB General Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [is](is) module"]
 pub type IS = crate::Reg<u8, _IS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -574,7 +574,7 @@ pub struct _IS;
 impl crate::Readable for IS {}
 #[doc = "USB General Interrupt Status"]
 pub mod is;
-#[doc = "USB Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ie](ie) module"]
+#[doc = "USB Interrupt Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ie](ie) module"]
 pub type IE = crate::Reg<u8, _IE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -585,7 +585,7 @@ impl crate::Readable for IE {}
 impl crate::Writable for IE {}
 #[doc = "USB Interrupt Enable"]
 pub mod ie;
-#[doc = "USB Frame Value\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [frame](frame) module"]
+#[doc = "USB Frame Value\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [frame](frame) module"]
 pub type FRAME = crate::Reg<u16, _FRAME>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -594,7 +594,7 @@ pub struct _FRAME;
 impl crate::Readable for FRAME {}
 #[doc = "USB Frame Value"]
 pub mod frame;
-#[doc = "USB Endpoint Index\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epidx](epidx) module"]
+#[doc = "USB Endpoint Index\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [epidx](epidx) module"]
 pub type EPIDX = crate::Reg<u8, _EPIDX>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -605,7 +605,7 @@ impl crate::Readable for EPIDX {}
 impl crate::Writable for EPIDX {}
 #[doc = "USB Endpoint Index"]
 pub mod epidx;
-#[doc = "USB Test Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [test](test) module"]
+#[doc = "USB Test Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [test](test) module"]
 pub type TEST = crate::Reg<u8, _TEST>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -616,7 +616,7 @@ impl crate::Readable for TEST {}
 impl crate::Writable for TEST {}
 #[doc = "USB Test Mode"]
 pub mod test;
-#[doc = "USB FIFO Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifo0](fifo0) module"]
+#[doc = "USB FIFO Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifo0](fifo0) module"]
 pub type FIFO0 = crate::Reg<u32, _FIFO0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -627,7 +627,7 @@ impl crate::Readable for FIFO0 {}
 impl crate::Writable for FIFO0 {}
 #[doc = "USB FIFO Endpoint 0"]
 pub mod fifo0;
-#[doc = "USB FIFO Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifo1](fifo1) module"]
+#[doc = "USB FIFO Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifo1](fifo1) module"]
 pub type FIFO1 = crate::Reg<u32, _FIFO1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -638,7 +638,7 @@ impl crate::Readable for FIFO1 {}
 impl crate::Writable for FIFO1 {}
 #[doc = "USB FIFO Endpoint 1"]
 pub mod fifo1;
-#[doc = "USB FIFO Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifo2](fifo2) module"]
+#[doc = "USB FIFO Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifo2](fifo2) module"]
 pub type FIFO2 = crate::Reg<u32, _FIFO2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -649,7 +649,7 @@ impl crate::Readable for FIFO2 {}
 impl crate::Writable for FIFO2 {}
 #[doc = "USB FIFO Endpoint 2"]
 pub mod fifo2;
-#[doc = "USB FIFO Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifo3](fifo3) module"]
+#[doc = "USB FIFO Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifo3](fifo3) module"]
 pub type FIFO3 = crate::Reg<u32, _FIFO3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -660,7 +660,7 @@ impl crate::Readable for FIFO3 {}
 impl crate::Writable for FIFO3 {}
 #[doc = "USB FIFO Endpoint 3"]
 pub mod fifo3;
-#[doc = "USB FIFO Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifo4](fifo4) module"]
+#[doc = "USB FIFO Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifo4](fifo4) module"]
 pub type FIFO4 = crate::Reg<u32, _FIFO4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -671,7 +671,7 @@ impl crate::Readable for FIFO4 {}
 impl crate::Writable for FIFO4 {}
 #[doc = "USB FIFO Endpoint 4"]
 pub mod fifo4;
-#[doc = "USB FIFO Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifo5](fifo5) module"]
+#[doc = "USB FIFO Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifo5](fifo5) module"]
 pub type FIFO5 = crate::Reg<u32, _FIFO5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -682,7 +682,7 @@ impl crate::Readable for FIFO5 {}
 impl crate::Writable for FIFO5 {}
 #[doc = "USB FIFO Endpoint 5"]
 pub mod fifo5;
-#[doc = "USB FIFO Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifo6](fifo6) module"]
+#[doc = "USB FIFO Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifo6](fifo6) module"]
 pub type FIFO6 = crate::Reg<u32, _FIFO6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -693,7 +693,7 @@ impl crate::Readable for FIFO6 {}
 impl crate::Writable for FIFO6 {}
 #[doc = "USB FIFO Endpoint 6"]
 pub mod fifo6;
-#[doc = "USB FIFO Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fifo7](fifo7) module"]
+#[doc = "USB FIFO Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fifo7](fifo7) module"]
 pub type FIFO7 = crate::Reg<u32, _FIFO7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -704,7 +704,7 @@ impl crate::Readable for FIFO7 {}
 impl crate::Writable for FIFO7 {}
 #[doc = "USB FIFO Endpoint 7"]
 pub mod fifo7;
-#[doc = "USB Device Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [devctl](devctl) module"]
+#[doc = "USB Device Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [devctl](devctl) module"]
 pub type DEVCTL = crate::Reg<u8, _DEVCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -715,7 +715,7 @@ impl crate::Readable for DEVCTL {}
 impl crate::Writable for DEVCTL {}
 #[doc = "USB Device Control"]
 pub mod devctl;
-#[doc = "USB Common Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cconf](cconf) module"]
+#[doc = "USB Common Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cconf](cconf) module"]
 pub type CCONF = crate::Reg<u8, _CCONF>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -726,7 +726,7 @@ impl crate::Readable for CCONF {}
 impl crate::Writable for CCONF {}
 #[doc = "USB Common Configuration"]
 pub mod cconf;
-#[doc = "USB Transmit Dynamic FIFO Sizing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfifosz](txfifosz) module"]
+#[doc = "USB Transmit Dynamic FIFO Sizing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfifosz](txfifosz) module"]
 pub type TXFIFOSZ = crate::Reg<u8, _TXFIFOSZ>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -737,7 +737,7 @@ impl crate::Readable for TXFIFOSZ {}
 impl crate::Writable for TXFIFOSZ {}
 #[doc = "USB Transmit Dynamic FIFO Sizing"]
 pub mod txfifosz;
-#[doc = "USB Receive Dynamic FIFO Sizing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfifosz](rxfifosz) module"]
+#[doc = "USB Receive Dynamic FIFO Sizing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfifosz](rxfifosz) module"]
 pub type RXFIFOSZ = crate::Reg<u8, _RXFIFOSZ>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -748,7 +748,7 @@ impl crate::Readable for RXFIFOSZ {}
 impl crate::Writable for RXFIFOSZ {}
 #[doc = "USB Receive Dynamic FIFO Sizing"]
 pub mod rxfifosz;
-#[doc = "USB Transmit FIFO Start Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfifoadd](txfifoadd) module"]
+#[doc = "USB Transmit FIFO Start Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfifoadd](txfifoadd) module"]
 pub type TXFIFOADD = crate::Reg<u16, _TXFIFOADD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -759,7 +759,7 @@ impl crate::Readable for TXFIFOADD {}
 impl crate::Writable for TXFIFOADD {}
 #[doc = "USB Transmit FIFO Start Address"]
 pub mod txfifoadd;
-#[doc = "USB Receive FIFO Start Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfifoadd](rxfifoadd) module"]
+#[doc = "USB Receive FIFO Start Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfifoadd](rxfifoadd) module"]
 pub type RXFIFOADD = crate::Reg<u16, _RXFIFOADD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -770,7 +770,7 @@ impl crate::Readable for RXFIFOADD {}
 impl crate::Writable for RXFIFOADD {}
 #[doc = "USB Receive FIFO Start Address"]
 pub mod rxfifoadd;
-#[doc = "USB ULPI VBUS Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ulpivbusctl](ulpivbusctl) module"]
+#[doc = "USB ULPI VBUS Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ulpivbusctl](ulpivbusctl) module"]
 pub type ULPIVBUSCTL = crate::Reg<u8, _ULPIVBUSCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -781,7 +781,7 @@ impl crate::Readable for ULPIVBUSCTL {}
 impl crate::Writable for ULPIVBUSCTL {}
 #[doc = "USB ULPI VBUS Control"]
 pub mod ulpivbusctl;
-#[doc = "USB ULPI Register Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ulpiregdata](ulpiregdata) module"]
+#[doc = "USB ULPI Register Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ulpiregdata](ulpiregdata) module"]
 pub type ULPIREGDATA = crate::Reg<u8, _ULPIREGDATA>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -792,7 +792,7 @@ impl crate::Readable for ULPIREGDATA {}
 impl crate::Writable for ULPIREGDATA {}
 #[doc = "USB ULPI Register Data"]
 pub mod ulpiregdata;
-#[doc = "USB ULPI Register Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ulpiregaddr](ulpiregaddr) module"]
+#[doc = "USB ULPI Register Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ulpiregaddr](ulpiregaddr) module"]
 pub type ULPIREGADDR = crate::Reg<u8, _ULPIREGADDR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -803,7 +803,7 @@ impl crate::Readable for ULPIREGADDR {}
 impl crate::Writable for ULPIREGADDR {}
 #[doc = "USB ULPI Register Address"]
 pub mod ulpiregaddr;
-#[doc = "USB ULPI Register Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ulpiregctl](ulpiregctl) module"]
+#[doc = "USB ULPI Register Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ulpiregctl](ulpiregctl) module"]
 pub type ULPIREGCTL = crate::Reg<u8, _ULPIREGCTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -814,7 +814,7 @@ impl crate::Readable for ULPIREGCTL {}
 impl crate::Writable for ULPIREGCTL {}
 #[doc = "USB ULPI Register Control"]
 pub mod ulpiregctl;
-#[doc = "USB Endpoint Information\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epinfo](epinfo) module"]
+#[doc = "USB Endpoint Information\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [epinfo](epinfo) module"]
 pub type EPINFO = crate::Reg<u8, _EPINFO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -823,7 +823,7 @@ pub struct _EPINFO;
 impl crate::Readable for EPINFO {}
 #[doc = "USB Endpoint Information"]
 pub mod epinfo;
-#[doc = "USB RAM Information\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [raminfo](raminfo) module"]
+#[doc = "USB RAM Information\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [raminfo](raminfo) module"]
 pub type RAMINFO = crate::Reg<u8, _RAMINFO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -832,7 +832,7 @@ pub struct _RAMINFO;
 impl crate::Readable for RAMINFO {}
 #[doc = "USB RAM Information"]
 pub mod raminfo;
-#[doc = "USB Connect Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [contim](contim) module"]
+#[doc = "USB Connect Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [contim](contim) module"]
 pub type CONTIM = crate::Reg<u8, _CONTIM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -843,7 +843,7 @@ impl crate::Readable for CONTIM {}
 impl crate::Writable for CONTIM {}
 #[doc = "USB Connect Timing"]
 pub mod contim;
-#[doc = "USB OTG VBUS Pulse Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [vplen](vplen) module"]
+#[doc = "USB OTG VBUS Pulse Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [vplen](vplen) module"]
 pub type VPLEN = crate::Reg<u8, _VPLEN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -854,7 +854,7 @@ impl crate::Readable for VPLEN {}
 impl crate::Writable for VPLEN {}
 #[doc = "USB OTG VBUS Pulse Timing"]
 pub mod vplen;
-#[doc = "USB High-Speed Last Transaction to End of Frame Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hseof](hseof) module"]
+#[doc = "USB High-Speed Last Transaction to End of Frame Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hseof](hseof) module"]
 pub type HSEOF = crate::Reg<u8, _HSEOF>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -865,7 +865,7 @@ impl crate::Readable for HSEOF {}
 impl crate::Writable for HSEOF {}
 #[doc = "USB High-Speed Last Transaction to End of Frame Timing"]
 pub mod hseof;
-#[doc = "USB Full-Speed Last Transaction to End of Frame Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fseof](fseof) module"]
+#[doc = "USB Full-Speed Last Transaction to End of Frame Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [fseof](fseof) module"]
 pub type FSEOF = crate::Reg<u8, _FSEOF>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -876,7 +876,7 @@ impl crate::Readable for FSEOF {}
 impl crate::Writable for FSEOF {}
 #[doc = "USB Full-Speed Last Transaction to End of Frame Timing"]
 pub mod fseof;
-#[doc = "USB Low-Speed Last Transaction to End of Frame Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [lseof](lseof) module"]
+#[doc = "USB Low-Speed Last Transaction to End of Frame Timing\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [lseof](lseof) module"]
 pub type LSEOF = crate::Reg<u8, _LSEOF>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -887,7 +887,7 @@ impl crate::Readable for LSEOF {}
 impl crate::Writable for LSEOF {}
 #[doc = "USB Low-Speed Last Transaction to End of Frame Timing"]
 pub mod lseof;
-#[doc = "USB Transmit Functional Address Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfuncaddr0](txfuncaddr0) module"]
+#[doc = "USB Transmit Functional Address Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfuncaddr0](txfuncaddr0) module"]
 pub type TXFUNCADDR0 = crate::Reg<u8, _TXFUNCADDR0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -898,7 +898,7 @@ impl crate::Readable for TXFUNCADDR0 {}
 impl crate::Writable for TXFUNCADDR0 {}
 #[doc = "USB Transmit Functional Address Endpoint 0"]
 pub mod txfuncaddr0;
-#[doc = "USB Transmit Hub Address Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubaddr0](txhubaddr0) module"]
+#[doc = "USB Transmit Hub Address Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubaddr0](txhubaddr0) module"]
 pub type TXHUBADDR0 = crate::Reg<u8, _TXHUBADDR0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -909,7 +909,7 @@ impl crate::Readable for TXHUBADDR0 {}
 impl crate::Writable for TXHUBADDR0 {}
 #[doc = "USB Transmit Hub Address Endpoint 0"]
 pub mod txhubaddr0;
-#[doc = "USB Transmit Hub Port Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubport0](txhubport0) module"]
+#[doc = "USB Transmit Hub Port Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubport0](txhubport0) module"]
 pub type TXHUBPORT0 = crate::Reg<u8, _TXHUBPORT0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -920,7 +920,7 @@ impl crate::Readable for TXHUBPORT0 {}
 impl crate::Writable for TXHUBPORT0 {}
 #[doc = "USB Transmit Hub Port Endpoint 0"]
 pub mod txhubport0;
-#[doc = "USB Transmit Functional Address Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfuncaddr1](txfuncaddr1) module"]
+#[doc = "USB Transmit Functional Address Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfuncaddr1](txfuncaddr1) module"]
 pub type TXFUNCADDR1 = crate::Reg<u8, _TXFUNCADDR1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -931,7 +931,7 @@ impl crate::Readable for TXFUNCADDR1 {}
 impl crate::Writable for TXFUNCADDR1 {}
 #[doc = "USB Transmit Functional Address Endpoint 1"]
 pub mod txfuncaddr1;
-#[doc = "USB Transmit Hub Address Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubaddr1](txhubaddr1) module"]
+#[doc = "USB Transmit Hub Address Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubaddr1](txhubaddr1) module"]
 pub type TXHUBADDR1 = crate::Reg<u8, _TXHUBADDR1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -942,7 +942,7 @@ impl crate::Readable for TXHUBADDR1 {}
 impl crate::Writable for TXHUBADDR1 {}
 #[doc = "USB Transmit Hub Address Endpoint 1"]
 pub mod txhubaddr1;
-#[doc = "USB Transmit Hub Port Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubport1](txhubport1) module"]
+#[doc = "USB Transmit Hub Port Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubport1](txhubport1) module"]
 pub type TXHUBPORT1 = crate::Reg<u8, _TXHUBPORT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -953,7 +953,7 @@ impl crate::Readable for TXHUBPORT1 {}
 impl crate::Writable for TXHUBPORT1 {}
 #[doc = "USB Transmit Hub Port Endpoint 1"]
 pub mod txhubport1;
-#[doc = "USB Receive Functional Address Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfuncaddr1](rxfuncaddr1) module"]
+#[doc = "USB Receive Functional Address Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfuncaddr1](rxfuncaddr1) module"]
 pub type RXFUNCADDR1 = crate::Reg<u8, _RXFUNCADDR1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -964,7 +964,7 @@ impl crate::Readable for RXFUNCADDR1 {}
 impl crate::Writable for RXFUNCADDR1 {}
 #[doc = "USB Receive Functional Address Endpoint 1"]
 pub mod rxfuncaddr1;
-#[doc = "USB Receive Hub Address Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubaddr1](rxhubaddr1) module"]
+#[doc = "USB Receive Hub Address Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubaddr1](rxhubaddr1) module"]
 pub type RXHUBADDR1 = crate::Reg<u8, _RXHUBADDR1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -975,7 +975,7 @@ impl crate::Readable for RXHUBADDR1 {}
 impl crate::Writable for RXHUBADDR1 {}
 #[doc = "USB Receive Hub Address Endpoint 1"]
 pub mod rxhubaddr1;
-#[doc = "USB Receive Hub Port Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubport1](rxhubport1) module"]
+#[doc = "USB Receive Hub Port Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubport1](rxhubport1) module"]
 pub type RXHUBPORT1 = crate::Reg<u8, _RXHUBPORT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -986,7 +986,7 @@ impl crate::Readable for RXHUBPORT1 {}
 impl crate::Writable for RXHUBPORT1 {}
 #[doc = "USB Receive Hub Port Endpoint 1"]
 pub mod rxhubport1;
-#[doc = "USB Transmit Functional Address Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfuncaddr2](txfuncaddr2) module"]
+#[doc = "USB Transmit Functional Address Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfuncaddr2](txfuncaddr2) module"]
 pub type TXFUNCADDR2 = crate::Reg<u8, _TXFUNCADDR2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -997,7 +997,7 @@ impl crate::Readable for TXFUNCADDR2 {}
 impl crate::Writable for TXFUNCADDR2 {}
 #[doc = "USB Transmit Functional Address Endpoint 2"]
 pub mod txfuncaddr2;
-#[doc = "USB Transmit Hub Address Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubaddr2](txhubaddr2) module"]
+#[doc = "USB Transmit Hub Address Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubaddr2](txhubaddr2) module"]
 pub type TXHUBADDR2 = crate::Reg<u8, _TXHUBADDR2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1008,7 +1008,7 @@ impl crate::Readable for TXHUBADDR2 {}
 impl crate::Writable for TXHUBADDR2 {}
 #[doc = "USB Transmit Hub Address Endpoint 2"]
 pub mod txhubaddr2;
-#[doc = "USB Transmit Hub Port Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubport2](txhubport2) module"]
+#[doc = "USB Transmit Hub Port Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubport2](txhubport2) module"]
 pub type TXHUBPORT2 = crate::Reg<u8, _TXHUBPORT2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1019,7 +1019,7 @@ impl crate::Readable for TXHUBPORT2 {}
 impl crate::Writable for TXHUBPORT2 {}
 #[doc = "USB Transmit Hub Port Endpoint 2"]
 pub mod txhubport2;
-#[doc = "USB Receive Functional Address Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfuncaddr2](rxfuncaddr2) module"]
+#[doc = "USB Receive Functional Address Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfuncaddr2](rxfuncaddr2) module"]
 pub type RXFUNCADDR2 = crate::Reg<u8, _RXFUNCADDR2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1030,7 +1030,7 @@ impl crate::Readable for RXFUNCADDR2 {}
 impl crate::Writable for RXFUNCADDR2 {}
 #[doc = "USB Receive Functional Address Endpoint 2"]
 pub mod rxfuncaddr2;
-#[doc = "USB Receive Hub Address Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubaddr2](rxhubaddr2) module"]
+#[doc = "USB Receive Hub Address Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubaddr2](rxhubaddr2) module"]
 pub type RXHUBADDR2 = crate::Reg<u8, _RXHUBADDR2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1041,7 +1041,7 @@ impl crate::Readable for RXHUBADDR2 {}
 impl crate::Writable for RXHUBADDR2 {}
 #[doc = "USB Receive Hub Address Endpoint 2"]
 pub mod rxhubaddr2;
-#[doc = "USB Receive Hub Port Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubport2](rxhubport2) module"]
+#[doc = "USB Receive Hub Port Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubport2](rxhubport2) module"]
 pub type RXHUBPORT2 = crate::Reg<u8, _RXHUBPORT2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1052,7 +1052,7 @@ impl crate::Readable for RXHUBPORT2 {}
 impl crate::Writable for RXHUBPORT2 {}
 #[doc = "USB Receive Hub Port Endpoint 2"]
 pub mod rxhubport2;
-#[doc = "USB Transmit Functional Address Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfuncaddr3](txfuncaddr3) module"]
+#[doc = "USB Transmit Functional Address Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfuncaddr3](txfuncaddr3) module"]
 pub type TXFUNCADDR3 = crate::Reg<u8, _TXFUNCADDR3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1063,7 +1063,7 @@ impl crate::Readable for TXFUNCADDR3 {}
 impl crate::Writable for TXFUNCADDR3 {}
 #[doc = "USB Transmit Functional Address Endpoint 3"]
 pub mod txfuncaddr3;
-#[doc = "USB Transmit Hub Address Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubaddr3](txhubaddr3) module"]
+#[doc = "USB Transmit Hub Address Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubaddr3](txhubaddr3) module"]
 pub type TXHUBADDR3 = crate::Reg<u8, _TXHUBADDR3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1074,7 +1074,7 @@ impl crate::Readable for TXHUBADDR3 {}
 impl crate::Writable for TXHUBADDR3 {}
 #[doc = "USB Transmit Hub Address Endpoint 3"]
 pub mod txhubaddr3;
-#[doc = "USB Transmit Hub Port Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubport3](txhubport3) module"]
+#[doc = "USB Transmit Hub Port Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubport3](txhubport3) module"]
 pub type TXHUBPORT3 = crate::Reg<u8, _TXHUBPORT3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1085,7 +1085,7 @@ impl crate::Readable for TXHUBPORT3 {}
 impl crate::Writable for TXHUBPORT3 {}
 #[doc = "USB Transmit Hub Port Endpoint 3"]
 pub mod txhubport3;
-#[doc = "USB Receive Functional Address Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfuncaddr3](rxfuncaddr3) module"]
+#[doc = "USB Receive Functional Address Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfuncaddr3](rxfuncaddr3) module"]
 pub type RXFUNCADDR3 = crate::Reg<u8, _RXFUNCADDR3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1096,7 +1096,7 @@ impl crate::Readable for RXFUNCADDR3 {}
 impl crate::Writable for RXFUNCADDR3 {}
 #[doc = "USB Receive Functional Address Endpoint 3"]
 pub mod rxfuncaddr3;
-#[doc = "USB Receive Hub Address Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubaddr3](rxhubaddr3) module"]
+#[doc = "USB Receive Hub Address Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubaddr3](rxhubaddr3) module"]
 pub type RXHUBADDR3 = crate::Reg<u8, _RXHUBADDR3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1107,7 +1107,7 @@ impl crate::Readable for RXHUBADDR3 {}
 impl crate::Writable for RXHUBADDR3 {}
 #[doc = "USB Receive Hub Address Endpoint 3"]
 pub mod rxhubaddr3;
-#[doc = "USB Receive Hub Port Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubport3](rxhubport3) module"]
+#[doc = "USB Receive Hub Port Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubport3](rxhubport3) module"]
 pub type RXHUBPORT3 = crate::Reg<u8, _RXHUBPORT3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1118,7 +1118,7 @@ impl crate::Readable for RXHUBPORT3 {}
 impl crate::Writable for RXHUBPORT3 {}
 #[doc = "USB Receive Hub Port Endpoint 3"]
 pub mod rxhubport3;
-#[doc = "USB Transmit Functional Address Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfuncaddr4](txfuncaddr4) module"]
+#[doc = "USB Transmit Functional Address Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfuncaddr4](txfuncaddr4) module"]
 pub type TXFUNCADDR4 = crate::Reg<u8, _TXFUNCADDR4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1129,7 +1129,7 @@ impl crate::Readable for TXFUNCADDR4 {}
 impl crate::Writable for TXFUNCADDR4 {}
 #[doc = "USB Transmit Functional Address Endpoint 4"]
 pub mod txfuncaddr4;
-#[doc = "USB Transmit Hub Address Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubaddr4](txhubaddr4) module"]
+#[doc = "USB Transmit Hub Address Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubaddr4](txhubaddr4) module"]
 pub type TXHUBADDR4 = crate::Reg<u8, _TXHUBADDR4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1140,7 +1140,7 @@ impl crate::Readable for TXHUBADDR4 {}
 impl crate::Writable for TXHUBADDR4 {}
 #[doc = "USB Transmit Hub Address Endpoint 4"]
 pub mod txhubaddr4;
-#[doc = "USB Transmit Hub Port Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubport4](txhubport4) module"]
+#[doc = "USB Transmit Hub Port Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubport4](txhubport4) module"]
 pub type TXHUBPORT4 = crate::Reg<u8, _TXHUBPORT4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1151,7 +1151,7 @@ impl crate::Readable for TXHUBPORT4 {}
 impl crate::Writable for TXHUBPORT4 {}
 #[doc = "USB Transmit Hub Port Endpoint 4"]
 pub mod txhubport4;
-#[doc = "USB Receive Functional Address Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfuncaddr4](rxfuncaddr4) module"]
+#[doc = "USB Receive Functional Address Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfuncaddr4](rxfuncaddr4) module"]
 pub type RXFUNCADDR4 = crate::Reg<u8, _RXFUNCADDR4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1162,7 +1162,7 @@ impl crate::Readable for RXFUNCADDR4 {}
 impl crate::Writable for RXFUNCADDR4 {}
 #[doc = "USB Receive Functional Address Endpoint 4"]
 pub mod rxfuncaddr4;
-#[doc = "USB Receive Hub Address Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubaddr4](rxhubaddr4) module"]
+#[doc = "USB Receive Hub Address Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubaddr4](rxhubaddr4) module"]
 pub type RXHUBADDR4 = crate::Reg<u8, _RXHUBADDR4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1173,7 +1173,7 @@ impl crate::Readable for RXHUBADDR4 {}
 impl crate::Writable for RXHUBADDR4 {}
 #[doc = "USB Receive Hub Address Endpoint 4"]
 pub mod rxhubaddr4;
-#[doc = "USB Receive Hub Port Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubport4](rxhubport4) module"]
+#[doc = "USB Receive Hub Port Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubport4](rxhubport4) module"]
 pub type RXHUBPORT4 = crate::Reg<u8, _RXHUBPORT4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1184,7 +1184,7 @@ impl crate::Readable for RXHUBPORT4 {}
 impl crate::Writable for RXHUBPORT4 {}
 #[doc = "USB Receive Hub Port Endpoint 4"]
 pub mod rxhubport4;
-#[doc = "USB Transmit Functional Address Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfuncaddr5](txfuncaddr5) module"]
+#[doc = "USB Transmit Functional Address Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfuncaddr5](txfuncaddr5) module"]
 pub type TXFUNCADDR5 = crate::Reg<u8, _TXFUNCADDR5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1195,7 +1195,7 @@ impl crate::Readable for TXFUNCADDR5 {}
 impl crate::Writable for TXFUNCADDR5 {}
 #[doc = "USB Transmit Functional Address Endpoint 5"]
 pub mod txfuncaddr5;
-#[doc = "USB Transmit Hub Address Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubaddr5](txhubaddr5) module"]
+#[doc = "USB Transmit Hub Address Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubaddr5](txhubaddr5) module"]
 pub type TXHUBADDR5 = crate::Reg<u8, _TXHUBADDR5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1206,7 +1206,7 @@ impl crate::Readable for TXHUBADDR5 {}
 impl crate::Writable for TXHUBADDR5 {}
 #[doc = "USB Transmit Hub Address Endpoint 5"]
 pub mod txhubaddr5;
-#[doc = "USB Transmit Hub Port Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubport5](txhubport5) module"]
+#[doc = "USB Transmit Hub Port Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubport5](txhubport5) module"]
 pub type TXHUBPORT5 = crate::Reg<u8, _TXHUBPORT5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1217,7 +1217,7 @@ impl crate::Readable for TXHUBPORT5 {}
 impl crate::Writable for TXHUBPORT5 {}
 #[doc = "USB Transmit Hub Port Endpoint 5"]
 pub mod txhubport5;
-#[doc = "USB Receive Functional Address Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfuncaddr5](rxfuncaddr5) module"]
+#[doc = "USB Receive Functional Address Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfuncaddr5](rxfuncaddr5) module"]
 pub type RXFUNCADDR5 = crate::Reg<u8, _RXFUNCADDR5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1228,7 +1228,7 @@ impl crate::Readable for RXFUNCADDR5 {}
 impl crate::Writable for RXFUNCADDR5 {}
 #[doc = "USB Receive Functional Address Endpoint 5"]
 pub mod rxfuncaddr5;
-#[doc = "USB Receive Hub Address Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubaddr5](rxhubaddr5) module"]
+#[doc = "USB Receive Hub Address Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubaddr5](rxhubaddr5) module"]
 pub type RXHUBADDR5 = crate::Reg<u8, _RXHUBADDR5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1239,7 +1239,7 @@ impl crate::Readable for RXHUBADDR5 {}
 impl crate::Writable for RXHUBADDR5 {}
 #[doc = "USB Receive Hub Address Endpoint 5"]
 pub mod rxhubaddr5;
-#[doc = "USB Receive Hub Port Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubport5](rxhubport5) module"]
+#[doc = "USB Receive Hub Port Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubport5](rxhubport5) module"]
 pub type RXHUBPORT5 = crate::Reg<u8, _RXHUBPORT5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1250,7 +1250,7 @@ impl crate::Readable for RXHUBPORT5 {}
 impl crate::Writable for RXHUBPORT5 {}
 #[doc = "USB Receive Hub Port Endpoint 5"]
 pub mod rxhubport5;
-#[doc = "USB Transmit Functional Address Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfuncaddr6](txfuncaddr6) module"]
+#[doc = "USB Transmit Functional Address Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfuncaddr6](txfuncaddr6) module"]
 pub type TXFUNCADDR6 = crate::Reg<u8, _TXFUNCADDR6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1261,7 +1261,7 @@ impl crate::Readable for TXFUNCADDR6 {}
 impl crate::Writable for TXFUNCADDR6 {}
 #[doc = "USB Transmit Functional Address Endpoint 6"]
 pub mod txfuncaddr6;
-#[doc = "USB Transmit Hub Address Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubaddr6](txhubaddr6) module"]
+#[doc = "USB Transmit Hub Address Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubaddr6](txhubaddr6) module"]
 pub type TXHUBADDR6 = crate::Reg<u8, _TXHUBADDR6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1272,7 +1272,7 @@ impl crate::Readable for TXHUBADDR6 {}
 impl crate::Writable for TXHUBADDR6 {}
 #[doc = "USB Transmit Hub Address Endpoint 6"]
 pub mod txhubaddr6;
-#[doc = "USB Transmit Hub Port Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubport6](txhubport6) module"]
+#[doc = "USB Transmit Hub Port Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubport6](txhubport6) module"]
 pub type TXHUBPORT6 = crate::Reg<u8, _TXHUBPORT6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1283,7 +1283,7 @@ impl crate::Readable for TXHUBPORT6 {}
 impl crate::Writable for TXHUBPORT6 {}
 #[doc = "USB Transmit Hub Port Endpoint 6"]
 pub mod txhubport6;
-#[doc = "USB Receive Functional Address Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfuncaddr6](rxfuncaddr6) module"]
+#[doc = "USB Receive Functional Address Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfuncaddr6](rxfuncaddr6) module"]
 pub type RXFUNCADDR6 = crate::Reg<u8, _RXFUNCADDR6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1294,7 +1294,7 @@ impl crate::Readable for RXFUNCADDR6 {}
 impl crate::Writable for RXFUNCADDR6 {}
 #[doc = "USB Receive Functional Address Endpoint 6"]
 pub mod rxfuncaddr6;
-#[doc = "USB Receive Hub Address Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubaddr6](rxhubaddr6) module"]
+#[doc = "USB Receive Hub Address Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubaddr6](rxhubaddr6) module"]
 pub type RXHUBADDR6 = crate::Reg<u8, _RXHUBADDR6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1305,7 +1305,7 @@ impl crate::Readable for RXHUBADDR6 {}
 impl crate::Writable for RXHUBADDR6 {}
 #[doc = "USB Receive Hub Address Endpoint 6"]
 pub mod rxhubaddr6;
-#[doc = "USB Receive Hub Port Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubport6](rxhubport6) module"]
+#[doc = "USB Receive Hub Port Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubport6](rxhubport6) module"]
 pub type RXHUBPORT6 = crate::Reg<u8, _RXHUBPORT6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1316,7 +1316,7 @@ impl crate::Readable for RXHUBPORT6 {}
 impl crate::Writable for RXHUBPORT6 {}
 #[doc = "USB Receive Hub Port Endpoint 6"]
 pub mod rxhubport6;
-#[doc = "USB Transmit Functional Address Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txfuncaddr7](txfuncaddr7) module"]
+#[doc = "USB Transmit Functional Address Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txfuncaddr7](txfuncaddr7) module"]
 pub type TXFUNCADDR7 = crate::Reg<u8, _TXFUNCADDR7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1327,7 +1327,7 @@ impl crate::Readable for TXFUNCADDR7 {}
 impl crate::Writable for TXFUNCADDR7 {}
 #[doc = "USB Transmit Functional Address Endpoint 7"]
 pub mod txfuncaddr7;
-#[doc = "USB Transmit Hub Address Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubaddr7](txhubaddr7) module"]
+#[doc = "USB Transmit Hub Address Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubaddr7](txhubaddr7) module"]
 pub type TXHUBADDR7 = crate::Reg<u8, _TXHUBADDR7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1338,7 +1338,7 @@ impl crate::Readable for TXHUBADDR7 {}
 impl crate::Writable for TXHUBADDR7 {}
 #[doc = "USB Transmit Hub Address Endpoint 7"]
 pub mod txhubaddr7;
-#[doc = "USB Transmit Hub Port Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txhubport7](txhubport7) module"]
+#[doc = "USB Transmit Hub Port Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txhubport7](txhubport7) module"]
 pub type TXHUBPORT7 = crate::Reg<u8, _TXHUBPORT7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1349,7 +1349,7 @@ impl crate::Readable for TXHUBPORT7 {}
 impl crate::Writable for TXHUBPORT7 {}
 #[doc = "USB Transmit Hub Port Endpoint 7"]
 pub mod txhubport7;
-#[doc = "USB Receive Functional Address Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxfuncaddr7](rxfuncaddr7) module"]
+#[doc = "USB Receive Functional Address Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxfuncaddr7](rxfuncaddr7) module"]
 pub type RXFUNCADDR7 = crate::Reg<u8, _RXFUNCADDR7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1360,7 +1360,7 @@ impl crate::Readable for RXFUNCADDR7 {}
 impl crate::Writable for RXFUNCADDR7 {}
 #[doc = "USB Receive Functional Address Endpoint 7"]
 pub mod rxfuncaddr7;
-#[doc = "USB Receive Hub Address Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubaddr7](rxhubaddr7) module"]
+#[doc = "USB Receive Hub Address Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubaddr7](rxhubaddr7) module"]
 pub type RXHUBADDR7 = crate::Reg<u8, _RXHUBADDR7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1371,7 +1371,7 @@ impl crate::Readable for RXHUBADDR7 {}
 impl crate::Writable for RXHUBADDR7 {}
 #[doc = "USB Receive Hub Address Endpoint 7"]
 pub mod rxhubaddr7;
-#[doc = "USB Receive Hub Port Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxhubport7](rxhubport7) module"]
+#[doc = "USB Receive Hub Port Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxhubport7](rxhubport7) module"]
 pub type RXHUBPORT7 = crate::Reg<u8, _RXHUBPORT7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1382,7 +1382,7 @@ impl crate::Readable for RXHUBPORT7 {}
 impl crate::Writable for RXHUBPORT7 {}
 #[doc = "USB Receive Hub Port Endpoint 7"]
 pub mod rxhubport7;
-#[doc = "USB Control and Status Endpoint 0 Low\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [csrl0](csrl0) module"]
+#[doc = "USB Control and Status Endpoint 0 Low\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [csrl0](csrl0) module"]
 pub type CSRL0 = crate::Reg<u8, _CSRL0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1391,7 +1391,7 @@ pub struct _CSRL0;
 impl crate::Writable for CSRL0 {}
 #[doc = "USB Control and Status Endpoint 0 Low"]
 pub mod csrl0;
-#[doc = "USB Control and Status Endpoint 0 High\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [csrh0](csrh0) module"]
+#[doc = "USB Control and Status Endpoint 0 High\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [csrh0](csrh0) module"]
 pub type CSRH0 = crate::Reg<u8, _CSRH0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1400,7 +1400,7 @@ pub struct _CSRH0;
 impl crate::Writable for CSRH0 {}
 #[doc = "USB Control and Status Endpoint 0 High"]
 pub mod csrh0;
-#[doc = "USB Receive Byte Count Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [count0](count0) module"]
+#[doc = "USB Receive Byte Count Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [count0](count0) module"]
 pub type COUNT0 = crate::Reg<u8, _COUNT0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1409,7 +1409,7 @@ pub struct _COUNT0;
 impl crate::Readable for COUNT0 {}
 #[doc = "USB Receive Byte Count Endpoint 0"]
 pub mod count0;
-#[doc = "USB Type Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [type0](type0) module"]
+#[doc = "USB Type Endpoint 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [type0](type0) module"]
 pub type TYPE0 = crate::Reg<u8, _TYPE0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1420,7 +1420,7 @@ impl crate::Readable for TYPE0 {}
 impl crate::Writable for TYPE0 {}
 #[doc = "USB Type Endpoint 0"]
 pub mod type0;
-#[doc = "USB NAK Limit\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [naklmt](naklmt) module"]
+#[doc = "USB NAK Limit\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [naklmt](naklmt) module"]
 pub type NAKLMT = crate::Reg<u8, _NAKLMT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1431,7 +1431,7 @@ impl crate::Readable for NAKLMT {}
 impl crate::Writable for NAKLMT {}
 #[doc = "USB NAK Limit"]
 pub mod naklmt;
-#[doc = "USB Maximum Transmit Data Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txmaxp1](txmaxp1) module"]
+#[doc = "USB Maximum Transmit Data Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txmaxp1](txmaxp1) module"]
 pub type TXMAXP1 = crate::Reg<u16, _TXMAXP1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1442,7 +1442,7 @@ impl crate::Readable for TXMAXP1 {}
 impl crate::Writable for TXMAXP1 {}
 #[doc = "USB Maximum Transmit Data Endpoint 1"]
 pub mod txmaxp1;
-#[doc = "USB Transmit Control and Status Endpoint 1 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrl1](txcsrl1) module"]
+#[doc = "USB Transmit Control and Status Endpoint 1 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrl1](txcsrl1) module"]
 pub type TXCSRL1 = crate::Reg<u8, _TXCSRL1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1453,7 +1453,7 @@ impl crate::Readable for TXCSRL1 {}
 impl crate::Writable for TXCSRL1 {}
 #[doc = "USB Transmit Control and Status Endpoint 1 Low"]
 pub mod txcsrl1;
-#[doc = "USB Transmit Control and Status Endpoint 1 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrh1](txcsrh1) module"]
+#[doc = "USB Transmit Control and Status Endpoint 1 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrh1](txcsrh1) module"]
 pub type TXCSRH1 = crate::Reg<u8, _TXCSRH1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1464,7 +1464,7 @@ impl crate::Readable for TXCSRH1 {}
 impl crate::Writable for TXCSRH1 {}
 #[doc = "USB Transmit Control and Status Endpoint 1 High"]
 pub mod txcsrh1;
-#[doc = "USB Maximum Receive Data Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxmaxp1](rxmaxp1) module"]
+#[doc = "USB Maximum Receive Data Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxmaxp1](rxmaxp1) module"]
 pub type RXMAXP1 = crate::Reg<u16, _RXMAXP1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1475,7 +1475,7 @@ impl crate::Readable for RXMAXP1 {}
 impl crate::Writable for RXMAXP1 {}
 #[doc = "USB Maximum Receive Data Endpoint 1"]
 pub mod rxmaxp1;
-#[doc = "USB Receive Control and Status Endpoint 1 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrl1](rxcsrl1) module"]
+#[doc = "USB Receive Control and Status Endpoint 1 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrl1](rxcsrl1) module"]
 pub type RXCSRL1 = crate::Reg<u8, _RXCSRL1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1486,7 +1486,7 @@ impl crate::Readable for RXCSRL1 {}
 impl crate::Writable for RXCSRL1 {}
 #[doc = "USB Receive Control and Status Endpoint 1 Low"]
 pub mod rxcsrl1;
-#[doc = "USB Receive Control and Status Endpoint 1 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrh1](rxcsrh1) module"]
+#[doc = "USB Receive Control and Status Endpoint 1 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrh1](rxcsrh1) module"]
 pub type RXCSRH1 = crate::Reg<u8, _RXCSRH1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1497,7 +1497,7 @@ impl crate::Readable for RXCSRH1 {}
 impl crate::Writable for RXCSRH1 {}
 #[doc = "USB Receive Control and Status Endpoint 1 High"]
 pub mod rxcsrh1;
-#[doc = "USB Receive Byte Count Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcount1](rxcount1) module"]
+#[doc = "USB Receive Byte Count Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcount1](rxcount1) module"]
 pub type RXCOUNT1 = crate::Reg<u16, _RXCOUNT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1506,7 +1506,7 @@ pub struct _RXCOUNT1;
 impl crate::Readable for RXCOUNT1 {}
 #[doc = "USB Receive Byte Count Endpoint 1"]
 pub mod rxcount1;
-#[doc = "USB Host Transmit Configure Type Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txtype1](txtype1) module"]
+#[doc = "USB Host Transmit Configure Type Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txtype1](txtype1) module"]
 pub type TXTYPE1 = crate::Reg<u8, _TXTYPE1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1517,7 +1517,7 @@ impl crate::Readable for TXTYPE1 {}
 impl crate::Writable for TXTYPE1 {}
 #[doc = "USB Host Transmit Configure Type Endpoint 1"]
 pub mod txtype1;
-#[doc = "USB Host Transmit Interval Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txinterval1](txinterval1) module"]
+#[doc = "USB Host Transmit Interval Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txinterval1](txinterval1) module"]
 pub type TXINTERVAL1 = crate::Reg<u8, _TXINTERVAL1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1528,7 +1528,7 @@ impl crate::Readable for TXINTERVAL1 {}
 impl crate::Writable for TXINTERVAL1 {}
 #[doc = "USB Host Transmit Interval Endpoint 1"]
 pub mod txinterval1;
-#[doc = "USB Host Configure Receive Type Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxtype1](rxtype1) module"]
+#[doc = "USB Host Configure Receive Type Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxtype1](rxtype1) module"]
 pub type RXTYPE1 = crate::Reg<u8, _RXTYPE1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1539,7 +1539,7 @@ impl crate::Readable for RXTYPE1 {}
 impl crate::Writable for RXTYPE1 {}
 #[doc = "USB Host Configure Receive Type Endpoint 1"]
 pub mod rxtype1;
-#[doc = "USB Host Receive Polling Interval Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxinterval1](rxinterval1) module"]
+#[doc = "USB Host Receive Polling Interval Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxinterval1](rxinterval1) module"]
 pub type RXINTERVAL1 = crate::Reg<u8, _RXINTERVAL1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1550,7 +1550,7 @@ impl crate::Readable for RXINTERVAL1 {}
 impl crate::Writable for RXINTERVAL1 {}
 #[doc = "USB Host Receive Polling Interval Endpoint 1"]
 pub mod rxinterval1;
-#[doc = "USB Maximum Transmit Data Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txmaxp2](txmaxp2) module"]
+#[doc = "USB Maximum Transmit Data Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txmaxp2](txmaxp2) module"]
 pub type TXMAXP2 = crate::Reg<u16, _TXMAXP2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1561,7 +1561,7 @@ impl crate::Readable for TXMAXP2 {}
 impl crate::Writable for TXMAXP2 {}
 #[doc = "USB Maximum Transmit Data Endpoint 2"]
 pub mod txmaxp2;
-#[doc = "USB Transmit Control and Status Endpoint 2 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrl2](txcsrl2) module"]
+#[doc = "USB Transmit Control and Status Endpoint 2 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrl2](txcsrl2) module"]
 pub type TXCSRL2 = crate::Reg<u8, _TXCSRL2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1572,7 +1572,7 @@ impl crate::Readable for TXCSRL2 {}
 impl crate::Writable for TXCSRL2 {}
 #[doc = "USB Transmit Control and Status Endpoint 2 Low"]
 pub mod txcsrl2;
-#[doc = "USB Transmit Control and Status Endpoint 2 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrh2](txcsrh2) module"]
+#[doc = "USB Transmit Control and Status Endpoint 2 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrh2](txcsrh2) module"]
 pub type TXCSRH2 = crate::Reg<u8, _TXCSRH2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1583,7 +1583,7 @@ impl crate::Readable for TXCSRH2 {}
 impl crate::Writable for TXCSRH2 {}
 #[doc = "USB Transmit Control and Status Endpoint 2 High"]
 pub mod txcsrh2;
-#[doc = "USB Maximum Receive Data Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxmaxp2](rxmaxp2) module"]
+#[doc = "USB Maximum Receive Data Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxmaxp2](rxmaxp2) module"]
 pub type RXMAXP2 = crate::Reg<u16, _RXMAXP2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1594,7 +1594,7 @@ impl crate::Readable for RXMAXP2 {}
 impl crate::Writable for RXMAXP2 {}
 #[doc = "USB Maximum Receive Data Endpoint 2"]
 pub mod rxmaxp2;
-#[doc = "USB Receive Control and Status Endpoint 2 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrl2](rxcsrl2) module"]
+#[doc = "USB Receive Control and Status Endpoint 2 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrl2](rxcsrl2) module"]
 pub type RXCSRL2 = crate::Reg<u8, _RXCSRL2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1605,7 +1605,7 @@ impl crate::Readable for RXCSRL2 {}
 impl crate::Writable for RXCSRL2 {}
 #[doc = "USB Receive Control and Status Endpoint 2 Low"]
 pub mod rxcsrl2;
-#[doc = "USB Receive Control and Status Endpoint 2 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrh2](rxcsrh2) module"]
+#[doc = "USB Receive Control and Status Endpoint 2 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrh2](rxcsrh2) module"]
 pub type RXCSRH2 = crate::Reg<u8, _RXCSRH2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1616,7 +1616,7 @@ impl crate::Readable for RXCSRH2 {}
 impl crate::Writable for RXCSRH2 {}
 #[doc = "USB Receive Control and Status Endpoint 2 High"]
 pub mod rxcsrh2;
-#[doc = "USB Receive Byte Count Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcount2](rxcount2) module"]
+#[doc = "USB Receive Byte Count Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcount2](rxcount2) module"]
 pub type RXCOUNT2 = crate::Reg<u16, _RXCOUNT2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1625,7 +1625,7 @@ pub struct _RXCOUNT2;
 impl crate::Readable for RXCOUNT2 {}
 #[doc = "USB Receive Byte Count Endpoint 2"]
 pub mod rxcount2;
-#[doc = "USB Host Transmit Configure Type Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txtype2](txtype2) module"]
+#[doc = "USB Host Transmit Configure Type Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txtype2](txtype2) module"]
 pub type TXTYPE2 = crate::Reg<u8, _TXTYPE2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1636,7 +1636,7 @@ impl crate::Readable for TXTYPE2 {}
 impl crate::Writable for TXTYPE2 {}
 #[doc = "USB Host Transmit Configure Type Endpoint 2"]
 pub mod txtype2;
-#[doc = "USB Host Transmit Interval Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txinterval2](txinterval2) module"]
+#[doc = "USB Host Transmit Interval Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txinterval2](txinterval2) module"]
 pub type TXINTERVAL2 = crate::Reg<u8, _TXINTERVAL2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1647,7 +1647,7 @@ impl crate::Readable for TXINTERVAL2 {}
 impl crate::Writable for TXINTERVAL2 {}
 #[doc = "USB Host Transmit Interval Endpoint 2"]
 pub mod txinterval2;
-#[doc = "USB Host Configure Receive Type Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxtype2](rxtype2) module"]
+#[doc = "USB Host Configure Receive Type Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxtype2](rxtype2) module"]
 pub type RXTYPE2 = crate::Reg<u8, _RXTYPE2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1658,7 +1658,7 @@ impl crate::Readable for RXTYPE2 {}
 impl crate::Writable for RXTYPE2 {}
 #[doc = "USB Host Configure Receive Type Endpoint 2"]
 pub mod rxtype2;
-#[doc = "USB Host Receive Polling Interval Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxinterval2](rxinterval2) module"]
+#[doc = "USB Host Receive Polling Interval Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxinterval2](rxinterval2) module"]
 pub type RXINTERVAL2 = crate::Reg<u8, _RXINTERVAL2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1669,7 +1669,7 @@ impl crate::Readable for RXINTERVAL2 {}
 impl crate::Writable for RXINTERVAL2 {}
 #[doc = "USB Host Receive Polling Interval Endpoint 2"]
 pub mod rxinterval2;
-#[doc = "USB Maximum Transmit Data Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txmaxp3](txmaxp3) module"]
+#[doc = "USB Maximum Transmit Data Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txmaxp3](txmaxp3) module"]
 pub type TXMAXP3 = crate::Reg<u16, _TXMAXP3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1680,7 +1680,7 @@ impl crate::Readable for TXMAXP3 {}
 impl crate::Writable for TXMAXP3 {}
 #[doc = "USB Maximum Transmit Data Endpoint 3"]
 pub mod txmaxp3;
-#[doc = "USB Transmit Control and Status Endpoint 3 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrl3](txcsrl3) module"]
+#[doc = "USB Transmit Control and Status Endpoint 3 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrl3](txcsrl3) module"]
 pub type TXCSRL3 = crate::Reg<u8, _TXCSRL3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1691,7 +1691,7 @@ impl crate::Readable for TXCSRL3 {}
 impl crate::Writable for TXCSRL3 {}
 #[doc = "USB Transmit Control and Status Endpoint 3 Low"]
 pub mod txcsrl3;
-#[doc = "USB Transmit Control and Status Endpoint 3 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrh3](txcsrh3) module"]
+#[doc = "USB Transmit Control and Status Endpoint 3 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrh3](txcsrh3) module"]
 pub type TXCSRH3 = crate::Reg<u8, _TXCSRH3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1702,7 +1702,7 @@ impl crate::Readable for TXCSRH3 {}
 impl crate::Writable for TXCSRH3 {}
 #[doc = "USB Transmit Control and Status Endpoint 3 High"]
 pub mod txcsrh3;
-#[doc = "USB Maximum Receive Data Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxmaxp3](rxmaxp3) module"]
+#[doc = "USB Maximum Receive Data Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxmaxp3](rxmaxp3) module"]
 pub type RXMAXP3 = crate::Reg<u16, _RXMAXP3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1713,7 +1713,7 @@ impl crate::Readable for RXMAXP3 {}
 impl crate::Writable for RXMAXP3 {}
 #[doc = "USB Maximum Receive Data Endpoint 3"]
 pub mod rxmaxp3;
-#[doc = "USB Receive Control and Status Endpoint 3 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrl3](rxcsrl3) module"]
+#[doc = "USB Receive Control and Status Endpoint 3 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrl3](rxcsrl3) module"]
 pub type RXCSRL3 = crate::Reg<u8, _RXCSRL3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1724,7 +1724,7 @@ impl crate::Readable for RXCSRL3 {}
 impl crate::Writable for RXCSRL3 {}
 #[doc = "USB Receive Control and Status Endpoint 3 Low"]
 pub mod rxcsrl3;
-#[doc = "USB Receive Control and Status Endpoint 3 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrh3](rxcsrh3) module"]
+#[doc = "USB Receive Control and Status Endpoint 3 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrh3](rxcsrh3) module"]
 pub type RXCSRH3 = crate::Reg<u8, _RXCSRH3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1735,7 +1735,7 @@ impl crate::Readable for RXCSRH3 {}
 impl crate::Writable for RXCSRH3 {}
 #[doc = "USB Receive Control and Status Endpoint 3 High"]
 pub mod rxcsrh3;
-#[doc = "USB Receive Byte Count Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcount3](rxcount3) module"]
+#[doc = "USB Receive Byte Count Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcount3](rxcount3) module"]
 pub type RXCOUNT3 = crate::Reg<u16, _RXCOUNT3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1744,7 +1744,7 @@ pub struct _RXCOUNT3;
 impl crate::Readable for RXCOUNT3 {}
 #[doc = "USB Receive Byte Count Endpoint 3"]
 pub mod rxcount3;
-#[doc = "USB Host Transmit Configure Type Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txtype3](txtype3) module"]
+#[doc = "USB Host Transmit Configure Type Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txtype3](txtype3) module"]
 pub type TXTYPE3 = crate::Reg<u8, _TXTYPE3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1755,7 +1755,7 @@ impl crate::Readable for TXTYPE3 {}
 impl crate::Writable for TXTYPE3 {}
 #[doc = "USB Host Transmit Configure Type Endpoint 3"]
 pub mod txtype3;
-#[doc = "USB Host Transmit Interval Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txinterval3](txinterval3) module"]
+#[doc = "USB Host Transmit Interval Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txinterval3](txinterval3) module"]
 pub type TXINTERVAL3 = crate::Reg<u8, _TXINTERVAL3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1766,7 +1766,7 @@ impl crate::Readable for TXINTERVAL3 {}
 impl crate::Writable for TXINTERVAL3 {}
 #[doc = "USB Host Transmit Interval Endpoint 3"]
 pub mod txinterval3;
-#[doc = "USB Host Configure Receive Type Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxtype3](rxtype3) module"]
+#[doc = "USB Host Configure Receive Type Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxtype3](rxtype3) module"]
 pub type RXTYPE3 = crate::Reg<u8, _RXTYPE3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1777,7 +1777,7 @@ impl crate::Readable for RXTYPE3 {}
 impl crate::Writable for RXTYPE3 {}
 #[doc = "USB Host Configure Receive Type Endpoint 3"]
 pub mod rxtype3;
-#[doc = "USB Host Receive Polling Interval Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxinterval3](rxinterval3) module"]
+#[doc = "USB Host Receive Polling Interval Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxinterval3](rxinterval3) module"]
 pub type RXINTERVAL3 = crate::Reg<u8, _RXINTERVAL3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1788,7 +1788,7 @@ impl crate::Readable for RXINTERVAL3 {}
 impl crate::Writable for RXINTERVAL3 {}
 #[doc = "USB Host Receive Polling Interval Endpoint 3"]
 pub mod rxinterval3;
-#[doc = "USB Maximum Transmit Data Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txmaxp4](txmaxp4) module"]
+#[doc = "USB Maximum Transmit Data Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txmaxp4](txmaxp4) module"]
 pub type TXMAXP4 = crate::Reg<u16, _TXMAXP4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1799,7 +1799,7 @@ impl crate::Readable for TXMAXP4 {}
 impl crate::Writable for TXMAXP4 {}
 #[doc = "USB Maximum Transmit Data Endpoint 4"]
 pub mod txmaxp4;
-#[doc = "USB Transmit Control and Status Endpoint 4 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrl4](txcsrl4) module"]
+#[doc = "USB Transmit Control and Status Endpoint 4 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrl4](txcsrl4) module"]
 pub type TXCSRL4 = crate::Reg<u8, _TXCSRL4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1810,7 +1810,7 @@ impl crate::Readable for TXCSRL4 {}
 impl crate::Writable for TXCSRL4 {}
 #[doc = "USB Transmit Control and Status Endpoint 4 Low"]
 pub mod txcsrl4;
-#[doc = "USB Transmit Control and Status Endpoint 4 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrh4](txcsrh4) module"]
+#[doc = "USB Transmit Control and Status Endpoint 4 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrh4](txcsrh4) module"]
 pub type TXCSRH4 = crate::Reg<u8, _TXCSRH4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1821,7 +1821,7 @@ impl crate::Readable for TXCSRH4 {}
 impl crate::Writable for TXCSRH4 {}
 #[doc = "USB Transmit Control and Status Endpoint 4 High"]
 pub mod txcsrh4;
-#[doc = "USB Maximum Receive Data Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxmaxp4](rxmaxp4) module"]
+#[doc = "USB Maximum Receive Data Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxmaxp4](rxmaxp4) module"]
 pub type RXMAXP4 = crate::Reg<u16, _RXMAXP4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1832,7 +1832,7 @@ impl crate::Readable for RXMAXP4 {}
 impl crate::Writable for RXMAXP4 {}
 #[doc = "USB Maximum Receive Data Endpoint 4"]
 pub mod rxmaxp4;
-#[doc = "USB Receive Control and Status Endpoint 4 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrl4](rxcsrl4) module"]
+#[doc = "USB Receive Control and Status Endpoint 4 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrl4](rxcsrl4) module"]
 pub type RXCSRL4 = crate::Reg<u8, _RXCSRL4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1843,7 +1843,7 @@ impl crate::Readable for RXCSRL4 {}
 impl crate::Writable for RXCSRL4 {}
 #[doc = "USB Receive Control and Status Endpoint 4 Low"]
 pub mod rxcsrl4;
-#[doc = "USB Receive Control and Status Endpoint 4 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrh4](rxcsrh4) module"]
+#[doc = "USB Receive Control and Status Endpoint 4 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrh4](rxcsrh4) module"]
 pub type RXCSRH4 = crate::Reg<u8, _RXCSRH4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1854,7 +1854,7 @@ impl crate::Readable for RXCSRH4 {}
 impl crate::Writable for RXCSRH4 {}
 #[doc = "USB Receive Control and Status Endpoint 4 High"]
 pub mod rxcsrh4;
-#[doc = "USB Receive Byte Count Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcount4](rxcount4) module"]
+#[doc = "USB Receive Byte Count Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcount4](rxcount4) module"]
 pub type RXCOUNT4 = crate::Reg<u16, _RXCOUNT4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1863,7 +1863,7 @@ pub struct _RXCOUNT4;
 impl crate::Readable for RXCOUNT4 {}
 #[doc = "USB Receive Byte Count Endpoint 4"]
 pub mod rxcount4;
-#[doc = "USB Host Transmit Configure Type Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txtype4](txtype4) module"]
+#[doc = "USB Host Transmit Configure Type Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txtype4](txtype4) module"]
 pub type TXTYPE4 = crate::Reg<u8, _TXTYPE4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1874,7 +1874,7 @@ impl crate::Readable for TXTYPE4 {}
 impl crate::Writable for TXTYPE4 {}
 #[doc = "USB Host Transmit Configure Type Endpoint 4"]
 pub mod txtype4;
-#[doc = "USB Host Transmit Interval Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txinterval4](txinterval4) module"]
+#[doc = "USB Host Transmit Interval Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txinterval4](txinterval4) module"]
 pub type TXINTERVAL4 = crate::Reg<u8, _TXINTERVAL4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1885,7 +1885,7 @@ impl crate::Readable for TXINTERVAL4 {}
 impl crate::Writable for TXINTERVAL4 {}
 #[doc = "USB Host Transmit Interval Endpoint 4"]
 pub mod txinterval4;
-#[doc = "USB Host Configure Receive Type Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxtype4](rxtype4) module"]
+#[doc = "USB Host Configure Receive Type Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxtype4](rxtype4) module"]
 pub type RXTYPE4 = crate::Reg<u8, _RXTYPE4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1896,7 +1896,7 @@ impl crate::Readable for RXTYPE4 {}
 impl crate::Writable for RXTYPE4 {}
 #[doc = "USB Host Configure Receive Type Endpoint 4"]
 pub mod rxtype4;
-#[doc = "USB Host Receive Polling Interval Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxinterval4](rxinterval4) module"]
+#[doc = "USB Host Receive Polling Interval Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxinterval4](rxinterval4) module"]
 pub type RXINTERVAL4 = crate::Reg<u8, _RXINTERVAL4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1907,7 +1907,7 @@ impl crate::Readable for RXINTERVAL4 {}
 impl crate::Writable for RXINTERVAL4 {}
 #[doc = "USB Host Receive Polling Interval Endpoint 4"]
 pub mod rxinterval4;
-#[doc = "USB Maximum Transmit Data Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txmaxp5](txmaxp5) module"]
+#[doc = "USB Maximum Transmit Data Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txmaxp5](txmaxp5) module"]
 pub type TXMAXP5 = crate::Reg<u16, _TXMAXP5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1918,7 +1918,7 @@ impl crate::Readable for TXMAXP5 {}
 impl crate::Writable for TXMAXP5 {}
 #[doc = "USB Maximum Transmit Data Endpoint 5"]
 pub mod txmaxp5;
-#[doc = "USB Transmit Control and Status Endpoint 5 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrl5](txcsrl5) module"]
+#[doc = "USB Transmit Control and Status Endpoint 5 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrl5](txcsrl5) module"]
 pub type TXCSRL5 = crate::Reg<u8, _TXCSRL5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1929,7 +1929,7 @@ impl crate::Readable for TXCSRL5 {}
 impl crate::Writable for TXCSRL5 {}
 #[doc = "USB Transmit Control and Status Endpoint 5 Low"]
 pub mod txcsrl5;
-#[doc = "USB Transmit Control and Status Endpoint 5 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrh5](txcsrh5) module"]
+#[doc = "USB Transmit Control and Status Endpoint 5 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrh5](txcsrh5) module"]
 pub type TXCSRH5 = crate::Reg<u8, _TXCSRH5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1940,7 +1940,7 @@ impl crate::Readable for TXCSRH5 {}
 impl crate::Writable for TXCSRH5 {}
 #[doc = "USB Transmit Control and Status Endpoint 5 High"]
 pub mod txcsrh5;
-#[doc = "USB Maximum Receive Data Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxmaxp5](rxmaxp5) module"]
+#[doc = "USB Maximum Receive Data Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxmaxp5](rxmaxp5) module"]
 pub type RXMAXP5 = crate::Reg<u16, _RXMAXP5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1951,7 +1951,7 @@ impl crate::Readable for RXMAXP5 {}
 impl crate::Writable for RXMAXP5 {}
 #[doc = "USB Maximum Receive Data Endpoint 5"]
 pub mod rxmaxp5;
-#[doc = "USB Receive Control and Status Endpoint 5 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrl5](rxcsrl5) module"]
+#[doc = "USB Receive Control and Status Endpoint 5 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrl5](rxcsrl5) module"]
 pub type RXCSRL5 = crate::Reg<u8, _RXCSRL5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1962,7 +1962,7 @@ impl crate::Readable for RXCSRL5 {}
 impl crate::Writable for RXCSRL5 {}
 #[doc = "USB Receive Control and Status Endpoint 5 Low"]
 pub mod rxcsrl5;
-#[doc = "USB Receive Control and Status Endpoint 5 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrh5](rxcsrh5) module"]
+#[doc = "USB Receive Control and Status Endpoint 5 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrh5](rxcsrh5) module"]
 pub type RXCSRH5 = crate::Reg<u8, _RXCSRH5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1973,7 +1973,7 @@ impl crate::Readable for RXCSRH5 {}
 impl crate::Writable for RXCSRH5 {}
 #[doc = "USB Receive Control and Status Endpoint 5 High"]
 pub mod rxcsrh5;
-#[doc = "USB Receive Byte Count Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcount5](rxcount5) module"]
+#[doc = "USB Receive Byte Count Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcount5](rxcount5) module"]
 pub type RXCOUNT5 = crate::Reg<u16, _RXCOUNT5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1982,7 +1982,7 @@ pub struct _RXCOUNT5;
 impl crate::Readable for RXCOUNT5 {}
 #[doc = "USB Receive Byte Count Endpoint 5"]
 pub mod rxcount5;
-#[doc = "USB Host Transmit Configure Type Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txtype5](txtype5) module"]
+#[doc = "USB Host Transmit Configure Type Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txtype5](txtype5) module"]
 pub type TXTYPE5 = crate::Reg<u8, _TXTYPE5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -1993,7 +1993,7 @@ impl crate::Readable for TXTYPE5 {}
 impl crate::Writable for TXTYPE5 {}
 #[doc = "USB Host Transmit Configure Type Endpoint 5"]
 pub mod txtype5;
-#[doc = "USB Host Transmit Interval Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txinterval5](txinterval5) module"]
+#[doc = "USB Host Transmit Interval Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txinterval5](txinterval5) module"]
 pub type TXINTERVAL5 = crate::Reg<u8, _TXINTERVAL5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2004,7 +2004,7 @@ impl crate::Readable for TXINTERVAL5 {}
 impl crate::Writable for TXINTERVAL5 {}
 #[doc = "USB Host Transmit Interval Endpoint 5"]
 pub mod txinterval5;
-#[doc = "USB Host Configure Receive Type Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxtype5](rxtype5) module"]
+#[doc = "USB Host Configure Receive Type Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxtype5](rxtype5) module"]
 pub type RXTYPE5 = crate::Reg<u8, _RXTYPE5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2015,7 +2015,7 @@ impl crate::Readable for RXTYPE5 {}
 impl crate::Writable for RXTYPE5 {}
 #[doc = "USB Host Configure Receive Type Endpoint 5"]
 pub mod rxtype5;
-#[doc = "USB Host Receive Polling Interval Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxinterval5](rxinterval5) module"]
+#[doc = "USB Host Receive Polling Interval Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxinterval5](rxinterval5) module"]
 pub type RXINTERVAL5 = crate::Reg<u8, _RXINTERVAL5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2026,7 +2026,7 @@ impl crate::Readable for RXINTERVAL5 {}
 impl crate::Writable for RXINTERVAL5 {}
 #[doc = "USB Host Receive Polling Interval Endpoint 5"]
 pub mod rxinterval5;
-#[doc = "USB Maximum Transmit Data Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txmaxp6](txmaxp6) module"]
+#[doc = "USB Maximum Transmit Data Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txmaxp6](txmaxp6) module"]
 pub type TXMAXP6 = crate::Reg<u16, _TXMAXP6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2037,7 +2037,7 @@ impl crate::Readable for TXMAXP6 {}
 impl crate::Writable for TXMAXP6 {}
 #[doc = "USB Maximum Transmit Data Endpoint 6"]
 pub mod txmaxp6;
-#[doc = "USB Transmit Control and Status Endpoint 6 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrl6](txcsrl6) module"]
+#[doc = "USB Transmit Control and Status Endpoint 6 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrl6](txcsrl6) module"]
 pub type TXCSRL6 = crate::Reg<u8, _TXCSRL6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2048,7 +2048,7 @@ impl crate::Readable for TXCSRL6 {}
 impl crate::Writable for TXCSRL6 {}
 #[doc = "USB Transmit Control and Status Endpoint 6 Low"]
 pub mod txcsrl6;
-#[doc = "USB Transmit Control and Status Endpoint 6 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrh6](txcsrh6) module"]
+#[doc = "USB Transmit Control and Status Endpoint 6 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrh6](txcsrh6) module"]
 pub type TXCSRH6 = crate::Reg<u8, _TXCSRH6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2059,7 +2059,7 @@ impl crate::Readable for TXCSRH6 {}
 impl crate::Writable for TXCSRH6 {}
 #[doc = "USB Transmit Control and Status Endpoint 6 High"]
 pub mod txcsrh6;
-#[doc = "USB Maximum Receive Data Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxmaxp6](rxmaxp6) module"]
+#[doc = "USB Maximum Receive Data Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxmaxp6](rxmaxp6) module"]
 pub type RXMAXP6 = crate::Reg<u16, _RXMAXP6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2070,7 +2070,7 @@ impl crate::Readable for RXMAXP6 {}
 impl crate::Writable for RXMAXP6 {}
 #[doc = "USB Maximum Receive Data Endpoint 6"]
 pub mod rxmaxp6;
-#[doc = "USB Receive Control and Status Endpoint 6 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrl6](rxcsrl6) module"]
+#[doc = "USB Receive Control and Status Endpoint 6 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrl6](rxcsrl6) module"]
 pub type RXCSRL6 = crate::Reg<u8, _RXCSRL6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2081,7 +2081,7 @@ impl crate::Readable for RXCSRL6 {}
 impl crate::Writable for RXCSRL6 {}
 #[doc = "USB Receive Control and Status Endpoint 6 Low"]
 pub mod rxcsrl6;
-#[doc = "USB Receive Control and Status Endpoint 6 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrh6](rxcsrh6) module"]
+#[doc = "USB Receive Control and Status Endpoint 6 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrh6](rxcsrh6) module"]
 pub type RXCSRH6 = crate::Reg<u8, _RXCSRH6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2092,7 +2092,7 @@ impl crate::Readable for RXCSRH6 {}
 impl crate::Writable for RXCSRH6 {}
 #[doc = "USB Receive Control and Status Endpoint 6 High"]
 pub mod rxcsrh6;
-#[doc = "USB Receive Byte Count Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcount6](rxcount6) module"]
+#[doc = "USB Receive Byte Count Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcount6](rxcount6) module"]
 pub type RXCOUNT6 = crate::Reg<u16, _RXCOUNT6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2101,7 +2101,7 @@ pub struct _RXCOUNT6;
 impl crate::Readable for RXCOUNT6 {}
 #[doc = "USB Receive Byte Count Endpoint 6"]
 pub mod rxcount6;
-#[doc = "USB Host Transmit Configure Type Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txtype6](txtype6) module"]
+#[doc = "USB Host Transmit Configure Type Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txtype6](txtype6) module"]
 pub type TXTYPE6 = crate::Reg<u8, _TXTYPE6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2112,7 +2112,7 @@ impl crate::Readable for TXTYPE6 {}
 impl crate::Writable for TXTYPE6 {}
 #[doc = "USB Host Transmit Configure Type Endpoint 6"]
 pub mod txtype6;
-#[doc = "USB Host Transmit Interval Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txinterval6](txinterval6) module"]
+#[doc = "USB Host Transmit Interval Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txinterval6](txinterval6) module"]
 pub type TXINTERVAL6 = crate::Reg<u8, _TXINTERVAL6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2123,7 +2123,7 @@ impl crate::Readable for TXINTERVAL6 {}
 impl crate::Writable for TXINTERVAL6 {}
 #[doc = "USB Host Transmit Interval Endpoint 6"]
 pub mod txinterval6;
-#[doc = "USB Host Configure Receive Type Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxtype6](rxtype6) module"]
+#[doc = "USB Host Configure Receive Type Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxtype6](rxtype6) module"]
 pub type RXTYPE6 = crate::Reg<u8, _RXTYPE6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2134,7 +2134,7 @@ impl crate::Readable for RXTYPE6 {}
 impl crate::Writable for RXTYPE6 {}
 #[doc = "USB Host Configure Receive Type Endpoint 6"]
 pub mod rxtype6;
-#[doc = "USB Host Receive Polling Interval Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxinterval6](rxinterval6) module"]
+#[doc = "USB Host Receive Polling Interval Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxinterval6](rxinterval6) module"]
 pub type RXINTERVAL6 = crate::Reg<u8, _RXINTERVAL6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2145,7 +2145,7 @@ impl crate::Readable for RXINTERVAL6 {}
 impl crate::Writable for RXINTERVAL6 {}
 #[doc = "USB Host Receive Polling Interval Endpoint 6"]
 pub mod rxinterval6;
-#[doc = "USB Maximum Transmit Data Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txmaxp7](txmaxp7) module"]
+#[doc = "USB Maximum Transmit Data Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txmaxp7](txmaxp7) module"]
 pub type TXMAXP7 = crate::Reg<u16, _TXMAXP7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2156,7 +2156,7 @@ impl crate::Readable for TXMAXP7 {}
 impl crate::Writable for TXMAXP7 {}
 #[doc = "USB Maximum Transmit Data Endpoint 7"]
 pub mod txmaxp7;
-#[doc = "USB Transmit Control and Status Endpoint 7 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrl7](txcsrl7) module"]
+#[doc = "USB Transmit Control and Status Endpoint 7 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrl7](txcsrl7) module"]
 pub type TXCSRL7 = crate::Reg<u8, _TXCSRL7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2167,7 +2167,7 @@ impl crate::Readable for TXCSRL7 {}
 impl crate::Writable for TXCSRL7 {}
 #[doc = "USB Transmit Control and Status Endpoint 7 Low"]
 pub mod txcsrl7;
-#[doc = "USB Transmit Control and Status Endpoint 7 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txcsrh7](txcsrh7) module"]
+#[doc = "USB Transmit Control and Status Endpoint 7 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txcsrh7](txcsrh7) module"]
 pub type TXCSRH7 = crate::Reg<u8, _TXCSRH7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2178,7 +2178,7 @@ impl crate::Readable for TXCSRH7 {}
 impl crate::Writable for TXCSRH7 {}
 #[doc = "USB Transmit Control and Status Endpoint 7 High"]
 pub mod txcsrh7;
-#[doc = "USB Maximum Receive Data Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxmaxp7](rxmaxp7) module"]
+#[doc = "USB Maximum Receive Data Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxmaxp7](rxmaxp7) module"]
 pub type RXMAXP7 = crate::Reg<u16, _RXMAXP7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2189,7 +2189,7 @@ impl crate::Readable for RXMAXP7 {}
 impl crate::Writable for RXMAXP7 {}
 #[doc = "USB Maximum Receive Data Endpoint 7"]
 pub mod rxmaxp7;
-#[doc = "USB Receive Control and Status Endpoint 7 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrl7](rxcsrl7) module"]
+#[doc = "USB Receive Control and Status Endpoint 7 Low\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrl7](rxcsrl7) module"]
 pub type RXCSRL7 = crate::Reg<u8, _RXCSRL7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2200,7 +2200,7 @@ impl crate::Readable for RXCSRL7 {}
 impl crate::Writable for RXCSRL7 {}
 #[doc = "USB Receive Control and Status Endpoint 7 Low"]
 pub mod rxcsrl7;
-#[doc = "USB Receive Control and Status Endpoint 7 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcsrh7](rxcsrh7) module"]
+#[doc = "USB Receive Control and Status Endpoint 7 High\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcsrh7](rxcsrh7) module"]
 pub type RXCSRH7 = crate::Reg<u8, _RXCSRH7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2211,7 +2211,7 @@ impl crate::Readable for RXCSRH7 {}
 impl crate::Writable for RXCSRH7 {}
 #[doc = "USB Receive Control and Status Endpoint 7 High"]
 pub mod rxcsrh7;
-#[doc = "USB Receive Byte Count Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxcount7](rxcount7) module"]
+#[doc = "USB Receive Byte Count Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxcount7](rxcount7) module"]
 pub type RXCOUNT7 = crate::Reg<u16, _RXCOUNT7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2220,7 +2220,7 @@ pub struct _RXCOUNT7;
 impl crate::Readable for RXCOUNT7 {}
 #[doc = "USB Receive Byte Count Endpoint 7"]
 pub mod rxcount7;
-#[doc = "USB Host Transmit Configure Type Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txtype7](txtype7) module"]
+#[doc = "USB Host Transmit Configure Type Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txtype7](txtype7) module"]
 pub type TXTYPE7 = crate::Reg<u8, _TXTYPE7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2231,7 +2231,7 @@ impl crate::Readable for TXTYPE7 {}
 impl crate::Writable for TXTYPE7 {}
 #[doc = "USB Host Transmit Configure Type Endpoint 7"]
 pub mod txtype7;
-#[doc = "USB Host Transmit Interval Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txinterval7](txinterval7) module"]
+#[doc = "USB Host Transmit Interval Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txinterval7](txinterval7) module"]
 pub type TXINTERVAL7 = crate::Reg<u8, _TXINTERVAL7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2242,7 +2242,7 @@ impl crate::Readable for TXINTERVAL7 {}
 impl crate::Writable for TXINTERVAL7 {}
 #[doc = "USB Host Transmit Interval Endpoint 7"]
 pub mod txinterval7;
-#[doc = "USB Host Configure Receive Type Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxtype7](rxtype7) module"]
+#[doc = "USB Host Configure Receive Type Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxtype7](rxtype7) module"]
 pub type RXTYPE7 = crate::Reg<u8, _RXTYPE7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2253,7 +2253,7 @@ impl crate::Readable for RXTYPE7 {}
 impl crate::Writable for RXTYPE7 {}
 #[doc = "USB Host Configure Receive Type Endpoint 7"]
 pub mod rxtype7;
-#[doc = "USB Host Receive Polling Interval Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxinterval7](rxinterval7) module"]
+#[doc = "USB Host Receive Polling Interval Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxinterval7](rxinterval7) module"]
 pub type RXINTERVAL7 = crate::Reg<u8, _RXINTERVAL7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2264,7 +2264,7 @@ impl crate::Readable for RXINTERVAL7 {}
 impl crate::Writable for RXINTERVAL7 {}
 #[doc = "USB Host Receive Polling Interval Endpoint 7"]
 pub mod rxinterval7;
-#[doc = "USB DMA Interrupt\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmaintr](dmaintr) module"]
+#[doc = "USB DMA Interrupt\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmaintr](dmaintr) module"]
 pub type DMAINTR = crate::Reg<u8, _DMAINTR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2275,7 +2275,7 @@ impl crate::Readable for DMAINTR {}
 impl crate::Writable for DMAINTR {}
 #[doc = "USB DMA Interrupt"]
 pub mod dmaintr;
-#[doc = "USB DMA Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmactl0](dmactl0) module"]
+#[doc = "USB DMA Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmactl0](dmactl0) module"]
 pub type DMACTL0 = crate::Reg<u16, _DMACTL0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2286,7 +2286,7 @@ impl crate::Readable for DMACTL0 {}
 impl crate::Writable for DMACTL0 {}
 #[doc = "USB DMA Control 0"]
 pub mod dmactl0;
-#[doc = "USB DMA Address 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmaaddr0](dmaaddr0) module"]
+#[doc = "USB DMA Address 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmaaddr0](dmaaddr0) module"]
 pub type DMAADDR0 = crate::Reg<u32, _DMAADDR0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2297,7 +2297,7 @@ impl crate::Readable for DMAADDR0 {}
 impl crate::Writable for DMAADDR0 {}
 #[doc = "USB DMA Address 0"]
 pub mod dmaaddr0;
-#[doc = "USB DMA Count 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmacount0](dmacount0) module"]
+#[doc = "USB DMA Count 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmacount0](dmacount0) module"]
 pub type DMACOUNT0 = crate::Reg<u32, _DMACOUNT0>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2308,7 +2308,7 @@ impl crate::Readable for DMACOUNT0 {}
 impl crate::Writable for DMACOUNT0 {}
 #[doc = "USB DMA Count 0"]
 pub mod dmacount0;
-#[doc = "USB DMA Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmactl1](dmactl1) module"]
+#[doc = "USB DMA Control 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmactl1](dmactl1) module"]
 pub type DMACTL1 = crate::Reg<u16, _DMACTL1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2319,7 +2319,7 @@ impl crate::Readable for DMACTL1 {}
 impl crate::Writable for DMACTL1 {}
 #[doc = "USB DMA Control 1"]
 pub mod dmactl1;
-#[doc = "USB DMA Address 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmaaddr1](dmaaddr1) module"]
+#[doc = "USB DMA Address 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmaaddr1](dmaaddr1) module"]
 pub type DMAADDR1 = crate::Reg<u32, _DMAADDR1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2330,7 +2330,7 @@ impl crate::Readable for DMAADDR1 {}
 impl crate::Writable for DMAADDR1 {}
 #[doc = "USB DMA Address 1"]
 pub mod dmaaddr1;
-#[doc = "USB DMA Count 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmacount1](dmacount1) module"]
+#[doc = "USB DMA Count 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmacount1](dmacount1) module"]
 pub type DMACOUNT1 = crate::Reg<u32, _DMACOUNT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2341,7 +2341,7 @@ impl crate::Readable for DMACOUNT1 {}
 impl crate::Writable for DMACOUNT1 {}
 #[doc = "USB DMA Count 1"]
 pub mod dmacount1;
-#[doc = "USB DMA Control 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmactl2](dmactl2) module"]
+#[doc = "USB DMA Control 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmactl2](dmactl2) module"]
 pub type DMACTL2 = crate::Reg<u16, _DMACTL2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2352,7 +2352,7 @@ impl crate::Readable for DMACTL2 {}
 impl crate::Writable for DMACTL2 {}
 #[doc = "USB DMA Control 2"]
 pub mod dmactl2;
-#[doc = "USB DMA Address 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmaaddr2](dmaaddr2) module"]
+#[doc = "USB DMA Address 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmaaddr2](dmaaddr2) module"]
 pub type DMAADDR2 = crate::Reg<u32, _DMAADDR2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2363,7 +2363,7 @@ impl crate::Readable for DMAADDR2 {}
 impl crate::Writable for DMAADDR2 {}
 #[doc = "USB DMA Address 2"]
 pub mod dmaaddr2;
-#[doc = "USB DMA Count 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmacount2](dmacount2) module"]
+#[doc = "USB DMA Count 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmacount2](dmacount2) module"]
 pub type DMACOUNT2 = crate::Reg<u32, _DMACOUNT2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2374,7 +2374,7 @@ impl crate::Readable for DMACOUNT2 {}
 impl crate::Writable for DMACOUNT2 {}
 #[doc = "USB DMA Count 2"]
 pub mod dmacount2;
-#[doc = "USB DMA Control 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmactl3](dmactl3) module"]
+#[doc = "USB DMA Control 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmactl3](dmactl3) module"]
 pub type DMACTL3 = crate::Reg<u16, _DMACTL3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2385,7 +2385,7 @@ impl crate::Readable for DMACTL3 {}
 impl crate::Writable for DMACTL3 {}
 #[doc = "USB DMA Control 3"]
 pub mod dmactl3;
-#[doc = "USB DMA Address 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmaaddr3](dmaaddr3) module"]
+#[doc = "USB DMA Address 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmaaddr3](dmaaddr3) module"]
 pub type DMAADDR3 = crate::Reg<u32, _DMAADDR3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2396,7 +2396,7 @@ impl crate::Readable for DMAADDR3 {}
 impl crate::Writable for DMAADDR3 {}
 #[doc = "USB DMA Address 3"]
 pub mod dmaaddr3;
-#[doc = "USB DMA Count 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmacount3](dmacount3) module"]
+#[doc = "USB DMA Count 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmacount3](dmacount3) module"]
 pub type DMACOUNT3 = crate::Reg<u32, _DMACOUNT3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2407,7 +2407,7 @@ impl crate::Readable for DMACOUNT3 {}
 impl crate::Writable for DMACOUNT3 {}
 #[doc = "USB DMA Count 3"]
 pub mod dmacount3;
-#[doc = "USB DMA Control 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmactl4](dmactl4) module"]
+#[doc = "USB DMA Control 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmactl4](dmactl4) module"]
 pub type DMACTL4 = crate::Reg<u16, _DMACTL4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2418,7 +2418,7 @@ impl crate::Readable for DMACTL4 {}
 impl crate::Writable for DMACTL4 {}
 #[doc = "USB DMA Control 4"]
 pub mod dmactl4;
-#[doc = "USB DMA Address 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmaaddr4](dmaaddr4) module"]
+#[doc = "USB DMA Address 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmaaddr4](dmaaddr4) module"]
 pub type DMAADDR4 = crate::Reg<u32, _DMAADDR4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2429,7 +2429,7 @@ impl crate::Readable for DMAADDR4 {}
 impl crate::Writable for DMAADDR4 {}
 #[doc = "USB DMA Address 4"]
 pub mod dmaaddr4;
-#[doc = "USB DMA Count 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmacount4](dmacount4) module"]
+#[doc = "USB DMA Count 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmacount4](dmacount4) module"]
 pub type DMACOUNT4 = crate::Reg<u32, _DMACOUNT4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2440,7 +2440,7 @@ impl crate::Readable for DMACOUNT4 {}
 impl crate::Writable for DMACOUNT4 {}
 #[doc = "USB DMA Count 4"]
 pub mod dmacount4;
-#[doc = "USB DMA Control 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmactl5](dmactl5) module"]
+#[doc = "USB DMA Control 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmactl5](dmactl5) module"]
 pub type DMACTL5 = crate::Reg<u16, _DMACTL5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2451,7 +2451,7 @@ impl crate::Readable for DMACTL5 {}
 impl crate::Writable for DMACTL5 {}
 #[doc = "USB DMA Control 5"]
 pub mod dmactl5;
-#[doc = "USB DMA Address 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmaaddr5](dmaaddr5) module"]
+#[doc = "USB DMA Address 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmaaddr5](dmaaddr5) module"]
 pub type DMAADDR5 = crate::Reg<u32, _DMAADDR5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2462,7 +2462,7 @@ impl crate::Readable for DMAADDR5 {}
 impl crate::Writable for DMAADDR5 {}
 #[doc = "USB DMA Address 5"]
 pub mod dmaaddr5;
-#[doc = "USB DMA Count 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmacount5](dmacount5) module"]
+#[doc = "USB DMA Count 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmacount5](dmacount5) module"]
 pub type DMACOUNT5 = crate::Reg<u32, _DMACOUNT5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2473,7 +2473,7 @@ impl crate::Readable for DMACOUNT5 {}
 impl crate::Writable for DMACOUNT5 {}
 #[doc = "USB DMA Count 5"]
 pub mod dmacount5;
-#[doc = "USB DMA Control 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmactl6](dmactl6) module"]
+#[doc = "USB DMA Control 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmactl6](dmactl6) module"]
 pub type DMACTL6 = crate::Reg<u16, _DMACTL6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2484,7 +2484,7 @@ impl crate::Readable for DMACTL6 {}
 impl crate::Writable for DMACTL6 {}
 #[doc = "USB DMA Control 6"]
 pub mod dmactl6;
-#[doc = "USB DMA Address 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmaaddr6](dmaaddr6) module"]
+#[doc = "USB DMA Address 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmaaddr6](dmaaddr6) module"]
 pub type DMAADDR6 = crate::Reg<u32, _DMAADDR6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2495,7 +2495,7 @@ impl crate::Readable for DMAADDR6 {}
 impl crate::Writable for DMAADDR6 {}
 #[doc = "USB DMA Address 6"]
 pub mod dmaaddr6;
-#[doc = "USB DMA Count 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmacount6](dmacount6) module"]
+#[doc = "USB DMA Count 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmacount6](dmacount6) module"]
 pub type DMACOUNT6 = crate::Reg<u32, _DMACOUNT6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2506,7 +2506,7 @@ impl crate::Readable for DMACOUNT6 {}
 impl crate::Writable for DMACOUNT6 {}
 #[doc = "USB DMA Count 6"]
 pub mod dmacount6;
-#[doc = "USB DMA Control 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmactl7](dmactl7) module"]
+#[doc = "USB DMA Control 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmactl7](dmactl7) module"]
 pub type DMACTL7 = crate::Reg<u16, _DMACTL7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2517,7 +2517,7 @@ impl crate::Readable for DMACTL7 {}
 impl crate::Writable for DMACTL7 {}
 #[doc = "USB DMA Control 7"]
 pub mod dmactl7;
-#[doc = "USB DMA Address 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmaaddr7](dmaaddr7) module"]
+#[doc = "USB DMA Address 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmaaddr7](dmaaddr7) module"]
 pub type DMAADDR7 = crate::Reg<u32, _DMAADDR7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2528,7 +2528,7 @@ impl crate::Readable for DMAADDR7 {}
 impl crate::Writable for DMAADDR7 {}
 #[doc = "USB DMA Address 7"]
 pub mod dmaaddr7;
-#[doc = "USB DMA Count 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dmacount7](dmacount7) module"]
+#[doc = "USB DMA Count 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [dmacount7](dmacount7) module"]
 pub type DMACOUNT7 = crate::Reg<u32, _DMACOUNT7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2539,7 +2539,7 @@ impl crate::Readable for DMACOUNT7 {}
 impl crate::Writable for DMACOUNT7 {}
 #[doc = "USB DMA Count 7"]
 pub mod dmacount7;
-#[doc = "USB Request Packet Count in Block Transfer Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rqpktcount1](rqpktcount1) module"]
+#[doc = "USB Request Packet Count in Block Transfer Endpoint 1\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rqpktcount1](rqpktcount1) module"]
 pub type RQPKTCOUNT1 = crate::Reg<u16, _RQPKTCOUNT1>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2550,7 +2550,7 @@ impl crate::Readable for RQPKTCOUNT1 {}
 impl crate::Writable for RQPKTCOUNT1 {}
 #[doc = "USB Request Packet Count in Block Transfer Endpoint 1"]
 pub mod rqpktcount1;
-#[doc = "USB Request Packet Count in Block Transfer Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rqpktcount2](rqpktcount2) module"]
+#[doc = "USB Request Packet Count in Block Transfer Endpoint 2\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rqpktcount2](rqpktcount2) module"]
 pub type RQPKTCOUNT2 = crate::Reg<u16, _RQPKTCOUNT2>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2561,7 +2561,7 @@ impl crate::Readable for RQPKTCOUNT2 {}
 impl crate::Writable for RQPKTCOUNT2 {}
 #[doc = "USB Request Packet Count in Block Transfer Endpoint 2"]
 pub mod rqpktcount2;
-#[doc = "USB Request Packet Count in Block Transfer Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rqpktcount3](rqpktcount3) module"]
+#[doc = "USB Request Packet Count in Block Transfer Endpoint 3\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rqpktcount3](rqpktcount3) module"]
 pub type RQPKTCOUNT3 = crate::Reg<u16, _RQPKTCOUNT3>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2572,7 +2572,7 @@ impl crate::Readable for RQPKTCOUNT3 {}
 impl crate::Writable for RQPKTCOUNT3 {}
 #[doc = "USB Request Packet Count in Block Transfer Endpoint 3"]
 pub mod rqpktcount3;
-#[doc = "USB Request Packet Count in Block Transfer Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rqpktcount4](rqpktcount4) module"]
+#[doc = "USB Request Packet Count in Block Transfer Endpoint 4\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rqpktcount4](rqpktcount4) module"]
 pub type RQPKTCOUNT4 = crate::Reg<u16, _RQPKTCOUNT4>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2583,7 +2583,7 @@ impl crate::Readable for RQPKTCOUNT4 {}
 impl crate::Writable for RQPKTCOUNT4 {}
 #[doc = "USB Request Packet Count in Block Transfer Endpoint 4"]
 pub mod rqpktcount4;
-#[doc = "USB Request Packet Count in Block Transfer Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rqpktcount5](rqpktcount5) module"]
+#[doc = "USB Request Packet Count in Block Transfer Endpoint 5\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rqpktcount5](rqpktcount5) module"]
 pub type RQPKTCOUNT5 = crate::Reg<u16, _RQPKTCOUNT5>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2594,7 +2594,7 @@ impl crate::Readable for RQPKTCOUNT5 {}
 impl crate::Writable for RQPKTCOUNT5 {}
 #[doc = "USB Request Packet Count in Block Transfer Endpoint 5"]
 pub mod rqpktcount5;
-#[doc = "USB Request Packet Count in Block Transfer Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rqpktcount6](rqpktcount6) module"]
+#[doc = "USB Request Packet Count in Block Transfer Endpoint 6\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rqpktcount6](rqpktcount6) module"]
 pub type RQPKTCOUNT6 = crate::Reg<u16, _RQPKTCOUNT6>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2605,7 +2605,7 @@ impl crate::Readable for RQPKTCOUNT6 {}
 impl crate::Writable for RQPKTCOUNT6 {}
 #[doc = "USB Request Packet Count in Block Transfer Endpoint 6"]
 pub mod rqpktcount6;
-#[doc = "USB Request Packet Count in Block Transfer Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rqpktcount7](rqpktcount7) module"]
+#[doc = "USB Request Packet Count in Block Transfer Endpoint 7\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rqpktcount7](rqpktcount7) module"]
 pub type RQPKTCOUNT7 = crate::Reg<u16, _RQPKTCOUNT7>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2616,7 +2616,7 @@ impl crate::Readable for RQPKTCOUNT7 {}
 impl crate::Writable for RQPKTCOUNT7 {}
 #[doc = "USB Request Packet Count in Block Transfer Endpoint 7"]
 pub mod rqpktcount7;
-#[doc = "USB Receive Double Packet Buffer Disable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxdpktbufdis](rxdpktbufdis) module"]
+#[doc = "USB Receive Double Packet Buffer Disable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [rxdpktbufdis](rxdpktbufdis) module"]
 pub type RXDPKTBUFDIS = crate::Reg<u16, _RXDPKTBUFDIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2627,7 +2627,7 @@ impl crate::Readable for RXDPKTBUFDIS {}
 impl crate::Writable for RXDPKTBUFDIS {}
 #[doc = "USB Receive Double Packet Buffer Disable"]
 pub mod rxdpktbufdis;
-#[doc = "USB Transmit Double Packet Buffer Disable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [txdpktbufdis](txdpktbufdis) module"]
+#[doc = "USB Transmit Double Packet Buffer Disable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [txdpktbufdis](txdpktbufdis) module"]
 pub type TXDPKTBUFDIS = crate::Reg<u16, _TXDPKTBUFDIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2638,7 +2638,7 @@ impl crate::Readable for TXDPKTBUFDIS {}
 impl crate::Writable for TXDPKTBUFDIS {}
 #[doc = "USB Transmit Double Packet Buffer Disable"]
 pub mod txdpktbufdis;
-#[doc = "USB Chirp Timeout\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cto](cto) module"]
+#[doc = "USB Chirp Timeout\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cto](cto) module"]
 pub type CTO = crate::Reg<u16, _CTO>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2649,7 +2649,7 @@ impl crate::Readable for CTO {}
 impl crate::Writable for CTO {}
 #[doc = "USB Chirp Timeout"]
 pub mod cto;
-#[doc = "USB High Speed to UTM Operating Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hhsrtn](hhsrtn) module"]
+#[doc = "USB High Speed to UTM Operating Delay\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hhsrtn](hhsrtn) module"]
 pub type HHSRTN = crate::Reg<u16, _HHSRTN>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2660,7 +2660,7 @@ impl crate::Readable for HHSRTN {}
 impl crate::Writable for HHSRTN {}
 #[doc = "USB High Speed to UTM Operating Delay"]
 pub mod hhsrtn;
-#[doc = "USB High Speed Time-out Adder\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [hsbt](hsbt) module"]
+#[doc = "USB High Speed Time-out Adder\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [hsbt](hsbt) module"]
 pub type HSBT = crate::Reg<u16, _HSBT>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2671,7 +2671,7 @@ impl crate::Readable for HSBT {}
 impl crate::Writable for HSBT {}
 #[doc = "USB High Speed Time-out Adder"]
 pub mod hsbt;
-#[doc = "USB LPM Attributes\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [lpmattr](lpmattr) module"]
+#[doc = "USB LPM Attributes\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [lpmattr](lpmattr) module"]
 pub type LPMATTR = crate::Reg<u16, _LPMATTR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2680,7 +2680,7 @@ pub struct _LPMATTR;
 impl crate::Readable for LPMATTR {}
 #[doc = "USB LPM Attributes"]
 pub mod lpmattr;
-#[doc = "USB LPM Control\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [lpmcntrl](lpmcntrl) module"]
+#[doc = "USB LPM Control\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [lpmcntrl](lpmcntrl) module"]
 pub type LPMCNTRL = crate::Reg<u8, _LPMCNTRL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2689,7 +2689,7 @@ pub struct _LPMCNTRL;
 impl crate::Readable for LPMCNTRL {}
 #[doc = "USB LPM Control"]
 pub mod lpmcntrl;
-#[doc = "USB LPM Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [lpmim](lpmim) module"]
+#[doc = "USB LPM Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [lpmim](lpmim) module"]
 pub type LPMIM = crate::Reg<u8, _LPMIM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2698,7 +2698,7 @@ pub struct _LPMIM;
 impl crate::Readable for LPMIM {}
 #[doc = "USB LPM Interrupt Mask"]
 pub mod lpmim;
-#[doc = "USB LPM Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [lpmris](lpmris) module"]
+#[doc = "USB LPM Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [lpmris](lpmris) module"]
 pub type LPMRIS = crate::Reg<u8, _LPMRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2707,7 +2707,7 @@ pub struct _LPMRIS;
 impl crate::Readable for LPMRIS {}
 #[doc = "USB LPM Raw Interrupt Status"]
 pub mod lpmris;
-#[doc = "USB LPM Function Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [lpmfaddr](lpmfaddr) module"]
+#[doc = "USB LPM Function Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [lpmfaddr](lpmfaddr) module"]
 pub type LPMFADDR = crate::Reg<u8, _LPMFADDR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2718,7 +2718,7 @@ impl crate::Readable for LPMFADDR {}
 impl crate::Writable for LPMFADDR {}
 #[doc = "USB LPM Function Address"]
 pub mod lpmfaddr;
-#[doc = "USB External Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epc](epc) module"]
+#[doc = "USB External Power Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [epc](epc) module"]
 pub type EPC = crate::Reg<u32, _EPC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2729,7 +2729,7 @@ impl crate::Readable for EPC {}
 impl crate::Writable for EPC {}
 #[doc = "USB External Power Control"]
 pub mod epc;
-#[doc = "USB External Power Control Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epcris](epcris) module"]
+#[doc = "USB External Power Control Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [epcris](epcris) module"]
 pub type EPCRIS = crate::Reg<u32, _EPCRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2738,7 +2738,7 @@ pub struct _EPCRIS;
 impl crate::Readable for EPCRIS {}
 #[doc = "USB External Power Control Raw Interrupt Status"]
 pub mod epcris;
-#[doc = "USB External Power Control Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epcim](epcim) module"]
+#[doc = "USB External Power Control Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [epcim](epcim) module"]
 pub type EPCIM = crate::Reg<u32, _EPCIM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2749,7 +2749,7 @@ impl crate::Readable for EPCIM {}
 impl crate::Writable for EPCIM {}
 #[doc = "USB External Power Control Interrupt Mask"]
 pub mod epcim;
-#[doc = "USB External Power Control Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epcisc](epcisc) module"]
+#[doc = "USB External Power Control Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [epcisc](epcisc) module"]
 pub type EPCISC = crate::Reg<u32, _EPCISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2760,7 +2760,7 @@ impl crate::Readable for EPCISC {}
 impl crate::Writable for EPCISC {}
 #[doc = "USB External Power Control Interrupt Status and Clear"]
 pub mod epcisc;
-#[doc = "USB Device RESUME Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [drris](drris) module"]
+#[doc = "USB Device RESUME Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [drris](drris) module"]
 pub type DRRIS = crate::Reg<u32, _DRRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2769,7 +2769,7 @@ pub struct _DRRIS;
 impl crate::Readable for DRRIS {}
 #[doc = "USB Device RESUME Raw Interrupt Status"]
 pub mod drris;
-#[doc = "USB Device RESUME Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [drim](drim) module"]
+#[doc = "USB Device RESUME Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [drim](drim) module"]
 pub type DRIM = crate::Reg<u32, _DRIM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2780,7 +2780,7 @@ impl crate::Readable for DRIM {}
 impl crate::Writable for DRIM {}
 #[doc = "USB Device RESUME Interrupt Mask"]
 pub mod drim;
-#[doc = "USB Device RESUME Interrupt Status and Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [drisc](drisc) module"]
+#[doc = "USB Device RESUME Interrupt Status and Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [drisc](drisc) module"]
 pub type DRISC = crate::Reg<u32, _DRISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2789,7 +2789,7 @@ pub struct _DRISC;
 impl crate::Writable for DRISC {}
 #[doc = "USB Device RESUME Interrupt Status and Clear"]
 pub mod drisc;
-#[doc = "USB General-Purpose Control and Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [gpcs](gpcs) module"]
+#[doc = "USB General-Purpose Control and Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [gpcs](gpcs) module"]
 pub type GPCS = crate::Reg<u32, _GPCS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2800,7 +2800,7 @@ impl crate::Readable for GPCS {}
 impl crate::Writable for GPCS {}
 #[doc = "USB General-Purpose Control and Status"]
 pub mod gpcs;
-#[doc = "USB VBUS Droop Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [vdc](vdc) module"]
+#[doc = "USB VBUS Droop Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [vdc](vdc) module"]
 pub type VDC = crate::Reg<u32, _VDC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2811,7 +2811,7 @@ impl crate::Readable for VDC {}
 impl crate::Writable for VDC {}
 #[doc = "USB VBUS Droop Control"]
 pub mod vdc;
-#[doc = "USB VBUS Droop Control Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [vdcris](vdcris) module"]
+#[doc = "USB VBUS Droop Control Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [vdcris](vdcris) module"]
 pub type VDCRIS = crate::Reg<u32, _VDCRIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2820,7 +2820,7 @@ pub struct _VDCRIS;
 impl crate::Readable for VDCRIS {}
 #[doc = "USB VBUS Droop Control Raw Interrupt Status"]
 pub mod vdcris;
-#[doc = "USB VBUS Droop Control Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [vdcim](vdcim) module"]
+#[doc = "USB VBUS Droop Control Interrupt Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [vdcim](vdcim) module"]
 pub type VDCIM = crate::Reg<u32, _VDCIM>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2831,7 +2831,7 @@ impl crate::Readable for VDCIM {}
 impl crate::Writable for VDCIM {}
 #[doc = "USB VBUS Droop Control Interrupt Mask"]
 pub mod vdcim;
-#[doc = "USB VBUS Droop Control Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [vdcisc](vdcisc) module"]
+#[doc = "USB VBUS Droop Control Interrupt Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [vdcisc](vdcisc) module"]
 pub type VDCISC = crate::Reg<u32, _VDCISC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2842,7 +2842,7 @@ impl crate::Readable for VDCISC {}
 impl crate::Writable for VDCISC {}
 #[doc = "USB VBUS Droop Control Interrupt Status and Clear"]
 pub mod vdcisc;
-#[doc = "USB Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pp](pp) module"]
+#[doc = "USB Peripheral Properties\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pp](pp) module"]
 pub type PP = crate::Reg<u32, _PP>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2851,7 +2851,7 @@ pub struct _PP;
 impl crate::Readable for PP {}
 #[doc = "USB Peripheral Properties"]
 pub mod pp;
-#[doc = "USB Peripheral Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pc](pc) module"]
+#[doc = "USB Peripheral Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [pc](pc) module"]
 pub type PC = crate::Reg<u32, _PC>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -2862,7 +2862,7 @@ impl crate::Readable for PC {}
 impl crate::Writable for PC {}
 #[doc = "USB Peripheral Configuration"]
 pub mod pc;
-#[doc = "USB Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc](cc) module"]
+#[doc = "USB Clock Configuration\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [cc](cc) module"]
 pub type CC = crate::Reg<u32, _CC>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/usb0/devctl.rs
+++ b/crates/tm4c129x/src/usb0/devctl.rs
@@ -84,25 +84,21 @@ impl<'a> HOST_W<'a> {
 }
 #[doc = "VBUS Level (OTG only)\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum VBUS_A {
     #[doc = "0: Below SessionEnd"]
-    NONE,
+    NONE = 0,
     #[doc = "1: Above SessionEnd, below AValid"]
-    SEND,
+    SEND = 1,
     #[doc = "2: Above AValid, below VBUSValid"]
-    AVALID,
+    AVALID = 2,
     #[doc = "3: Above VBUSValid"]
-    VALID,
+    VALID = 3,
 }
 impl From<VBUS_A> for u8 {
     #[inline(always)]
     fn from(variant: VBUS_A) -> Self {
-        match variant {
-            VBUS_A::NONE => 0,
-            VBUS_A::SEND => 1,
-            VBUS_A::AVALID => 2,
-            VBUS_A::VALID => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `VBUS`"]

--- a/crates/tm4c129x/src/usb0/dmactl0.rs
+++ b/crates/tm4c129x/src/usb0/dmactl0.rs
@@ -146,25 +146,21 @@ impl<'a> ERR_W<'a> {
 }
 #[doc = "Burst Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum BRSTM_A {
     #[doc = "0: Bursts of unspecified length"]
-    ANY,
+    ANY = 0,
     #[doc = "1: INCR4 or unspecified length"]
-    INC4,
+    INC4 = 1,
     #[doc = "2: INCR8, INCR4 or unspecified length"]
-    INC8,
+    INC8 = 2,
     #[doc = "3: INCR16, INCR8, INCR4 or unspecified length"]
-    INC16,
+    INC16 = 3,
 }
 impl From<BRSTM_A> for u8 {
     #[inline(always)]
     fn from(variant: BRSTM_A) -> Self {
-        match variant {
-            BRSTM_A::ANY => 0,
-            BRSTM_A::INC4 => 1,
-            BRSTM_A::INC8 => 2,
-            BRSTM_A::INC16 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `BRSTM`"]

--- a/crates/tm4c129x/src/usb0/dmactl1.rs
+++ b/crates/tm4c129x/src/usb0/dmactl1.rs
@@ -146,25 +146,21 @@ impl<'a> ERR_W<'a> {
 }
 #[doc = "Burst Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum BRSTM_A {
     #[doc = "0: Bursts of unspecified length"]
-    ANY,
+    ANY = 0,
     #[doc = "1: INCR4 or unspecified length"]
-    INC4,
+    INC4 = 1,
     #[doc = "2: INCR8, INCR4 or unspecified length"]
-    INC8,
+    INC8 = 2,
     #[doc = "3: INCR16, INCR8, INCR4 or unspecified length"]
-    INC16,
+    INC16 = 3,
 }
 impl From<BRSTM_A> for u8 {
     #[inline(always)]
     fn from(variant: BRSTM_A) -> Self {
-        match variant {
-            BRSTM_A::ANY => 0,
-            BRSTM_A::INC4 => 1,
-            BRSTM_A::INC8 => 2,
-            BRSTM_A::INC16 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `BRSTM`"]

--- a/crates/tm4c129x/src/usb0/dmactl2.rs
+++ b/crates/tm4c129x/src/usb0/dmactl2.rs
@@ -146,25 +146,21 @@ impl<'a> ERR_W<'a> {
 }
 #[doc = "Burst Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum BRSTM_A {
     #[doc = "0: Bursts of unspecified length"]
-    ANY,
+    ANY = 0,
     #[doc = "1: INCR4 or unspecified length"]
-    INC4,
+    INC4 = 1,
     #[doc = "2: INCR8, INCR4 or unspecified length"]
-    INC8,
+    INC8 = 2,
     #[doc = "3: INCR16, INCR8, INCR4 or unspecified length"]
-    INC16,
+    INC16 = 3,
 }
 impl From<BRSTM_A> for u8 {
     #[inline(always)]
     fn from(variant: BRSTM_A) -> Self {
-        match variant {
-            BRSTM_A::ANY => 0,
-            BRSTM_A::INC4 => 1,
-            BRSTM_A::INC8 => 2,
-            BRSTM_A::INC16 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `BRSTM`"]

--- a/crates/tm4c129x/src/usb0/dmactl3.rs
+++ b/crates/tm4c129x/src/usb0/dmactl3.rs
@@ -146,25 +146,21 @@ impl<'a> ERR_W<'a> {
 }
 #[doc = "Burst Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum BRSTM_A {
     #[doc = "0: Bursts of unspecified length"]
-    ANY,
+    ANY = 0,
     #[doc = "1: INCR4 or unspecified length"]
-    INC4,
+    INC4 = 1,
     #[doc = "2: INCR8, INCR4 or unspecified length"]
-    INC8,
+    INC8 = 2,
     #[doc = "3: INCR16, INCR8, INCR4 or unspecified length"]
-    INC16,
+    INC16 = 3,
 }
 impl From<BRSTM_A> for u8 {
     #[inline(always)]
     fn from(variant: BRSTM_A) -> Self {
-        match variant {
-            BRSTM_A::ANY => 0,
-            BRSTM_A::INC4 => 1,
-            BRSTM_A::INC8 => 2,
-            BRSTM_A::INC16 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `BRSTM`"]

--- a/crates/tm4c129x/src/usb0/dmactl4.rs
+++ b/crates/tm4c129x/src/usb0/dmactl4.rs
@@ -146,25 +146,21 @@ impl<'a> ERR_W<'a> {
 }
 #[doc = "Burst Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum BRSTM_A {
     #[doc = "0: Bursts of unspecified length"]
-    ANY,
+    ANY = 0,
     #[doc = "1: INCR4 or unspecified length"]
-    INC4,
+    INC4 = 1,
     #[doc = "2: INCR8, INCR4 or unspecified length"]
-    INC8,
+    INC8 = 2,
     #[doc = "3: INCR16, INCR8, INCR4 or unspecified length"]
-    INC16,
+    INC16 = 3,
 }
 impl From<BRSTM_A> for u8 {
     #[inline(always)]
     fn from(variant: BRSTM_A) -> Self {
-        match variant {
-            BRSTM_A::ANY => 0,
-            BRSTM_A::INC4 => 1,
-            BRSTM_A::INC8 => 2,
-            BRSTM_A::INC16 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `BRSTM`"]

--- a/crates/tm4c129x/src/usb0/dmactl5.rs
+++ b/crates/tm4c129x/src/usb0/dmactl5.rs
@@ -146,25 +146,21 @@ impl<'a> ERR_W<'a> {
 }
 #[doc = "Burst Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum BRSTM_A {
     #[doc = "0: Bursts of unspecified length"]
-    ANY,
+    ANY = 0,
     #[doc = "1: INCR4 or unspecified length"]
-    INC4,
+    INC4 = 1,
     #[doc = "2: INCR8, INCR4 or unspecified length"]
-    INC8,
+    INC8 = 2,
     #[doc = "3: INCR16, INCR8, INCR4 or unspecified length"]
-    INC16,
+    INC16 = 3,
 }
 impl From<BRSTM_A> for u8 {
     #[inline(always)]
     fn from(variant: BRSTM_A) -> Self {
-        match variant {
-            BRSTM_A::ANY => 0,
-            BRSTM_A::INC4 => 1,
-            BRSTM_A::INC8 => 2,
-            BRSTM_A::INC16 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `BRSTM`"]

--- a/crates/tm4c129x/src/usb0/dmactl6.rs
+++ b/crates/tm4c129x/src/usb0/dmactl6.rs
@@ -146,25 +146,21 @@ impl<'a> ERR_W<'a> {
 }
 #[doc = "Burst Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum BRSTM_A {
     #[doc = "0: Bursts of unspecified length"]
-    ANY,
+    ANY = 0,
     #[doc = "1: INCR4 or unspecified length"]
-    INC4,
+    INC4 = 1,
     #[doc = "2: INCR8, INCR4 or unspecified length"]
-    INC8,
+    INC8 = 2,
     #[doc = "3: INCR16, INCR8, INCR4 or unspecified length"]
-    INC16,
+    INC16 = 3,
 }
 impl From<BRSTM_A> for u8 {
     #[inline(always)]
     fn from(variant: BRSTM_A) -> Self {
-        match variant {
-            BRSTM_A::ANY => 0,
-            BRSTM_A::INC4 => 1,
-            BRSTM_A::INC8 => 2,
-            BRSTM_A::INC16 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `BRSTM`"]

--- a/crates/tm4c129x/src/usb0/dmactl7.rs
+++ b/crates/tm4c129x/src/usb0/dmactl7.rs
@@ -146,25 +146,21 @@ impl<'a> ERR_W<'a> {
 }
 #[doc = "Burst Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum BRSTM_A {
     #[doc = "0: Bursts of unspecified length"]
-    ANY,
+    ANY = 0,
     #[doc = "1: INCR4 or unspecified length"]
-    INC4,
+    INC4 = 1,
     #[doc = "2: INCR8, INCR4 or unspecified length"]
-    INC8,
+    INC8 = 2,
     #[doc = "3: INCR16, INCR8, INCR4 or unspecified length"]
-    INC16,
+    INC16 = 3,
 }
 impl From<BRSTM_A> for u8 {
     #[inline(always)]
     fn from(variant: BRSTM_A) -> Self {
-        match variant {
-            BRSTM_A::ANY => 0,
-            BRSTM_A::INC4 => 1,
-            BRSTM_A::INC8 => 2,
-            BRSTM_A::INC16 => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `BRSTM`"]

--- a/crates/tm4c129x/src/usb0/epc.rs
+++ b/crates/tm4c129x/src/usb0/epc.rs
@@ -12,25 +12,21 @@ impl crate::ResetValue for super::EPC {
 }
 #[doc = "External Power Supply Enable Configuration\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum EPEN_A {
     #[doc = "0: Power Enable Active Low"]
-    LOW,
+    LOW = 0,
     #[doc = "1: Power Enable Active High"]
-    HIGH,
+    HIGH = 1,
     #[doc = "2: Power Enable High if VBUS Low (OTG only)"]
-    VBLOW,
+    VBLOW = 2,
     #[doc = "3: Power Enable High if VBUS High (OTG only)"]
-    VBHIGH,
+    VBHIGH = 3,
 }
 impl From<EPEN_A> for u8 {
     #[inline(always)]
     fn from(variant: EPEN_A) -> Self {
-        match variant {
-            EPEN_A::LOW => 0,
-            EPEN_A::HIGH => 1,
-            EPEN_A::VBLOW => 2,
-            EPEN_A::VBHIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `EPEN`"]
@@ -205,25 +201,21 @@ impl<'a> PFLTAEN_W<'a> {
 }
 #[doc = "Power Fault Action\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PFLTACT_A {
     #[doc = "0: Unchanged"]
-    UNCHG,
+    UNCHG = 0,
     #[doc = "1: Tristate"]
-    TRIS,
+    TRIS = 1,
     #[doc = "2: Low"]
-    LOW,
+    LOW = 2,
     #[doc = "3: High"]
-    HIGH,
+    HIGH = 3,
 }
 impl From<PFLTACT_A> for u8 {
     #[inline(always)]
     fn from(variant: PFLTACT_A) -> Self {
-        match variant {
-            PFLTACT_A::UNCHG => 0,
-            PFLTACT_A::TRIS => 1,
-            PFLTACT_A::LOW => 2,
-            PFLTACT_A::HIGH => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PFLTACT`"]

--- a/crates/tm4c129x/src/usb0/gpcs.rs
+++ b/crates/tm4c129x/src/usb0/gpcs.rs
@@ -12,28 +12,23 @@ impl crate::ResetValue for super::GPCS {
 }
 #[doc = "Device Mode\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum DEVMOD_A {
     #[doc = "0: Use USB0VBUS and USB0ID pin"]
-    OTG,
+    OTG = 0,
     #[doc = "2: Force USB0VBUS and USB0ID low"]
-    HOST,
+    HOST = 2,
     #[doc = "3: Force USB0VBUS and USB0ID high"]
-    DEV,
+    DEV = 3,
     #[doc = "4: Use USB0VBUS and force USB0ID low"]
-    HOSTVBUS,
+    HOSTVBUS = 4,
     #[doc = "5: Use USB0VBUS and force USB0ID high"]
-    DEVVBUS,
+    DEVVBUS = 5,
 }
 impl From<DEVMOD_A> for u8 {
     #[inline(always)]
     fn from(variant: DEVMOD_A) -> Self {
-        match variant {
-            DEVMOD_A::OTG => 0,
-            DEVMOD_A::HOST => 2,
-            DEVMOD_A::DEV => 3,
-            DEVMOD_A::HOSTVBUS => 4,
-            DEVMOD_A::DEVVBUS => 5,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `DEVMOD`"]

--- a/crates/tm4c129x/src/usb0/lpmattr.rs
+++ b/crates/tm4c129x/src/usb0/lpmattr.rs
@@ -2,16 +2,15 @@
 pub type R = crate::R<u16, super::LPMATTR>;
 #[doc = "Link State\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum LS_A {
     #[doc = "1: Sleep State (L1)"]
-    L1,
+    L1 = 1,
 }
 impl From<LS_A> for u8 {
     #[inline(always)]
     fn from(variant: LS_A) -> Self {
-        match variant {
-            LS_A::L1 => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `LS`"]

--- a/crates/tm4c129x/src/usb0/lpmcntrl.rs
+++ b/crates/tm4c129x/src/usb0/lpmcntrl.rs
@@ -6,22 +6,19 @@ pub type TXLPM_R = crate::R<bool, bool>;
 pub type RES_R = crate::R<bool, bool>;
 #[doc = "LPM Enable\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum EN_A {
     #[doc = "0: LPM and Extended transactions are not supported. In this case, the USB does not respond to LPM transactions and LPM transactions cause a timeout"]
-    NONE,
+    NONE = 0,
     #[doc = "1: LPM is not supported but extended transactions are supported. In this case, the USB does respond to an LPM transaction with a STALL"]
-    EXT,
+    EXT = 1,
     #[doc = "3: The USB supports LPM extended transactions. In this case, the USB responds with a NYET or an ACK as determined by the value of TXLPM and other conditions"]
-    LPMEXT,
+    LPMEXT = 3,
 }
 impl From<EN_A> for u8 {
     #[inline(always)]
     fn from(variant: EN_A) -> Self {
-        match variant {
-            EN_A::NONE => 0,
-            EN_A::EXT => 1,
-            EN_A::LPMEXT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `EN`"]

--- a/crates/tm4c129x/src/usb0/pp.rs
+++ b/crates/tm4c129x/src/usb0/pp.rs
@@ -2,19 +2,17 @@
 pub type R = crate::R<u32, super::PP>;
 #[doc = "Controller Type\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum TYPE_A {
     #[doc = "0: The first-generation USB controller"]
-    _0,
+    _0 = 0,
     #[doc = "1: Second-generation USB controller.The controller implemented in post Icestorm devices that use the 3.0 version of the Mentor controller"]
-    _1,
+    _1 = 1,
 }
 impl From<TYPE_A> for u8 {
     #[inline(always)]
     fn from(variant: TYPE_A) -> Self {
-        match variant {
-            TYPE_A::_0 => 0,
-            TYPE_A::_1 => 1,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `TYPE`"]
@@ -47,22 +45,19 @@ pub type PHY_R = crate::R<bool, bool>;
 pub type ULPI_R = crate::R<bool, bool>;
 #[doc = "USB Capability\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum USB_A {
     #[doc = "1: DEVICE"]
-    DEVICE,
+    DEVICE = 1,
     #[doc = "2: HOST"]
-    HOSTDEVICE,
+    HOSTDEVICE = 2,
     #[doc = "3: OTG"]
-    OTG,
+    OTG = 3,
 }
 impl From<USB_A> for u8 {
     #[inline(always)]
     fn from(variant: USB_A) -> Self {
-        match variant {
-            USB_A::DEVICE => 1,
-            USB_A::HOSTDEVICE => 2,
-            USB_A::OTG => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `USB`"]

--- a/crates/tm4c129x/src/usb0/rxfifosz.rs
+++ b/crates/tm4c129x/src/usb0/rxfifosz.rs
@@ -12,40 +12,31 @@ impl crate::ResetValue for super::RXFIFOSZ {
 }
 #[doc = "Max Packet Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SIZE_A {
     #[doc = "0: 8"]
-    _8,
+    _8 = 0,
     #[doc = "1: 16"]
-    _16,
+    _16 = 1,
     #[doc = "2: 32"]
-    _32,
+    _32 = 2,
     #[doc = "3: 64"]
-    _64,
+    _64 = 3,
     #[doc = "4: 128"]
-    _128,
+    _128 = 4,
     #[doc = "5: 256"]
-    _256,
+    _256 = 5,
     #[doc = "6: 512"]
-    _512,
+    _512 = 6,
     #[doc = "7: 1024"]
-    _1024,
+    _1024 = 7,
     #[doc = "8: 2048"]
-    _2048,
+    _2048 = 8,
 }
 impl From<SIZE_A> for u8 {
     #[inline(always)]
     fn from(variant: SIZE_A) -> Self {
-        match variant {
-            SIZE_A::_8 => 0,
-            SIZE_A::_16 => 1,
-            SIZE_A::_32 => 2,
-            SIZE_A::_64 => 3,
-            SIZE_A::_128 => 4,
-            SIZE_A::_256 => 5,
-            SIZE_A::_512 => 6,
-            SIZE_A::_1024 => 7,
-            SIZE_A::_2048 => 8,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SIZE`"]

--- a/crates/tm4c129x/src/usb0/rxtype1.rs
+++ b/crates/tm4c129x/src/usb0/rxtype1.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,25 +119,21 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "1: High"]
-    HIGH,
+    HIGH = 1,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::HIGH => 1,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c129x/src/usb0/rxtype2.rs
+++ b/crates/tm4c129x/src/usb0/rxtype2.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,25 +119,21 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "1: High"]
-    HIGH,
+    HIGH = 1,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::HIGH => 1,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c129x/src/usb0/rxtype3.rs
+++ b/crates/tm4c129x/src/usb0/rxtype3.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,25 +119,21 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "1: High"]
-    HIGH,
+    HIGH = 1,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::HIGH => 1,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c129x/src/usb0/rxtype4.rs
+++ b/crates/tm4c129x/src/usb0/rxtype4.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,25 +119,21 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "1: High"]
-    HIGH,
+    HIGH = 1,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::HIGH => 1,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c129x/src/usb0/rxtype5.rs
+++ b/crates/tm4c129x/src/usb0/rxtype5.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,25 +119,21 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "1: High"]
-    HIGH,
+    HIGH = 1,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::HIGH => 1,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c129x/src/usb0/rxtype6.rs
+++ b/crates/tm4c129x/src/usb0/rxtype6.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,25 +119,21 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "1: High"]
-    HIGH,
+    HIGH = 1,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::HIGH => 1,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c129x/src/usb0/rxtype7.rs
+++ b/crates/tm4c129x/src/usb0/rxtype7.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,25 +119,21 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "1: High"]
-    HIGH,
+    HIGH = 1,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::HIGH => 1,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c129x/src/usb0/txfifosz.rs
+++ b/crates/tm4c129x/src/usb0/txfifosz.rs
@@ -12,40 +12,31 @@ impl crate::ResetValue for super::TXFIFOSZ {
 }
 #[doc = "Max Packet Size\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SIZE_A {
     #[doc = "0: 8"]
-    _8,
+    _8 = 0,
     #[doc = "1: 16"]
-    _16,
+    _16 = 1,
     #[doc = "2: 32"]
-    _32,
+    _32 = 2,
     #[doc = "3: 64"]
-    _64,
+    _64 = 3,
     #[doc = "4: 128"]
-    _128,
+    _128 = 4,
     #[doc = "5: 256"]
-    _256,
+    _256 = 5,
     #[doc = "6: 512"]
-    _512,
+    _512 = 6,
     #[doc = "7: 1024"]
-    _1024,
+    _1024 = 7,
     #[doc = "8: 2048"]
-    _2048,
+    _2048 = 8,
 }
 impl From<SIZE_A> for u8 {
     #[inline(always)]
     fn from(variant: SIZE_A) -> Self {
-        match variant {
-            SIZE_A::_8 => 0,
-            SIZE_A::_16 => 1,
-            SIZE_A::_32 => 2,
-            SIZE_A::_64 => 3,
-            SIZE_A::_128 => 4,
-            SIZE_A::_256 => 5,
-            SIZE_A::_512 => 6,
-            SIZE_A::_1024 => 7,
-            SIZE_A::_2048 => 8,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SIZE`"]

--- a/crates/tm4c129x/src/usb0/txtype1.rs
+++ b/crates/tm4c129x/src/usb0/txtype1.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,25 +119,21 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "1: High"]
-    HIGH,
+    HIGH = 1,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::HIGH => 1,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c129x/src/usb0/txtype2.rs
+++ b/crates/tm4c129x/src/usb0/txtype2.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,25 +119,21 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "1: High"]
-    HIGH,
+    HIGH = 1,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::HIGH => 1,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c129x/src/usb0/txtype3.rs
+++ b/crates/tm4c129x/src/usb0/txtype3.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,25 +119,21 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "1: High"]
-    HIGH,
+    HIGH = 1,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::HIGH => 1,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c129x/src/usb0/txtype4.rs
+++ b/crates/tm4c129x/src/usb0/txtype4.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,25 +119,21 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "1: High"]
-    HIGH,
+    HIGH = 1,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::HIGH => 1,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c129x/src/usb0/txtype5.rs
+++ b/crates/tm4c129x/src/usb0/txtype5.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,25 +119,21 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "1: High"]
-    HIGH,
+    HIGH = 1,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::HIGH => 1,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c129x/src/usb0/txtype6.rs
+++ b/crates/tm4c129x/src/usb0/txtype6.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,25 +119,21 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "1: High"]
-    HIGH,
+    HIGH = 1,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::HIGH => 1,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c129x/src/usb0/txtype7.rs
+++ b/crates/tm4c129x/src/usb0/txtype7.rs
@@ -26,25 +26,21 @@ impl<'a> TEP_W<'a> {
 }
 #[doc = "Protocol\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum PROTO_A {
     #[doc = "0: Control"]
-    CTRL,
+    CTRL = 0,
     #[doc = "1: Isochronous"]
-    ISOC,
+    ISOC = 1,
     #[doc = "2: Bulk"]
-    BULK,
+    BULK = 2,
     #[doc = "3: Interrupt"]
-    INT,
+    INT = 3,
 }
 impl From<PROTO_A> for u8 {
     #[inline(always)]
     fn from(variant: PROTO_A) -> Self {
-        match variant {
-            PROTO_A::CTRL => 0,
-            PROTO_A::ISOC => 1,
-            PROTO_A::BULK => 2,
-            PROTO_A::INT => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `PROTO`"]
@@ -123,25 +119,21 @@ impl<'a> PROTO_W<'a> {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "0: Default"]
-    DFLT,
+    DFLT = 0,
     #[doc = "1: High"]
-    HIGH,
+    HIGH = 1,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::DFLT => 0,
-            SPEED_A::HIGH => 1,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c129x/src/usb0/type0.rs
+++ b/crates/tm4c129x/src/usb0/type0.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::TYPE0 {
 }
 #[doc = "Operating Speed\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
 pub enum SPEED_A {
     #[doc = "1: High"]
-    HIGH,
+    HIGH = 1,
     #[doc = "2: Full"]
-    FULL,
+    FULL = 2,
     #[doc = "3: Low"]
-    LOW,
+    LOW = 3,
 }
 impl From<SPEED_A> for u8 {
     #[inline(always)]
     fn from(variant: SPEED_A) -> Self {
-        match variant {
-            SPEED_A::HIGH => 1,
-            SPEED_A::FULL => 2,
-            SPEED_A::LOW => 3,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `SPEED`"]

--- a/crates/tm4c129x/src/watchdog0.rs
+++ b/crates/tm4c129x/src/watchdog0.rs
@@ -20,7 +20,7 @@ pub struct RegisterBlock {
     #[doc = "0xc00 - Watchdog Lock"]
     pub lock: LOCK,
 }
-#[doc = "Watchdog Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [load](load) module"]
+#[doc = "Watchdog Load\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [load](load) module"]
 pub type LOAD = crate::Reg<u32, _LOAD>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -31,7 +31,7 @@ impl crate::Readable for LOAD {}
 impl crate::Writable for LOAD {}
 #[doc = "Watchdog Load"]
 pub mod load;
-#[doc = "Watchdog Value\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [value](value) module"]
+#[doc = "Watchdog Value\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [value](value) module"]
 pub type VALUE = crate::Reg<u32, _VALUE>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -40,7 +40,7 @@ pub struct _VALUE;
 impl crate::Readable for VALUE {}
 #[doc = "Watchdog Value"]
 pub mod value;
-#[doc = "Watchdog Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctl](ctl) module"]
+#[doc = "Watchdog Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctl](ctl) module"]
 pub type CTL = crate::Reg<u32, _CTL>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -51,7 +51,7 @@ impl crate::Readable for CTL {}
 impl crate::Writable for CTL {}
 #[doc = "Watchdog Control"]
 pub mod ctl;
-#[doc = "Watchdog Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [icr](icr) module"]
+#[doc = "Watchdog Interrupt Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [icr](icr) module"]
 pub type ICR = crate::Reg<u32, _ICR>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -60,7 +60,7 @@ pub struct _ICR;
 impl crate::Writable for ICR {}
 #[doc = "Watchdog Interrupt Clear"]
 pub mod icr;
-#[doc = "Watchdog Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ris](ris) module"]
+#[doc = "Watchdog Raw Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ris](ris) module"]
 pub type RIS = crate::Reg<u32, _RIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -69,7 +69,7 @@ pub struct _RIS;
 impl crate::Readable for RIS {}
 #[doc = "Watchdog Raw Interrupt Status"]
 pub mod ris;
-#[doc = "Watchdog Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mis](mis) module"]
+#[doc = "Watchdog Masked Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [mis](mis) module"]
 pub type MIS = crate::Reg<u32, _MIS>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -78,7 +78,7 @@ pub struct _MIS;
 impl crate::Readable for MIS {}
 #[doc = "Watchdog Masked Interrupt Status"]
 pub mod mis;
-#[doc = "Watchdog Test\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [test](test) module"]
+#[doc = "Watchdog Test\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [test](test) module"]
 pub type TEST = crate::Reg<u32, _TEST>;
 #[allow(missing_docs)]
 #[doc(hidden)]
@@ -89,7 +89,7 @@ impl crate::Readable for TEST {}
 impl crate::Writable for TEST {}
 #[doc = "Watchdog Test"]
 pub mod test;
-#[doc = "Watchdog Lock\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [lock](lock) module"]
+#[doc = "Watchdog Lock\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [lock](lock) module"]
 pub type LOCK = crate::Reg<u32, _LOCK>;
 #[allow(missing_docs)]
 #[doc(hidden)]

--- a/crates/tm4c129x/src/watchdog0/lock.rs
+++ b/crates/tm4c129x/src/watchdog0/lock.rs
@@ -12,22 +12,19 @@ impl crate::ResetValue for super::LOCK {
 }
 #[doc = "Watchdog Lock\n\nValue on reset: 0"]
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u32)]
 pub enum LOCK_A {
     #[doc = "0: Unlocked"]
-    UNLOCKED,
+    UNLOCKED = 0,
     #[doc = "1: Locked"]
-    LOCKED,
+    LOCKED = 1,
     #[doc = "449635665: Unlocks the watchdog timer"]
-    UNLOCK,
+    UNLOCK = 449635665,
 }
 impl From<LOCK_A> for u32 {
     #[inline(always)]
     fn from(variant: LOCK_A) -> Self {
-        match variant {
-            LOCK_A::UNLOCKED => 0,
-            LOCK_A::LOCKED => 1,
-            LOCK_A::UNLOCK => 449635665,
-        }
+        variant as _
     }
 }
 #[doc = "Reader of field `LOCK`"]

--- a/overlay/tm4c123x.patch
+++ b/overlay/tm4c123x.patch
@@ -9,10 +9,10 @@
    <series>Tiva C Series</series>
    <version>1</version>
    <description>(no description)</description>
-   <addressUnitBits>8</addressUnitBits>
-   <width>32</width>
-   <resetValue>0x00000000</resetValue>
-@@ -24474,13 +24474,20 @@
+   <cpu>
+     <name>CM4</name>
+     <revision>r0p0</revision>
+@@ -24483,13 +24483,20 @@
                <name>WRBUF</name>
                <description>Buffered Flash Memory Write</description>
                <lsb>0</lsb>
@@ -34,7 +34,7 @@
            <displayName>FLASH_FWBVAL</displayName>
            <description>Flash Write Buffer Valid</description>
            <addressOffset>0x00000030</addressOffset>
-@@ -24493,15 +24500,18 @@
+@@ -24502,15 +24509,18 @@
                <msb>31</msb>
                <access>read-write</access>
              </field>

--- a/overlay/tm4c129x.patch
+++ b/overlay/tm4c129x.patch
@@ -9,10 +9,10 @@
    <series>Tiva C Series</series>
    <version>1</version>
    <description>(no description)</description>
-   <addressUnitBits>8</addressUnitBits>
-   <width>32</width>
-   <resetValue>0x00000000</resetValue>
-@@ -1403,12 +1403,18 @@
+   <cpu>
+     <name>CM4</name>
+     <revision>r0p0</revision>
+@@ -1412,12 +1412,18 @@
              <field>
                <name>DATA</name>
                <description>Data Transmitted or Received</description>
@@ -31,7 +31,7 @@
                <description>UART Framing Error</description>
                <lsb>8</lsb>
                <msb>8</msb>
-@@ -1588,12 +1594,18 @@
+@@ -1597,12 +1603,18 @@
              <field>
                <name>DIVINT</name>
                <description>Integer Baud-Rate Divisor</description>
@@ -50,7 +50,7 @@
          <register>
            <name>FBRD</name>
            <displayName>UART_FBRD</displayName>
-@@ -1604,12 +1616,18 @@
+@@ -1613,12 +1625,18 @@
              <field>
                <name>DIVFRAC</name>
                <description>Fractional Baud-Rate Divisor</description>
@@ -69,7 +69,7 @@
          <register>
            <name>LCRH</name>
            <displayName>UART_LCRH</displayName>
-@@ -2458,14 +2476,14 @@
+@@ -2467,14 +2485,14 @@
                  <enumeratedValue>
                    <name>SYSCLK</name>
                    <description>System clock (based on clock source and divisor factor)</description>
@@ -86,7 +86,7 @@
              </field>
            </fields>
          </register>
-@@ -5141,12 +5159,18 @@
+@@ -5150,12 +5168,18 @@
              <field>
                <name>LOAD</name>
                <description>Counter Load Value</description>
@@ -105,7 +105,7 @@
          <register>
            <name>_0_COUNT</name>
            <displayName>PWM_0_COUNT</displayName>
-@@ -5168,33 +5192,45 @@
+@@ -5177,33 +5201,45 @@
            <displayName>PWM_0_CMPA</displayName>
            <description>PWM0 Compare A</description>
            <addressOffset>0x00000058</addressOffset>
@@ -153,7 +153,7 @@
          <register>
            <name>_0_GENA</name>
            <displayName>PWM_0_GENA</displayName>
-@@ -5757,12 +5793,18 @@
+@@ -5766,12 +5802,18 @@
              <field>
                <name>MINFLTPER</name>
                <description>Minimum Fault Period</description>
@@ -172,7 +172,7 @@
          <register>
            <name>_1_CTL</name>
            <displayName>PWM_1_CTL</displayName>
-@@ -6175,12 +6217,18 @@
+@@ -6184,12 +6226,18 @@
              <field>
                <name>LOAD</name>
                <description>Counter Load Value</description>
@@ -191,7 +191,7 @@
          <register>
            <name>_1_COUNT</name>
            <displayName>PWM_1_COUNT</displayName>
-@@ -6207,12 +6255,18 @@
+@@ -6216,12 +6264,18 @@
              <field>
                <name>COMPA</name>
                <description>Comparator A Value</description>
@@ -210,7 +210,7 @@
          <register>
            <name>_1_CMPB</name>
            <displayName>PWM_1_CMPB</displayName>
-@@ -6223,12 +6277,18 @@
+@@ -6232,12 +6286,18 @@
              <field>
                <name>COMPB</name>
                <description>Comparator B Value</description>
@@ -229,7 +229,7 @@
          <register>
            <name>_1_GENA</name>
            <displayName>PWM_1_GENA</displayName>
-@@ -6791,12 +6851,18 @@
+@@ -6800,12 +6860,18 @@
              <field>
                <name>MFP</name>
                <description>Minimum Fault Period</description>
@@ -248,7 +248,7 @@
          <register>
            <name>_2_CTL</name>
            <displayName>PWM_2_CTL</displayName>
-@@ -7209,12 +7275,18 @@
+@@ -7218,12 +7284,18 @@
              <field>
                <name>LOAD</name>
                <description>Counter Load Value</description>
@@ -267,7 +267,7 @@
          <register>
            <name>_2_COUNT</name>
            <displayName>PWM_2_COUNT</displayName>
-@@ -7241,12 +7313,18 @@
+@@ -7250,12 +7322,18 @@
              <field>
                <name>COMPA</name>
                <description>Comparator A Value</description>
@@ -286,7 +286,7 @@
          <register>
            <name>_2_CMPB</name>
            <displayName>PWM_2_CMPB</displayName>
-@@ -7257,12 +7335,18 @@
+@@ -7266,12 +7344,18 @@
              <field>
                <name>COMPB</name>
                <description>Comparator B Value</description>
@@ -305,7 +305,7 @@
          <register>
            <name>_2_GENA</name>
            <displayName>PWM_2_GENA</displayName>
-@@ -7825,12 +7909,18 @@
+@@ -7834,12 +7918,18 @@
              <field>
                <name>MFP</name>
                <description>Minimum Fault Period</description>
@@ -324,7 +324,7 @@
          <register>
            <name>_3_CTL</name>
            <displayName>PWM_3_CTL</displayName>
-@@ -8243,12 +8333,18 @@
+@@ -8252,12 +8342,18 @@
              <field>
                <name>LOAD</name>
                <description>Counter Load Value</description>
@@ -343,7 +343,7 @@
          <register>
            <name>_3_COUNT</name>
            <displayName>PWM_3_COUNT</displayName>
-@@ -8275,12 +8371,18 @@
+@@ -8284,12 +8380,18 @@
              <field>
                <name>COMPA</name>
                <description>Comparator A Value</description>
@@ -362,7 +362,7 @@
          <register>
            <name>_3_CMPB</name>
            <displayName>PWM_3_CMPB</displayName>
-@@ -8291,12 +8393,18 @@
+@@ -8300,12 +8402,18 @@
              <field>
                <name>COMPB</name>
                <description>Comparator B Value</description>
@@ -381,7 +381,7 @@
          <register>
            <name>_3_GENA</name>
            <displayName>PWM_3_GENA</displayName>
-@@ -8859,12 +8967,18 @@
+@@ -8868,12 +8976,18 @@
              <field>
                <name>MFP</name>
                <description>Minimum Fault Period</description>
@@ -400,7 +400,7 @@
          <register>
            <name>_0_FLTSEN</name>
            <displayName>PWM_0_FLTSEN</displayName>
-@@ -12581,61 +12695,109 @@
+@@ -12590,61 +12704,109 @@
              <field>
                <name>MUX0</name>
                <description>1st Sample Input Select</description>
@@ -510,7 +510,7 @@
          <register>
            <name>SSCTL0</name>
            <displayName>ADC_SSCTL0</displayName>
-@@ -13127,61 +13289,357 @@
+@@ -13136,61 +13298,357 @@
              <field>
                <name>TSH0</name>
                <description>1st Sample and Hold Period Select</description>
@@ -868,7 +868,7 @@
          <register>
            <name>SSMUX1</name>
            <displayName>ADC_SSMUX1</displayName>
-@@ -15659,12 +16117,18 @@
+@@ -15668,12 +16126,18 @@
              <field>
                <name>CLKDIV</name>
                <description>PLL VCO Clock Divisor</description>
@@ -887,7 +887,7 @@
        </registers>
      </peripheral>
      <!-- ../Modules/Tiva_TM4C/sc4c1290kcpdt/adc.xml -->
-@@ -25345,19 +25809,47 @@
+@@ -25354,19 +25818,47 @@
          <register>
            <name>DATA</name>
            <displayName>GPIO_DATA</displayName>
@@ -935,7 +935,7 @@
            <displayName>GPIO_IS</displayName>
            <description>GPIO Interrupt Sense</description>
            <addressOffset>0x00000404</addressOffset>
-@@ -25472,68 +25964,194 @@
+@@ -25481,68 +25973,194 @@
          <register>
            <name>AFSEL</name>
            <displayName>GPIO_AFSEL</displayName>
@@ -1130,7 +1130,7 @@
            <displayName>GPIO_LOCK</displayName>
            <description>GPIO Lock</description>
            <addressOffset>0x00000520</addressOffset>
-@@ -25578,33 +26196,125 @@
+@@ -25587,33 +26205,125 @@
          <register>
            <name>AMSEL</name>
            <displayName>GPIO_AMSEL</displayName>
@@ -1256,7 +1256,7 @@
            <displayName>GPIO_SI</displayName>
            <description>GPIO Select Interrupt</description>
            <addressOffset>0x00000538</addressOffset>
-@@ -25625,26 +26335,21 @@
+@@ -25634,26 +26344,21 @@
            <description>GPIO 12-mA Drive Select</description>
            <addressOffset>0x0000053C</addressOffset>
            <size>32</size>
@@ -1287,7 +1287,7 @@
          <register>
            <name>WAKEPEN</name>
            <displayName>GPIO_WAKEPEN</displayName>
-@@ -35902,19 +36607,31 @@
+@@ -35911,19 +36616,31 @@
              <field>
                <name>PSYSDIV</name>
                <description>PLL System Clock Divisor</description>
@@ -1319,7 +1319,7 @@
                <description>Oscillator Source</description>
                <lsb>20</lsb>
                <msb>23</msb>
-@@ -36256,12 +36973,18 @@
+@@ -36265,12 +36982,18 @@
              <field>
                <name>DIV</name>
                <description>Divisor Value</description>
@@ -1338,7 +1338,7 @@
                <description>Clock Source</description>
                <lsb>16</lsb>
                <msb>17</msb>
-@@ -36322,12 +37045,18 @@
+@@ -36331,12 +37054,18 @@
              <field>
                <name>UT</name>
                <description>User Trim Value</description>
@@ -1357,7 +1357,7 @@
                <description>Update Trim</description>
                <lsb>8</lsb>
                <msb>8</msb>
-@@ -36409,19 +37138,31 @@
+@@ -36418,19 +37147,31 @@
              <field>
                <name>MINT</name>
                <description>PLL M Integer Value</description>
@@ -1389,7 +1389,7 @@
                <description>PLL Power</description>
                <lsb>23</lsb>
                <msb>23</msb>
-@@ -36439,19 +37180,31 @@
+@@ -36448,19 +37189,31 @@
              <field>
                <name>N</name>
                <description>PLL N Value</description>

--- a/svd/tm4c123x-vendor.xml
+++ b/svd/tm4c123x-vendor.xml
@@ -5,6 +5,15 @@
   <series>Tiva C Series</series>
   <version>1</version>
   <description>(no description)</description>
+  <cpu>
+    <name>CM4</name>
+    <revision>r0p0</revision>
+    <endian>little</endian>
+    <mpuPresent>true</mpuPresent>
+    <fpuPresent>true</fpuPresent>
+    <nvicPrioBits>3</nvicPrioBits>
+    <vendorSystickConfig>false</vendorSystickConfig>
+  </cpu>
   <addressUnitBits>8</addressUnitBits>
   <width>32</width>
   <resetValue>0x00000000</resetValue>

--- a/svd/tm4c123x.xml
+++ b/svd/tm4c123x.xml
@@ -5,6 +5,15 @@
   <series>Tiva C Series</series>
   <version>1</version>
   <description>(no description)</description>
+  <cpu>
+    <name>CM4</name>
+    <revision>r0p0</revision>
+    <endian>little</endian>
+    <mpuPresent>true</mpuPresent>
+    <fpuPresent>true</fpuPresent>
+    <nvicPrioBits>3</nvicPrioBits>
+    <vendorSystickConfig>false</vendorSystickConfig>
+  </cpu>
   <addressUnitBits>8</addressUnitBits>
   <width>32</width>
   <resetValue>0x00000000</resetValue>

--- a/svd/tm4c129x-vendor.xml
+++ b/svd/tm4c129x-vendor.xml
@@ -5,6 +5,15 @@
   <series>Tiva C Series</series>
   <version>1</version>
   <description>(no description)</description>
+  <cpu>
+    <name>CM4</name>
+    <revision>r0p0</revision>
+    <endian>little</endian>
+    <mpuPresent>true</mpuPresent>
+    <fpuPresent>true</fpuPresent>
+    <nvicPrioBits>3</nvicPrioBits>
+    <vendorSystickConfig>false</vendorSystickConfig>
+  </cpu>
   <addressUnitBits>8</addressUnitBits>
   <width>32</width>
   <resetValue>0x00000000</resetValue>

--- a/svd/tm4c129x.xml
+++ b/svd/tm4c129x.xml
@@ -5,6 +5,15 @@
   <series>Tiva C Series</series>
   <version>1</version>
   <description>(no description)</description>
+  <cpu>
+    <name>CM4</name>
+    <revision>r0p0</revision>
+    <endian>little</endian>
+    <mpuPresent>true</mpuPresent>
+    <fpuPresent>true</fpuPresent>
+    <nvicPrioBits>3</nvicPrioBits>
+    <vendorSystickConfig>false</vendorSystickConfig>
+  </cpu>
   <addressUnitBits>8</addressUnitBits>
   <width>32</width>
   <resetValue>0x00000000</resetValue>


### PR DESCRIPTION
Add the `cpu` node to the generated XML, so that the final bindings contain `NVIC_PRIO_BITS` (as required by cortex-m-rtic).