### PR TITLE
Updated deps v2

### DIFF
--- a/crates/tm4c123x/Cargo.toml
+++ b/crates/tm4c123x/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tm4c123x"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["whitequark <whitequark@whitequark.org>"]
 description = "Peripheral access API for TI TM4C123x microcontrollers"
 documentation = "https://docs.rs/tm4c123x"
@@ -10,13 +10,12 @@ categories = ["embedded"]
 license = "0BSD"
 
 [dependencies]
-bare-metal = "0.2.0"
-cortex-m = "0.6"
+cortex-m = "0.7.6"
 vcell = "0.1.0"
 
 [dependencies.cortex-m-rt]
 optional = true
-version = "0.6"
+version = "0.7.2"
 
 [features]
 rt = ["cortex-m-rt/device"]

--- a/crates/tm4c123x/src/lib.rs
+++ b/crates/tm4c123x/src/lib.rs
@@ -21,7 +21,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![no_std]
-extern crate bare_metal;
 extern crate cortex_m;
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;
@@ -422,10 +421,10 @@ pub enum Interrupt {
     #[doc = "138 - PWM1 Fault"]
     PWM1_FAULT = 138,
 }
-unsafe impl bare_metal::Nr for Interrupt {
+unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
     #[inline(always)]
-    fn nr(&self) -> u8 {
-        *self as u8
+    fn number(self) -> u16 {
+        self as u16
     }
 }
 #[cfg(feature = "rt")]

--- a/crates/tm4c129x/Cargo.toml
+++ b/crates/tm4c129x/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tm4c129x"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["whitequark <whitequark@whitequark.org>"]
 description = "Peripheral access API for TI TM4C129x microcontrollers"
 documentation = "https://docs.rs/tm4c129x"
@@ -10,13 +10,12 @@ categories = ["embedded"]
 license = "0BSD"
 
 [dependencies]
-bare-metal = "0.2.0"
-cortex-m = "0.6"
+cortex-m = "0.7.6"
 vcell = "0.1.0"
 
 [dependencies.cortex-m-rt]
 optional = true
-version = "0.6"
+version = "0.7.2"
 
 [features]
 rt = ["cortex-m-rt/device"]

--- a/crates/tm4c129x/src/lib.rs
+++ b/crates/tm4c129x/src/lib.rs
@@ -21,7 +21,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![no_std]
-extern crate bare_metal;
 extern crate cortex_m;
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;
@@ -476,10 +475,10 @@ pub enum Interrupt {
     #[doc = "111 - GPIO T"]
     GPIOT = 111,
 }
-unsafe impl bare_metal::Nr for Interrupt {
+unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
     #[inline(always)]
-    fn nr(&self) -> u8 {
-        *self as u8
+    fn number(self) -> u16 {
+        self as u16
     }
 }
 #[cfg(feature = "rt")]


### PR DESCRIPTION
Howdy, 

This is my first Rust pull request! I wanted to use the latest RTIC with the TM4C for a work project and the dependencies for the tm4c_hal relied on this project which relied on bare_metal which locked cortex_m to 0.6.

These commits strip out bare_metal, update cortex_m and cortex_m_rt to the latest, implement the missing trait [InterruptNumber](https://docs.rs/cortex-m/latest/cortex_m/interrupt/trait.InterruptNumber.html), and uprev the package.

I plan on updating the Cargo.toml files for the HAL next. Thanks for your consideration. 