### PR TITLE
Macro registers

### DIFF
--- a/crates/tm4c123x/Cargo.toml
+++ b/crates/tm4c123x/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tm4c123x"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["whitequark <whitequark@whitequark.org>"]
 description = "Peripheral access API for TI TM4C123x microcontrollers"
 documentation = "https://docs.rs/tm4c123x"

--- a/crates/tm4c123x/src/lib.rs
+++ b/crates/tm4c123x/src/lib.rs
@@ -1700,6 +1700,7 @@ pub struct Peripherals {
     pub UDMA: UDMA,
 }
 
+/// Allows for easier, unsafe access of Peripheral Registers
 #[macro_export]
 macro_rules! borrow_registers {
     (

--- a/crates/tm4c123x/src/lib.rs
+++ b/crates/tm4c123x/src/lib.rs
@@ -1700,6 +1700,16 @@ pub struct Peripherals {
     #[doc = "UDMA"]
     pub UDMA: UDMA,
 }
+
+#[macro_export]
+macro_rules! borrow_registers {
+    (
+        $PERIPHERAL:ident
+    ) => {
+        &*$PERIPHERAL::ptr()
+    }
+}
+
 impl Peripherals {
     #[doc = r"Returns all the peripherals *once*"]
     #[inline]


### PR DESCRIPTION
I'm currently using RTIC and need to work with peripheral registers in the interrupt space and can't find really any documentation or support that shows this. Something as simple as clearing an interrupt register seems really difficult to find examples and documentation on in the Rust / RTIC space. I've seen people access the HAL peripherals using borrowed pointers but wouldn't have figured it out without seeing it in the wild. 

Is there another way to do this? If not, I propose:

```
use tm4c123x_hal::tm4c123x::borrow_registers;

#[task(binds = TIMER0A, priority = 4)]
fn timer0_irq(cx: timer0_irq::Context) {
  unsafe {
   // Proposed usage
    let _t = borrow_registers!(TIMER0);
    _t.icr.write(|w| w.tatocint().set_bit() );
    
    // This was the non-obvious example that works and inspired the macro
    let _u = &*TIMER0::ptr();
    _u.icr.write(|w| w.tatocint().set_bit() );
  }

  // Do timeout stuff here
}

```